### PR TITLE
Add ProcMarker decorator

### DIFF
--- a/assembly/src/context/mod.rs
+++ b/assembly/src/context/mod.rs
@@ -35,21 +35,21 @@ impl<'a> AssemblyContext<'a> {
         self.local_procs.contains_key(label) || self.imported_procs.contains_key(label)
     }
 
-    /// Returns a code root of a procedure for the specified label from this context.
-    pub fn get_proc_code(&self, label: &str) -> Option<&CodeBlock> {
+    /// Returns a code root and num_locals of a procedure for the specified label from this context.
+    pub fn get_proc_code(&self, label: &str) -> Option<(&CodeBlock, u32)> {
         // `expect()`'s are OK here because we first check if a given map contains the key
         if self.imported_procs.contains_key(label) {
             let proc = *self
                 .imported_procs
                 .get(label)
                 .expect("no procedure after contains");
-            Some(proc.code_root())
+            Some((proc.code_root(), proc.num_locals()))
         } else if self.local_procs.contains_key(label) {
             let proc = self
                 .local_procs
                 .get(label)
                 .expect("no procedure after contains");
-            Some(proc.code_root())
+            Some((proc.code_root(), proc.num_locals()))
         } else {
             None
         }

--- a/assembly/src/parsers/mod.rs
+++ b/assembly/src/parsers/mod.rs
@@ -30,7 +30,7 @@ fn parse_op_token(
     let dec_len = decorators.len();
     // if assembler is in debug mode, populate decorators list with debug related
     // decorators like AsmOp.
-    if in_debug_mode {
+    if in_debug_mode && !matches!(op.parts()[0], "adv") {
         decorators.push((
             span_ops.len(),
             Decorator::AsmOp(AssemblyOp::new(op.to_string(), 1)),
@@ -177,7 +177,7 @@ fn parse_op_token(
         _ => return Err(AssemblyError::invalid_op(op)),
     }?;
 
-    if in_debug_mode {
+    if in_debug_mode && !matches!(op.parts()[0], "adv") {
         let op_start = decorators[dec_len].0;
         // edit the number of cycles corresponding to the asmop decorator at an index
         if let Decorator::AsmOp(assembly_op) = &mut decorators[dec_len].1 {

--- a/assembly/src/procedures/mod.rs
+++ b/assembly/src/procedures/mod.rs
@@ -35,6 +35,11 @@ impl Procedure {
         self.is_export
     }
 
+    /// Returns num_locals of this procedure.
+    pub fn num_locals(&self) -> u32 {
+        self.num_locals
+    }
+
     // PARSER
     // --------------------------------------------------------------------------------------------
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -18,7 +18,7 @@ pub use program::{blocks as code_blocks, Library, Program};
 
 mod operations;
 pub use operations::{
-    AdviceInjector, AssemblyOp, Decorator, DecoratorIterator, DecoratorList, Operation,
+    AdviceInjector, AssemblyOp, Decorator, DecoratorIterator, DecoratorList, Operation, ProcMarker,
 };
 
 mod inputs;

--- a/core/src/operations/decorators/mod.rs
+++ b/core/src/operations/decorators/mod.rs
@@ -1,9 +1,11 @@
 mod advice;
 mod assembly_op;
+mod proc_marker;
 use crate::utils::collections::Vec;
 pub use advice::AdviceInjector;
 pub use assembly_op::AssemblyOp;
 use core::fmt;
+pub use proc_marker::ProcMarker;
 
 // DECORATORS
 // ================================================================================================
@@ -15,8 +17,11 @@ pub enum Decorator {
     /// (e.g., stack, memory), and does not advance VM clock.
     Advice(AdviceInjector),
     /// Adds information about the assembly instruction at a particular index
-    /// (only applicable in debug mode)
+    /// (only applicable in debug mode).
     AsmOp(AssemblyOp),
+    /// Adds procedure marker decorator to a program. Used to mark the beginning and end of a
+    /// procedure being executed (only applicable in debug mode).
+    ProcMarker(ProcMarker),
 }
 
 impl fmt::Display for Decorator {
@@ -31,6 +36,16 @@ impl fmt::Display for Decorator {
                     assembly_op.num_cycles()
                 )
             }
+            Self::ProcMarker(marker) => match marker {
+                ProcMarker::ProcStarted(label, num_locals) => {
+                    if *num_locals == 0 {
+                        write!(f, "procStarted({})", label)
+                    } else {
+                        write!(f, "procStarted({}.{})", label, num_locals)
+                    }
+                }
+                ProcMarker::ProcEnded => write!(f, "procEnded"),
+            },
         }
     }
 }

--- a/core/src/operations/decorators/proc_marker.rs
+++ b/core/src/operations/decorators/proc_marker.rs
@@ -1,0 +1,11 @@
+use crate::utils::string::String;
+
+// PROC MARKER
+// ================================================================================================
+
+/// Contains information corresponsing to a ProcMarker decorator
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ProcMarker {
+    ProcStarted(String, u32),
+    ProcEnded,
+}

--- a/core/src/operations/mod.rs
+++ b/core/src/operations/mod.rs
@@ -1,7 +1,9 @@
 use super::Felt;
 use core::fmt;
 mod decorators;
-pub use decorators::{AdviceInjector, AssemblyOp, Decorator, DecoratorIterator, DecoratorList};
+pub use decorators::{
+    AdviceInjector, AssemblyOp, Decorator, DecoratorIterator, DecoratorList, ProcMarker,
+};
 
 // OPERATIONS
 // ================================================================================================

--- a/core/src/program/blocks/join_block.rs
+++ b/core/src/program/blocks/join_block.rs
@@ -1,4 +1,5 @@
 use super::{fmt, hasher, Box, CodeBlock, Digest};
+use crate::Decorator;
 
 // JOIN BLOCKS
 // ================================================================================================
@@ -12,6 +13,7 @@ use super::{fmt, hasher, Box, CodeBlock, Digest};
 pub struct Join {
     body: Box<[CodeBlock; 2]>,
     hash: Digest,
+    proc_marker: Option<Decorator>,
 }
 
 impl Join {
@@ -23,6 +25,7 @@ impl Join {
         Self {
             body: Box::new(body),
             hash,
+            proc_marker: None,
         }
     }
 
@@ -44,6 +47,18 @@ impl Join {
     /// is executed.
     pub fn second(&self) -> &CodeBlock {
         &self.body[1]
+    }
+
+    /// If a procedure starts at this join block, returns ProcMarker corresponding to the procedure.
+    /// Returns None otherwise.
+    pub fn proc_marker(&self) -> &Option<Decorator> {
+        &self.proc_marker
+    }
+
+    /// If a procedure starts at this join block, set ProcMarker corresponding to the procedure
+    /// to this loop block.
+    pub fn set_proc_marker(&mut self, proc_marker: Decorator) {
+        self.proc_marker = Some(proc_marker);
     }
 }
 

--- a/core/src/program/blocks/loop_block.rs
+++ b/core/src/program/blocks/loop_block.rs
@@ -1,4 +1,5 @@
 use super::{fmt, hasher, Box, CodeBlock, Digest};
+use crate::Decorator;
 
 // LOOP BLOCK
 // ================================================================================================
@@ -16,6 +17,7 @@ use super::{fmt, hasher, Box, CodeBlock, Digest};
 pub struct Loop {
     body: Box<CodeBlock>,
     hash: Digest,
+    proc_marker: Option<Decorator>,
 }
 
 impl Loop {
@@ -27,6 +29,7 @@ impl Loop {
         Self {
             body: Box::new(body),
             hash,
+            proc_marker: None,
         }
     }
 
@@ -41,6 +44,18 @@ impl Loop {
     /// Returns a reference to the code block which represents the body of the loop.
     pub fn body(&self) -> &CodeBlock {
         &self.body
+    }
+
+    /// If a procedure starts at this loop block, returns ProcMarker corresponding to the procedure.
+    /// Returns None otherwise.
+    pub fn proc_marker(&self) -> &Option<Decorator> {
+        &self.proc_marker
+    }
+
+    /// If a procedure starts at this loop block, set ProcMarker corresponding to the procedure
+    /// to this loop block.
+    pub fn set_proc_marker(&mut self, proc_marker: Decorator) {
+        self.proc_marker = Some(proc_marker);
     }
 }
 

--- a/core/src/program/blocks/split_block.rs
+++ b/core/src/program/blocks/split_block.rs
@@ -1,4 +1,5 @@
 use super::{fmt, hasher, Box, CodeBlock, Digest};
+use crate::Decorator;
 
 // SPLIT BLOCK
 // ================================================================================================
@@ -15,6 +16,7 @@ use super::{fmt, hasher, Box, CodeBlock, Digest};
 pub struct Split {
     branches: Box<[CodeBlock; 2]>,
     hash: Digest,
+    proc_marker: Option<Decorator>,
 }
 
 impl Split {
@@ -26,6 +28,7 @@ impl Split {
         Self {
             branches: Box::new([t_branch, f_branch]),
             hash,
+            proc_marker: None,
         }
     }
 
@@ -47,6 +50,18 @@ impl Split {
     /// is `0`.
     pub fn on_false(&self) -> &CodeBlock {
         &self.branches[1]
+    }
+
+    /// If a procedure starts at this split block, returns ProcMarker corresponding to the procedure.
+    /// Returns None otherwise.
+    pub fn proc_marker(&self) -> &Option<Decorator> {
+        &self.proc_marker
+    }
+
+    /// If a procedure starts at this split block, set ProcMarker corresponding to the procedure
+    /// to this loop block.
+    pub fn set_proc_marker(&mut self, proc_marker: Decorator) {
+        self.proc_marker = Some(proc_marker);
     }
 }
 

--- a/miden/tests/integration/exec_iters.rs
+++ b/miden/tests/integration/exec_iters.rs
@@ -1,5 +1,5 @@
 use super::build_debug_test;
-use processor::{AsmOpInfo, VmState};
+use processor::{AsmOpInfo, ProcInfo, VmState};
 use vm_core::{utils::ToElements, Felt, FieldElement, Operation};
 
 // EXEC ITER TESTS
@@ -21,6 +21,7 @@ fn test_exec_iter() {
             clk: 0,
             op: None,
             asmop: None,
+            proc_stack: vec![],
             stack: [16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1].to_elements(),
             fmp,
             memory: Vec::new(),
@@ -29,6 +30,7 @@ fn test_exec_iter() {
             clk: 1,
             op: Some(Operation::Span),
             asmop: None,
+            proc_stack: vec![],
             stack: [16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 1].to_elements(),
             fmp,
             memory: Vec::new(),
@@ -37,6 +39,7 @@ fn test_exec_iter() {
             clk: 2,
             op: Some(Operation::Push(Felt::new(1))),
             asmop: Some(AsmOpInfo::new("popw.mem.1".to_string(), 6, 1)),
+            proc_stack: vec![],
             stack: [1, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2].to_elements(),
             fmp,
             memory: Vec::new(),
@@ -45,6 +48,7 @@ fn test_exec_iter() {
             clk: 3,
             op: Some(Operation::MStoreW),
             asmop: Some(AsmOpInfo::new("popw.mem.1".to_string(), 6, 2)),
+            proc_stack: vec![],
             stack: [16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1].to_elements(),
             fmp,
             memory: mem.clone(),
@@ -53,6 +57,7 @@ fn test_exec_iter() {
             clk: 4,
             op: Some(Operation::Drop),
             asmop: Some(AsmOpInfo::new("popw.mem.1".to_string(), 6, 3)),
+            proc_stack: vec![],
             stack: [15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0].to_elements(),
             fmp,
             memory: mem.clone(),
@@ -61,6 +66,7 @@ fn test_exec_iter() {
             clk: 5,
             op: Some(Operation::Drop),
             asmop: Some(AsmOpInfo::new("popw.mem.1".to_string(), 6, 4)),
+            proc_stack: vec![],
             stack: [14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0].to_elements(),
             fmp,
             memory: mem.clone(),
@@ -69,6 +75,7 @@ fn test_exec_iter() {
             clk: 6,
             op: Some(Operation::Drop),
             asmop: Some(AsmOpInfo::new("popw.mem.1".to_string(), 6, 5)),
+            proc_stack: vec![],
             stack: [13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0].to_elements(),
             fmp,
             memory: mem.clone(),
@@ -77,6 +84,7 @@ fn test_exec_iter() {
             clk: 7,
             op: Some(Operation::Drop),
             asmop: Some(AsmOpInfo::new("popw.mem.1".to_string(), 6, 6)),
+            proc_stack: vec![],
             stack: [12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0].to_elements(),
             fmp,
             memory: mem.clone(),
@@ -85,6 +93,7 @@ fn test_exec_iter() {
             clk: 8,
             op: Some(Operation::Push(Felt::new(17))),
             asmop: Some(AsmOpInfo::new("push.17".to_string(), 1, 1)),
+            proc_stack: vec![],
             stack: [17, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0].to_elements(),
             fmp,
             memory: mem.clone(),
@@ -93,6 +102,7 @@ fn test_exec_iter() {
             clk: 9,
             op: Some(Operation::Push(Felt::new(1))),
             asmop: None,
+            proc_stack: vec![ProcInfo::new("foo".to_string(), 1, 9)],
             stack: [1, 17, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0].to_elements(),
             fmp,
             memory: mem.clone(),
@@ -101,6 +111,7 @@ fn test_exec_iter() {
             clk: 10,
             op: Some(Operation::FmpUpdate),
             asmop: None,
+            proc_stack: vec![ProcInfo::new("foo".to_string(), 1, 9)],
             stack: [17, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0].to_elements(),
             fmp: next_fmp,
             memory: mem.clone(),
@@ -109,6 +120,7 @@ fn test_exec_iter() {
             clk: 11,
             op: Some(Operation::Pad),
             asmop: Some(AsmOpInfo::new("pop.local.0".to_string(), 10, 1)),
+            proc_stack: vec![ProcInfo::new("foo".to_string(), 1, 9)],
             stack: [0, 17, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0].to_elements(),
             fmp: next_fmp,
             memory: mem.clone(),
@@ -117,6 +129,7 @@ fn test_exec_iter() {
             clk: 12,
             op: Some(Operation::Pad),
             asmop: Some(AsmOpInfo::new("pop.local.0".to_string(), 10, 2)),
+            proc_stack: vec![ProcInfo::new("foo".to_string(), 1, 9)],
             stack: [
                 0, 0, 17, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0,
             ]
@@ -128,6 +141,7 @@ fn test_exec_iter() {
             clk: 13,
             op: Some(Operation::Pad),
             asmop: Some(AsmOpInfo::new("pop.local.0".to_string(), 10, 3)),
+            proc_stack: vec![ProcInfo::new("foo".to_string(), 1, 9)],
             stack: [
                 0, 0, 0, 17, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 1, 0, 0, 0, 0,
             ]
@@ -139,6 +153,7 @@ fn test_exec_iter() {
             clk: 14,
             op: Some(Operation::Pad),
             asmop: Some(AsmOpInfo::new("pop.local.0".to_string(), 10, 4)),
+            proc_stack: vec![ProcInfo::new("foo".to_string(), 1, 9)],
             stack: [
                 0, 0, 0, 0, 17, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0,
             ]
@@ -150,6 +165,7 @@ fn test_exec_iter() {
             clk: 15,
             op: Some(Operation::FmpAdd),
             asmop: Some(AsmOpInfo::new("pop.local.0".to_string(), 10, 5)),
+            proc_stack: vec![ProcInfo::new("foo".to_string(), 1, 9)],
             stack: [
                 2u64.pow(30) + 1,
                 0,
@@ -180,6 +196,7 @@ fn test_exec_iter() {
             clk: 16,
             op: Some(Operation::MStoreW),
             asmop: Some(AsmOpInfo::new("pop.local.0".to_string(), 10, 6)),
+            proc_stack: vec![ProcInfo::new("foo".to_string(), 1, 9)],
             stack: [0, 0, 0, 17, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0].to_elements(),
             fmp: next_fmp,
             memory: vec![
@@ -191,6 +208,7 @@ fn test_exec_iter() {
             clk: 17,
             op: Some(Operation::Drop),
             asmop: Some(AsmOpInfo::new("pop.local.0".to_string(), 10, 7)),
+            proc_stack: vec![ProcInfo::new("foo".to_string(), 1, 9)],
             stack: [0, 0, 17, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0].to_elements(),
             fmp: next_fmp,
             memory: vec![

--- a/miden/tests/integration/operations/decorators/asmop.rs
+++ b/miden/tests/integration/operations/decorators/asmop.rs
@@ -1,5 +1,6 @@
+use super::{build_vm_state, VmStatePartial};
 use crate::build_debug_test;
-use processor::{AsmOpInfo, VmStateIterator};
+use processor::{AsmOpInfo, ProcInfo};
 use vm_core::{Felt, Operation};
 
 #[test]
@@ -12,36 +13,43 @@ fn asmop_one_span_block_test() {
             clk: 0,
             asmop: None,
             op: None,
+            proc_stack: vec![],
         },
         VmStatePartial {
             clk: 1,
             asmop: None,
             op: Some(Operation::Span),
+            proc_stack: vec![],
         },
         VmStatePartial {
             clk: 2,
             asmop: Some(AsmOpInfo::new("push.1".to_string(), 2, 1)),
             op: Some(Operation::Pad),
+            proc_stack: vec![],
         },
         VmStatePartial {
             clk: 3,
             asmop: Some(AsmOpInfo::new("push.1".to_string(), 2, 2)),
             op: Some(Operation::Incr),
+            proc_stack: vec![],
         },
         VmStatePartial {
             clk: 4,
             asmop: Some(AsmOpInfo::new("push.2".to_string(), 1, 1)),
             op: Some(Operation::Push(Felt::new(2))),
+            proc_stack: vec![],
         },
         VmStatePartial {
             clk: 5,
             asmop: Some(AsmOpInfo::new("add".to_string(), 1, 1)),
             op: Some(Operation::Add),
+            proc_stack: vec![],
         },
         VmStatePartial {
             clk: 6,
             asmop: None,
             op: Some(Operation::End),
+            proc_stack: vec![],
         },
     ];
     let vm_state = build_vm_state(vm_state_iterator);
@@ -58,36 +66,43 @@ fn asmop_with_one_procedure() {
             clk: 0,
             asmop: None,
             op: None,
+            proc_stack: vec![],
         },
         VmStatePartial {
             clk: 1,
             asmop: None,
             op: Some(Operation::Span),
+            proc_stack: vec![],
         },
         VmStatePartial {
             clk: 2,
             asmop: Some(AsmOpInfo::new("push.1".to_string(), 2, 1)),
             op: Some(Operation::Pad),
+            proc_stack: vec![ProcInfo::new("foo".to_string(), 0, 2)],
         },
         VmStatePartial {
             clk: 3,
             asmop: Some(AsmOpInfo::new("push.1".to_string(), 2, 2)),
             op: Some(Operation::Incr),
+            proc_stack: vec![ProcInfo::new("foo".to_string(), 0, 2)],
         },
         VmStatePartial {
             clk: 4,
             asmop: Some(AsmOpInfo::new("push.2".to_string(), 1, 1)),
             op: Some(Operation::Push(Felt::new(2))),
+            proc_stack: vec![ProcInfo::new("foo".to_string(), 0, 2)],
         },
         VmStatePartial {
             clk: 5,
             asmop: Some(AsmOpInfo::new("add".to_string(), 1, 1)),
             op: Some(Operation::Add),
+            proc_stack: vec![ProcInfo::new("foo".to_string(), 0, 2)],
         },
         VmStatePartial {
             clk: 6,
             asmop: None,
             op: Some(Operation::End),
+            proc_stack: vec![],
         },
     ];
     let vm_state = build_vm_state(vm_state_iterator);
@@ -108,91 +123,109 @@ fn asmop_repeat_test() {
             clk: 0,
             asmop: None,
             op: None,
+            proc_stack: vec![],
         },
         VmStatePartial {
             clk: 1,
             asmop: None,
             op: Some(Operation::Span),
+            proc_stack: vec![],
         },
         VmStatePartial {
             clk: 2,
             asmop: Some(AsmOpInfo::new("push.1".to_string(), 2, 1)),
             op: Some(Operation::Pad),
+            proc_stack: vec![],
         },
         VmStatePartial {
             clk: 3,
             asmop: Some(AsmOpInfo::new("push.1".to_string(), 2, 2)),
             op: Some(Operation::Incr),
+            proc_stack: vec![],
         },
         VmStatePartial {
             clk: 4,
             asmop: Some(AsmOpInfo::new("push.2".to_string(), 1, 1)),
             op: Some(Operation::Push(Felt::new(2))),
+            proc_stack: vec![],
         },
         VmStatePartial {
             clk: 5,
             asmop: Some(AsmOpInfo::new("add".to_string(), 1, 1)),
             op: Some(Operation::Add),
+            proc_stack: vec![],
         },
         VmStatePartial {
             clk: 6,
             asmop: Some(AsmOpInfo::new("push.1".to_string(), 2, 1)),
             op: Some(Operation::Pad),
+            proc_stack: vec![],
         },
         VmStatePartial {
             clk: 7,
             asmop: Some(AsmOpInfo::new("push.1".to_string(), 2, 2)),
             op: Some(Operation::Incr),
+            proc_stack: vec![],
         },
         VmStatePartial {
             clk: 8,
             asmop: Some(AsmOpInfo::new("push.2".to_string(), 1, 1)),
             op: Some(Operation::Push(Felt::new(2))),
+            proc_stack: vec![],
         },
         VmStatePartial {
             clk: 9,
             asmop: Some(AsmOpInfo::new("add".to_string(), 1, 1)),
             op: Some(Operation::Add),
+            proc_stack: vec![],
         },
         VmStatePartial {
             clk: 10,
             asmop: Some(AsmOpInfo::new("push.1".to_string(), 2, 1)),
             op: Some(Operation::Pad),
+            proc_stack: vec![],
         },
         VmStatePartial {
             clk: 11,
             asmop: Some(AsmOpInfo::new("push.1".to_string(), 2, 2)),
             op: Some(Operation::Incr),
+            proc_stack: vec![],
         },
         VmStatePartial {
             clk: 12,
             asmop: Some(AsmOpInfo::new("push.2".to_string(), 1, 1)),
             op: Some(Operation::Push(Felt::new(2))),
+            proc_stack: vec![],
         },
         VmStatePartial {
             clk: 13,
             asmop: Some(AsmOpInfo::new("add".to_string(), 1, 1)),
             op: Some(Operation::Add),
+            proc_stack: vec![],
         },
         VmStatePartial {
             clk: 14,
             asmop: None,
             op: Some(Operation::Noop),
+            proc_stack: vec![],
         },
         VmStatePartial {
             clk: 15,
             asmop: None,
             op: Some(Operation::Noop),
+            proc_stack: vec![],
         },
         VmStatePartial {
             clk: 16,
             asmop: None,
             op: Some(Operation::Noop),
+            proc_stack: vec![],
         },
         VmStatePartial {
             clk: 17,
             asmop: None,
             op: Some(Operation::End),
+            proc_stack: vec![],
         },
     ];
     let vm_state = build_vm_state(vm_state_iterator);
@@ -218,71 +251,85 @@ fn asmop_conditional_execution_test() {
             clk: 0,
             asmop: None,
             op: None,
+            proc_stack: vec![],
         },
         VmStatePartial {
             clk: 1,
             asmop: None,
             op: Some(Operation::Join),
+            proc_stack: vec![],
         },
         VmStatePartial {
             clk: 2,
             asmop: None,
             op: Some(Operation::Span),
+            proc_stack: vec![],
         },
         VmStatePartial {
             clk: 3,
             asmop: Some(AsmOpInfo::new("eq".to_string(), 1, 1)),
             op: Some(Operation::Eq),
+            proc_stack: vec![],
         },
         VmStatePartial {
             clk: 4,
             asmop: None,
             op: Some(Operation::End),
+            proc_stack: vec![],
         },
         VmStatePartial {
             clk: 5,
             asmop: None,
             op: Some(Operation::Split),
+            proc_stack: vec![],
         },
         VmStatePartial {
             clk: 6,
             asmop: None,
             op: Some(Operation::Span),
+            proc_stack: vec![],
         },
         VmStatePartial {
             clk: 7,
             asmop: Some(AsmOpInfo::new("push.1".to_string(), 2, 1)),
             op: Some(Operation::Pad),
+            proc_stack: vec![],
         },
         VmStatePartial {
             clk: 8,
             asmop: Some(AsmOpInfo::new("push.1".to_string(), 2, 2)),
             op: Some(Operation::Incr),
+            proc_stack: vec![],
         },
         VmStatePartial {
             clk: 9,
             asmop: Some(AsmOpInfo::new("push.2".to_string(), 1, 1)),
             op: Some(Operation::Push(Felt::new(2))),
+            proc_stack: vec![],
         },
         VmStatePartial {
             clk: 10,
             asmop: Some(AsmOpInfo::new("add".to_string(), 1, 1)),
             op: Some(Operation::Add),
+            proc_stack: vec![],
         },
         VmStatePartial {
             clk: 11,
             asmop: None,
             op: Some(Operation::End),
+            proc_stack: vec![],
         },
         VmStatePartial {
             clk: 12,
             asmop: None,
             op: Some(Operation::End),
+            proc_stack: vec![],
         },
         VmStatePartial {
             clk: 13,
             asmop: None,
             op: Some(Operation::End),
+            proc_stack: vec![],
         },
     ];
     let vm_state = build_vm_state(vm_state_iterator);
@@ -296,97 +343,87 @@ fn asmop_conditional_execution_test() {
             clk: 0,
             asmop: None,
             op: None,
+            proc_stack: vec![],
         },
         VmStatePartial {
             clk: 1,
             asmop: None,
             op: Some(Operation::Join),
+            proc_stack: vec![],
         },
         VmStatePartial {
             clk: 2,
             asmop: None,
             op: Some(Operation::Span),
+            proc_stack: vec![],
         },
         VmStatePartial {
             clk: 3,
             asmop: Some(AsmOpInfo::new("eq".to_string(), 1, 1)),
             op: Some(Operation::Eq),
+            proc_stack: vec![],
         },
         VmStatePartial {
             clk: 4,
             asmop: None,
             op: Some(Operation::End),
+            proc_stack: vec![],
         },
         VmStatePartial {
             clk: 5,
             asmop: None,
             op: Some(Operation::Split),
+            proc_stack: vec![],
         },
         VmStatePartial {
             clk: 6,
             asmop: None,
             op: Some(Operation::Span),
+            proc_stack: vec![],
         },
         VmStatePartial {
             clk: 7,
             asmop: Some(AsmOpInfo::new("push.3".to_string(), 1, 1)),
             op: Some(Operation::Push(Felt::new(3))),
+            proc_stack: vec![],
         },
         VmStatePartial {
             clk: 8,
             asmop: Some(AsmOpInfo::new("push.4".to_string(), 1, 1)),
             op: Some(Operation::Push(Felt::new(4))),
+            proc_stack: vec![],
         },
         VmStatePartial {
             clk: 9,
             asmop: Some(AsmOpInfo::new("add".to_string(), 1, 1)),
             op: Some(Operation::Add),
+            proc_stack: vec![],
         },
         VmStatePartial {
             clk: 10,
             asmop: None,
             op: Some(Operation::Noop),
+            proc_stack: vec![],
         },
         VmStatePartial {
             clk: 11,
             asmop: None,
             op: Some(Operation::End),
+            proc_stack: vec![],
         },
         VmStatePartial {
             clk: 12,
             asmop: None,
             op: Some(Operation::End),
+            proc_stack: vec![],
         },
         VmStatePartial {
             clk: 13,
             asmop: None,
             op: Some(Operation::End),
+            proc_stack: vec![],
         },
     ];
     let vm_state = build_vm_state(vm_state_iterator);
     assert_eq!(expected_vm_state, vm_state);
-}
-
-/// This is a helper function to build a vector of [VmStatePartial] from a specified [VmStateIterator].
-fn build_vm_state(vm_state_iterator: VmStateIterator) -> Vec<VmStatePartial> {
-    let mut vm_state = Vec::new();
-    for state in vm_state_iterator {
-        vm_state.push(VmStatePartial {
-            clk: state.as_ref().unwrap().clk,
-            asmop: state.as_ref().unwrap().asmop.clone(),
-            op: state.as_ref().unwrap().op,
-        });
-    }
-    vm_state
-}
-
-/// [VmStatePartial] holds the following current process state information at a specific clock cycle
-/// * clk: Current clock cycle
-/// * asmop: AsmOp decorator at the specific clock cycle
-/// * op: Operation executed at the specific clock cycle
-#[derive(Clone, Debug, Eq, PartialEq)]
-struct VmStatePartial {
-    clk: usize,
-    asmop: Option<AsmOpInfo>,
-    op: Option<Operation>,
 }

--- a/miden/tests/integration/operations/decorators/mod.rs
+++ b/miden/tests/integration/operations/decorators/mod.rs
@@ -1,2 +1,32 @@
 mod advice;
 mod asmop;
+mod proc_marker;
+use processor::{AsmOpInfo, ProcInfo, VmStateIterator};
+use vm_core::Operation;
+
+/// [VmStatePartial] holds the following current process state information at a specific clock cycle
+/// * clk: Current clock cycle
+/// * asmop: [AsmOp] decorator at the specific clock cycle
+/// * op: [Operation] executed at the specific clock cycle
+/// * proc_stack: stack of currently executing procedures at the specified clock cycle
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct VmStatePartial {
+    clk: usize,
+    asmop: Option<AsmOpInfo>,
+    op: Option<Operation>,
+    proc_stack: Vec<ProcInfo>,
+}
+
+/// This is a helper function to build a vector of [VmStatePartial] from a specified [VmStateIterator].
+pub fn build_vm_state(vm_state_iterator: VmStateIterator) -> Vec<VmStatePartial> {
+    let mut vm_state = Vec::new();
+    for state in vm_state_iterator {
+        vm_state.push(VmStatePartial {
+            clk: state.as_ref().unwrap().clk,
+            asmop: state.as_ref().unwrap().asmop.clone(),
+            op: state.as_ref().unwrap().op,
+            proc_stack: state.as_ref().unwrap().proc_stack.clone(),
+        });
+    }
+    vm_state
+}

--- a/miden/tests/integration/operations/decorators/proc_marker.rs
+++ b/miden/tests/integration/operations/decorators/proc_marker.rs
@@ -1,0 +1,952 @@
+use super::{build_vm_state, VmStatePartial};
+use crate::build_debug_test;
+use processor::{AsmOpInfo, ProcInfo};
+use vm_core::{utils::string::ToString, Felt, Operation};
+
+#[test]
+fn proc_with_one_span() {
+    let source = "proc.foo push.1 push.2 add end begin exec.foo end";
+    let test = build_debug_test!(source);
+    let vm_state_iterator = test.execute_iter();
+    let expected_vm_state = vec![
+        VmStatePartial {
+            clk: 0,
+            asmop: None,
+            op: None,
+            proc_stack: vec![],
+        },
+        VmStatePartial {
+            clk: 1,
+            asmop: None,
+            op: Some(Operation::Span),
+            proc_stack: vec![],
+        },
+        VmStatePartial {
+            clk: 2,
+            asmop: Some(AsmOpInfo::new("push.1".to_string(), 2, 1)),
+            op: Some(Operation::Pad),
+            proc_stack: vec![ProcInfo::new("foo".to_string(), 0, 2)],
+        },
+        VmStatePartial {
+            clk: 3,
+            asmop: Some(AsmOpInfo::new("push.1".to_string(), 2, 2)),
+            op: Some(Operation::Incr),
+            proc_stack: vec![ProcInfo::new("foo".to_string(), 0, 2)],
+        },
+        VmStatePartial {
+            clk: 4,
+            asmop: Some(AsmOpInfo::new("push.2".to_string(), 1, 1)),
+            op: Some(Operation::Push(Felt::new(2))),
+            proc_stack: vec![ProcInfo::new("foo".to_string(), 0, 2)],
+        },
+        VmStatePartial {
+            clk: 5,
+            asmop: Some(AsmOpInfo::new("add".to_string(), 1, 1)),
+            op: Some(Operation::Add),
+            proc_stack: vec![ProcInfo::new("foo".to_string(), 0, 2)],
+        },
+        VmStatePartial {
+            clk: 6,
+            asmop: None,
+            op: Some(Operation::End),
+            proc_stack: vec![],
+        },
+    ];
+    let vm_state = build_vm_state(vm_state_iterator);
+    assert_eq!(expected_vm_state, vm_state);
+}
+
+#[test]
+fn proc_inside_repeat() {
+    let source = "
+        proc.foo push.1 push.2 add end
+        begin
+            repeat.3
+                exec.foo
+            end
+        end";
+    let test = build_debug_test!(source);
+    let vm_state_iterator = test.execute_iter();
+    let expected_vm_state = vec![
+        VmStatePartial {
+            clk: 0,
+            asmop: None,
+            op: None,
+            proc_stack: vec![],
+        },
+        VmStatePartial {
+            clk: 1,
+            asmop: None,
+            op: Some(Operation::Span),
+            proc_stack: vec![],
+        },
+        VmStatePartial {
+            clk: 2,
+            asmop: Some(AsmOpInfo::new("push.1".to_string(), 2, 1)),
+            op: Some(Operation::Pad),
+            proc_stack: vec![ProcInfo::new("foo".to_string(), 0, 2)],
+        },
+        VmStatePartial {
+            clk: 3,
+            asmop: Some(AsmOpInfo::new("push.1".to_string(), 2, 2)),
+            op: Some(Operation::Incr),
+            proc_stack: vec![ProcInfo::new("foo".to_string(), 0, 2)],
+        },
+        VmStatePartial {
+            clk: 4,
+            asmop: Some(AsmOpInfo::new("push.2".to_string(), 1, 1)),
+            op: Some(Operation::Push(Felt::new(2))),
+            proc_stack: vec![ProcInfo::new("foo".to_string(), 0, 2)],
+        },
+        VmStatePartial {
+            clk: 5,
+            asmop: Some(AsmOpInfo::new("add".to_string(), 1, 1)),
+            op: Some(Operation::Add),
+            proc_stack: vec![ProcInfo::new("foo".to_string(), 0, 2)],
+        },
+        VmStatePartial {
+            clk: 6,
+            asmop: Some(AsmOpInfo::new("push.1".to_string(), 2, 1)),
+            op: Some(Operation::Pad),
+            proc_stack: vec![ProcInfo::new("foo".to_string(), 0, 6)],
+        },
+        VmStatePartial {
+            clk: 7,
+            asmop: Some(AsmOpInfo::new("push.1".to_string(), 2, 2)),
+            op: Some(Operation::Incr),
+            proc_stack: vec![ProcInfo::new("foo".to_string(), 0, 6)],
+        },
+        VmStatePartial {
+            clk: 8,
+            asmop: Some(AsmOpInfo::new("push.2".to_string(), 1, 1)),
+            op: Some(Operation::Push(Felt::new(2))),
+            proc_stack: vec![ProcInfo::new("foo".to_string(), 0, 6)],
+        },
+        VmStatePartial {
+            clk: 9,
+            asmop: Some(AsmOpInfo::new("add".to_string(), 1, 1)),
+            op: Some(Operation::Add),
+            proc_stack: vec![ProcInfo::new("foo".to_string(), 0, 6)],
+        },
+        VmStatePartial {
+            clk: 10,
+            asmop: Some(AsmOpInfo::new("push.1".to_string(), 2, 1)),
+            op: Some(Operation::Pad),
+            proc_stack: vec![ProcInfo::new("foo".to_string(), 0, 10)],
+        },
+        VmStatePartial {
+            clk: 11,
+            asmop: Some(AsmOpInfo::new("push.1".to_string(), 2, 2)),
+            op: Some(Operation::Incr),
+            proc_stack: vec![ProcInfo::new("foo".to_string(), 0, 10)],
+        },
+        VmStatePartial {
+            clk: 12,
+            asmop: Some(AsmOpInfo::new("push.2".to_string(), 1, 1)),
+            op: Some(Operation::Push(Felt::new(2))),
+            proc_stack: vec![ProcInfo::new("foo".to_string(), 0, 10)],
+        },
+        VmStatePartial {
+            clk: 13,
+            asmop: Some(AsmOpInfo::new("add".to_string(), 1, 1)),
+            op: Some(Operation::Add),
+            proc_stack: vec![ProcInfo::new("foo".to_string(), 0, 10)],
+        },
+        VmStatePartial {
+            clk: 14,
+            asmop: None,
+            op: Some(Operation::Noop),
+            proc_stack: vec![],
+        },
+        VmStatePartial {
+            clk: 15,
+            asmop: None,
+            op: Some(Operation::Noop),
+            proc_stack: vec![],
+        },
+        VmStatePartial {
+            clk: 16,
+            asmop: None,
+            op: Some(Operation::Noop),
+            proc_stack: vec![],
+        },
+        VmStatePartial {
+            clk: 17,
+            asmop: None,
+            op: Some(Operation::End),
+            proc_stack: vec![],
+        },
+    ];
+    let vm_state = build_vm_state(vm_state_iterator);
+    assert_eq!(expected_vm_state, vm_state);
+}
+
+#[test]
+fn proc_with_repeat() {
+    let source = "
+        proc.foo repeat.3 push.1 push.2 add end end
+        begin
+            exec.foo
+        end";
+    let test = build_debug_test!(source);
+    let vm_state_iterator = test.execute_iter();
+    let expected_vm_state = vec![
+        VmStatePartial {
+            clk: 0,
+            asmop: None,
+            op: None,
+            proc_stack: vec![],
+        },
+        VmStatePartial {
+            clk: 1,
+            asmop: None,
+            op: Some(Operation::Span),
+            proc_stack: vec![],
+        },
+        VmStatePartial {
+            clk: 2,
+            asmop: Some(AsmOpInfo::new("push.1".to_string(), 2, 1)),
+            op: Some(Operation::Pad),
+            proc_stack: vec![ProcInfo::new("foo".to_string(), 0, 2)],
+        },
+        VmStatePartial {
+            clk: 3,
+            asmop: Some(AsmOpInfo::new("push.1".to_string(), 2, 2)),
+            op: Some(Operation::Incr),
+            proc_stack: vec![ProcInfo::new("foo".to_string(), 0, 2)],
+        },
+        VmStatePartial {
+            clk: 4,
+            asmop: Some(AsmOpInfo::new("push.2".to_string(), 1, 1)),
+            op: Some(Operation::Push(Felt::new(2))),
+            proc_stack: vec![ProcInfo::new("foo".to_string(), 0, 2)],
+        },
+        VmStatePartial {
+            clk: 5,
+            asmop: Some(AsmOpInfo::new("add".to_string(), 1, 1)),
+            op: Some(Operation::Add),
+            proc_stack: vec![ProcInfo::new("foo".to_string(), 0, 2)],
+        },
+        VmStatePartial {
+            clk: 6,
+            asmop: Some(AsmOpInfo::new("push.1".to_string(), 2, 1)),
+            op: Some(Operation::Pad),
+            proc_stack: vec![ProcInfo::new("foo".to_string(), 0, 2)],
+        },
+        VmStatePartial {
+            clk: 7,
+            asmop: Some(AsmOpInfo::new("push.1".to_string(), 2, 2)),
+            op: Some(Operation::Incr),
+            proc_stack: vec![ProcInfo::new("foo".to_string(), 0, 2)],
+        },
+        VmStatePartial {
+            clk: 8,
+            asmop: Some(AsmOpInfo::new("push.2".to_string(), 1, 1)),
+            op: Some(Operation::Push(Felt::new(2))),
+            proc_stack: vec![ProcInfo::new("foo".to_string(), 0, 2)],
+        },
+        VmStatePartial {
+            clk: 9,
+            asmop: Some(AsmOpInfo::new("add".to_string(), 1, 1)),
+            op: Some(Operation::Add),
+            proc_stack: vec![ProcInfo::new("foo".to_string(), 0, 2)],
+        },
+        VmStatePartial {
+            clk: 10,
+            asmop: Some(AsmOpInfo::new("push.1".to_string(), 2, 1)),
+            op: Some(Operation::Pad),
+            proc_stack: vec![ProcInfo::new("foo".to_string(), 0, 2)],
+        },
+        VmStatePartial {
+            clk: 11,
+            asmop: Some(AsmOpInfo::new("push.1".to_string(), 2, 2)),
+            op: Some(Operation::Incr),
+            proc_stack: vec![ProcInfo::new("foo".to_string(), 0, 2)],
+        },
+        VmStatePartial {
+            clk: 12,
+            asmop: Some(AsmOpInfo::new("push.2".to_string(), 1, 1)),
+            op: Some(Operation::Push(Felt::new(2))),
+            proc_stack: vec![ProcInfo::new("foo".to_string(), 0, 2)],
+        },
+        VmStatePartial {
+            clk: 13,
+            asmop: Some(AsmOpInfo::new("add".to_string(), 1, 1)),
+            op: Some(Operation::Add),
+            proc_stack: vec![ProcInfo::new("foo".to_string(), 0, 2)],
+        },
+        VmStatePartial {
+            clk: 14,
+            asmop: None,
+            op: Some(Operation::Noop),
+            proc_stack: vec![],
+        },
+        VmStatePartial {
+            clk: 15,
+            asmop: None,
+            op: Some(Operation::Noop),
+            proc_stack: vec![],
+        },
+        VmStatePartial {
+            clk: 16,
+            asmop: None,
+            op: Some(Operation::Noop),
+            proc_stack: vec![],
+        },
+        VmStatePartial {
+            clk: 17,
+            asmop: None,
+            op: Some(Operation::End),
+            proc_stack: vec![],
+        },
+    ];
+    let vm_state = build_vm_state(vm_state_iterator);
+    assert_eq!(expected_vm_state, vm_state);
+}
+
+#[test]
+fn proc_conditional_execution() {
+    let source = "
+        proc.foo
+            if.true
+                push.1 push.2 add
+            else
+                push.3 push.4 add
+            end
+        end
+        begin
+            eq
+            exec.foo            
+        end";
+
+    //if branch
+    let test = build_debug_test!(source, &[1, 1]);
+    let vm_state_iterator = test.execute_iter();
+    let expected_vm_state = vec![
+        VmStatePartial {
+            clk: 0,
+            asmop: None,
+            op: None,
+            proc_stack: vec![],
+        },
+        VmStatePartial {
+            clk: 1,
+            asmop: None,
+            op: Some(Operation::Join),
+            proc_stack: vec![],
+        },
+        VmStatePartial {
+            clk: 2,
+            asmop: None,
+            op: Some(Operation::Span),
+            proc_stack: vec![],
+        },
+        VmStatePartial {
+            clk: 3,
+            asmop: Some(AsmOpInfo::new("eq".to_string(), 1, 1)),
+            op: Some(Operation::Eq),
+            proc_stack: vec![],
+        },
+        VmStatePartial {
+            clk: 4,
+            asmop: None,
+            op: Some(Operation::End),
+            proc_stack: vec![],
+        },
+        VmStatePartial {
+            clk: 5,
+            asmop: None,
+            op: Some(Operation::Split),
+            proc_stack: vec![ProcInfo::new("foo".to_string(), 0, 5)],
+        },
+        VmStatePartial {
+            clk: 6,
+            asmop: None,
+            op: Some(Operation::Span),
+            proc_stack: vec![ProcInfo::new("foo".to_string(), 0, 5)],
+        },
+        VmStatePartial {
+            clk: 7,
+            asmop: Some(AsmOpInfo::new("push.1".to_string(), 2, 1)),
+            op: Some(Operation::Pad),
+            proc_stack: vec![ProcInfo::new("foo".to_string(), 0, 5)],
+        },
+        VmStatePartial {
+            clk: 8,
+            asmop: Some(AsmOpInfo::new("push.1".to_string(), 2, 2)),
+            op: Some(Operation::Incr),
+            proc_stack: vec![ProcInfo::new("foo".to_string(), 0, 5)],
+        },
+        VmStatePartial {
+            clk: 9,
+            asmop: Some(AsmOpInfo::new("push.2".to_string(), 1, 1)),
+            op: Some(Operation::Push(Felt::new(2))),
+            proc_stack: vec![ProcInfo::new("foo".to_string(), 0, 5)],
+        },
+        VmStatePartial {
+            clk: 10,
+            asmop: Some(AsmOpInfo::new("add".to_string(), 1, 1)),
+            op: Some(Operation::Add),
+            proc_stack: vec![ProcInfo::new("foo".to_string(), 0, 5)],
+        },
+        VmStatePartial {
+            clk: 11,
+            asmop: None,
+            op: Some(Operation::End),
+            proc_stack: vec![ProcInfo::new("foo".to_string(), 0, 5)],
+        },
+        VmStatePartial {
+            clk: 12,
+            asmop: None,
+            op: Some(Operation::End),
+            proc_stack: vec![ProcInfo::new("foo".to_string(), 0, 5)],
+        },
+        VmStatePartial {
+            clk: 13,
+            asmop: None,
+            op: Some(Operation::End),
+            proc_stack: vec![],
+        },
+    ];
+    let vm_state = build_vm_state(vm_state_iterator);
+    assert_eq!(expected_vm_state, vm_state);
+
+    //else branch
+    let test = build_debug_test!(source, &[1, 0]);
+    let vm_state_iterator = test.execute_iter();
+    let expected_vm_state = vec![
+        VmStatePartial {
+            clk: 0,
+            asmop: None,
+            op: None,
+            proc_stack: vec![],
+        },
+        VmStatePartial {
+            clk: 1,
+            asmop: None,
+            op: Some(Operation::Join),
+            proc_stack: vec![],
+        },
+        VmStatePartial {
+            clk: 2,
+            asmop: None,
+            op: Some(Operation::Span),
+            proc_stack: vec![],
+        },
+        VmStatePartial {
+            clk: 3,
+            asmop: Some(AsmOpInfo::new("eq".to_string(), 1, 1)),
+            op: Some(Operation::Eq),
+            proc_stack: vec![],
+        },
+        VmStatePartial {
+            clk: 4,
+            asmop: None,
+            op: Some(Operation::End),
+            proc_stack: vec![],
+        },
+        VmStatePartial {
+            clk: 5,
+            asmop: None,
+            op: Some(Operation::Split),
+            proc_stack: vec![ProcInfo::new("foo".to_string(), 0, 5)],
+        },
+        VmStatePartial {
+            clk: 6,
+            asmop: None,
+            op: Some(Operation::Span),
+            proc_stack: vec![ProcInfo::new("foo".to_string(), 0, 5)],
+        },
+        VmStatePartial {
+            clk: 7,
+            asmop: Some(AsmOpInfo::new("push.3".to_string(), 1, 1)),
+            op: Some(Operation::Push(Felt::new(3))),
+            proc_stack: vec![ProcInfo::new("foo".to_string(), 0, 5)],
+        },
+        VmStatePartial {
+            clk: 8,
+            asmop: Some(AsmOpInfo::new("push.4".to_string(), 1, 1)),
+            op: Some(Operation::Push(Felt::new(4))),
+            proc_stack: vec![ProcInfo::new("foo".to_string(), 0, 5)],
+        },
+        VmStatePartial {
+            clk: 9,
+            asmop: Some(AsmOpInfo::new("add".to_string(), 1, 1)),
+            op: Some(Operation::Add),
+            proc_stack: vec![ProcInfo::new("foo".to_string(), 0, 5)],
+        },
+        VmStatePartial {
+            clk: 10,
+            asmop: None,
+            op: Some(Operation::Noop),
+            proc_stack: vec![ProcInfo::new("foo".to_string(), 0, 5)],
+        },
+        VmStatePartial {
+            clk: 11,
+            asmop: None,
+            op: Some(Operation::End),
+            proc_stack: vec![ProcInfo::new("foo".to_string(), 0, 5)],
+        },
+        VmStatePartial {
+            clk: 12,
+            asmop: None,
+            op: Some(Operation::End),
+            proc_stack: vec![ProcInfo::new("foo".to_string(), 0, 5)],
+        },
+        VmStatePartial {
+            clk: 13,
+            asmop: None,
+            op: Some(Operation::End),
+            proc_stack: vec![],
+        },
+    ];
+    let vm_state = build_vm_state(vm_state_iterator);
+    assert_eq!(expected_vm_state, vm_state);
+}
+
+#[test]
+fn proc_split_inside_join() {
+    let source = "
+        proc.foo
+            eq
+            if.true
+                push.1 push.2 add
+            else
+                push.3 push.4 add
+            end
+        end
+        begin
+            exec.foo            
+        end";
+
+    //if branch
+    let test = build_debug_test!(source, &[1, 1]);
+    let vm_state_iterator = test.execute_iter();
+    let expected_vm_state = vec![
+        VmStatePartial {
+            clk: 0,
+            asmop: None,
+            op: None,
+            proc_stack: vec![],
+        },
+        VmStatePartial {
+            clk: 1,
+            asmop: None,
+            op: Some(Operation::Join),
+            proc_stack: vec![ProcInfo::new("foo".to_string(), 0, 1)],
+        },
+        VmStatePartial {
+            clk: 2,
+            asmop: None,
+            op: Some(Operation::Span),
+            proc_stack: vec![ProcInfo::new("foo".to_string(), 0, 1)],
+        },
+        VmStatePartial {
+            clk: 3,
+            asmop: Some(AsmOpInfo::new("eq".to_string(), 1, 1)),
+            op: Some(Operation::Eq),
+            proc_stack: vec![ProcInfo::new("foo".to_string(), 0, 1)],
+        },
+        VmStatePartial {
+            clk: 4,
+            asmop: None,
+            op: Some(Operation::End),
+            proc_stack: vec![ProcInfo::new("foo".to_string(), 0, 1)],
+        },
+        VmStatePartial {
+            clk: 5,
+            asmop: None,
+            op: Some(Operation::Split),
+            proc_stack: vec![ProcInfo::new("foo".to_string(), 0, 1)],
+        },
+        VmStatePartial {
+            clk: 6,
+            asmop: None,
+            op: Some(Operation::Span),
+            proc_stack: vec![ProcInfo::new("foo".to_string(), 0, 1)],
+        },
+        VmStatePartial {
+            clk: 7,
+            asmop: Some(AsmOpInfo::new("push.1".to_string(), 2, 1)),
+            op: Some(Operation::Pad),
+            proc_stack: vec![ProcInfo::new("foo".to_string(), 0, 1)],
+        },
+        VmStatePartial {
+            clk: 8,
+            asmop: Some(AsmOpInfo::new("push.1".to_string(), 2, 2)),
+            op: Some(Operation::Incr),
+            proc_stack: vec![ProcInfo::new("foo".to_string(), 0, 1)],
+        },
+        VmStatePartial {
+            clk: 9,
+            asmop: Some(AsmOpInfo::new("push.2".to_string(), 1, 1)),
+            op: Some(Operation::Push(Felt::new(2))),
+            proc_stack: vec![ProcInfo::new("foo".to_string(), 0, 1)],
+        },
+        VmStatePartial {
+            clk: 10,
+            asmop: Some(AsmOpInfo::new("add".to_string(), 1, 1)),
+            op: Some(Operation::Add),
+            proc_stack: vec![ProcInfo::new("foo".to_string(), 0, 1)],
+        },
+        VmStatePartial {
+            clk: 11,
+            asmop: None,
+            op: Some(Operation::End),
+            proc_stack: vec![ProcInfo::new("foo".to_string(), 0, 1)],
+        },
+        VmStatePartial {
+            clk: 12,
+            asmop: None,
+            op: Some(Operation::End),
+            proc_stack: vec![ProcInfo::new("foo".to_string(), 0, 1)],
+        },
+        VmStatePartial {
+            clk: 13,
+            asmop: None,
+            op: Some(Operation::End),
+            proc_stack: vec![ProcInfo::new("foo".to_string(), 0, 1)],
+        },
+    ];
+    let vm_state = build_vm_state(vm_state_iterator);
+    assert_eq!(expected_vm_state, vm_state);
+}
+
+#[test]
+fn proc_nested_procedures() {
+    let source = "
+        proc.foo push.3 push.7 mul end
+        proc.bar push.5 exec.foo add end
+        begin push.2 push.4 add exec.foo push.11 exec.bar sub end";
+
+    let test = build_debug_test!(source);
+    let vm_state_iterator = test.execute_iter();
+    let expected_vm_state = vec![
+        VmStatePartial {
+            clk: 0,
+            asmop: None,
+            op: None,
+            proc_stack: vec![],
+        },
+        VmStatePartial {
+            clk: 1,
+            asmop: None,
+            op: Some(Operation::Span),
+            proc_stack: vec![],
+        },
+        VmStatePartial {
+            clk: 2,
+            asmop: Some(AsmOpInfo::new("push.2".to_string(), 1, 1)),
+            op: Some(Operation::Push(Felt::new(2))),
+            proc_stack: vec![],
+        },
+        VmStatePartial {
+            clk: 3,
+            asmop: Some(AsmOpInfo::new("push.4".to_string(), 1, 1)),
+            op: Some(Operation::Push(Felt::new(4))),
+            proc_stack: vec![],
+        },
+        VmStatePartial {
+            clk: 4,
+            asmop: Some(AsmOpInfo::new("add".to_string(), 1, 1)),
+            op: Some(Operation::Add),
+            proc_stack: vec![],
+        },
+        VmStatePartial {
+            clk: 5,
+            asmop: Some(AsmOpInfo::new("push.3".to_string(), 1, 1)),
+            op: Some(Operation::Push(Felt::new(3))),
+            proc_stack: vec![ProcInfo::new("foo".to_string(), 0, 5)],
+        },
+        VmStatePartial {
+            clk: 6,
+            asmop: Some(AsmOpInfo::new("push.7".to_string(), 1, 1)),
+            op: Some(Operation::Push(Felt::new(7))),
+            proc_stack: vec![ProcInfo::new("foo".to_string(), 0, 5)],
+        },
+        VmStatePartial {
+            clk: 7,
+            asmop: Some(AsmOpInfo::new("mul".to_string(), 1, 1)),
+            op: Some(Operation::Mul),
+            proc_stack: vec![ProcInfo::new("foo".to_string(), 0, 5)],
+        },
+        VmStatePartial {
+            clk: 8,
+            asmop: Some(AsmOpInfo::new("push.11".to_string(), 1, 1)),
+            op: Some(Operation::Push(Felt::new(11))),
+            proc_stack: vec![],
+        },
+        VmStatePartial {
+            clk: 9,
+            asmop: Some(AsmOpInfo::new("push.5".to_string(), 1, 1)),
+            op: Some(Operation::Push(Felt::new(5))),
+            proc_stack: vec![ProcInfo::new("bar".to_string(), 0, 9)],
+        },
+        VmStatePartial {
+            clk: 10,
+            asmop: None,
+            op: Some(Operation::Noop),
+            proc_stack: vec![ProcInfo::new("bar".to_string(), 0, 9)],
+        },
+        VmStatePartial {
+            clk: 11,
+            asmop: None,
+            op: Some(Operation::Noop),
+            proc_stack: vec![ProcInfo::new("bar".to_string(), 0, 9)],
+        },
+        VmStatePartial {
+            clk: 12,
+            asmop: None,
+            op: Some(Operation::Respan),
+            proc_stack: vec![ProcInfo::new("bar".to_string(), 0, 9)],
+        },
+        VmStatePartial {
+            clk: 13,
+            asmop: Some(AsmOpInfo::new("push.3".to_string(), 1, 1)),
+            op: Some(Operation::Push(Felt::new(3))),
+            proc_stack: vec![
+                ProcInfo::new("bar".to_string(), 0, 9),
+                ProcInfo::new("foo".to_string(), 0, 13),
+            ],
+        },
+        VmStatePartial {
+            clk: 14,
+            asmop: Some(AsmOpInfo::new("push.7".to_string(), 1, 1)),
+            op: Some(Operation::Push(Felt::new(7))),
+            proc_stack: vec![
+                ProcInfo::new("bar".to_string(), 0, 9),
+                ProcInfo::new("foo".to_string(), 0, 13),
+            ],
+        },
+        VmStatePartial {
+            clk: 15,
+            asmop: Some(AsmOpInfo::new("mul".to_string(), 1, 1)),
+            op: Some(Operation::Mul),
+            proc_stack: vec![
+                ProcInfo::new("bar".to_string(), 0, 9),
+                ProcInfo::new("foo".to_string(), 0, 13),
+            ],
+        },
+        VmStatePartial {
+            clk: 16,
+            asmop: Some(AsmOpInfo::new("add".to_string(), 1, 1)),
+            op: Some(Operation::Add),
+            proc_stack: vec![ProcInfo::new("bar".to_string(), 0, 9)],
+        },
+        VmStatePartial {
+            clk: 17,
+            asmop: Some(AsmOpInfo::new("sub".to_string(), 2, 1)),
+            op: Some(Operation::Neg),
+            proc_stack: vec![],
+        },
+        VmStatePartial {
+            clk: 18,
+            asmop: Some(AsmOpInfo::new("sub".to_string(), 2, 2)),
+            op: Some(Operation::Add),
+            proc_stack: vec![],
+        },
+        VmStatePartial {
+            clk: 19,
+            asmop: None,
+            op: Some(Operation::Noop),
+            proc_stack: vec![],
+        },
+        VmStatePartial {
+            clk: 20,
+            asmop: None,
+            op: Some(Operation::End),
+            proc_stack: vec![],
+        },
+    ];
+    let vm_state = build_vm_state(vm_state_iterator);
+    assert_eq!(expected_vm_state, vm_state);
+}
+
+#[test]
+fn multiple_procs_end_at_same_clk() {
+    let source = "
+        proc.foo push.3 end
+        proc.bar push.5 exec.foo end
+        begin exec.bar end";
+
+    let test = build_debug_test!(source);
+    let vm_state_iterator = test.execute_iter();
+    let expected_vm_state = vec![
+        VmStatePartial {
+            clk: 0,
+            asmop: None,
+            op: None,
+            proc_stack: vec![],
+        },
+        VmStatePartial {
+            clk: 1,
+            asmop: None,
+            op: Some(Operation::Span),
+            proc_stack: vec![],
+        },
+        VmStatePartial {
+            clk: 2,
+            asmop: Some(AsmOpInfo::new("push.5".to_string(), 1, 1)),
+            op: Some(Operation::Push(Felt::new(5))),
+            proc_stack: vec![ProcInfo::new("bar".to_string(), 0, 2)],
+        },
+        VmStatePartial {
+            clk: 3,
+            asmop: Some(AsmOpInfo::new("push.3".to_string(), 1, 1)),
+            op: Some(Operation::Push(Felt::new(3))),
+            proc_stack: vec![
+                ProcInfo::new("bar".to_string(), 0, 2),
+                ProcInfo::new("foo".to_string(), 0, 3),
+            ],
+        },
+        VmStatePartial {
+            clk: 4,
+            asmop: None,
+            op: Some(Operation::Noop),
+            proc_stack: vec![],
+        },
+        VmStatePartial {
+            clk: 5,
+            asmop: None,
+            op: Some(Operation::Noop),
+            proc_stack: vec![],
+        },
+        VmStatePartial {
+            clk: 6,
+            asmop: None,
+            op: Some(Operation::End),
+            proc_stack: vec![],
+        },
+    ];
+    let vm_state = build_vm_state(vm_state_iterator);
+    assert_eq!(expected_vm_state, vm_state);
+}
+
+#[test]
+fn multiple_non_span_alias() {
+    // in case multiple methods are aliases of a procedure starting at a non-span block, only add
+    // the outermost procedure to proc_stack
+    let source = "
+        proc.foo1 if.true push.3 else push.4 end end
+        proc.foo2 exec.foo1 end
+        proc.foo3 exec.foo2 end
+        proc.foo4 exec.foo3 end
+        proc.foo5 exec.foo4 end
+        begin exec.foo5 end";
+
+    let test = build_debug_test!(source);
+    let vm_state_iterator = test.execute_iter();
+    let expected_vm_state = vec![
+        VmStatePartial {
+            clk: 0,
+            asmop: None,
+            op: None,
+            proc_stack: vec![],
+        },
+        VmStatePartial {
+            clk: 1,
+            asmop: None,
+            op: Some(Operation::Split),
+            proc_stack: vec![ProcInfo::new("foo5".to_string(), 0, 1)],
+        },
+        VmStatePartial {
+            clk: 2,
+            asmop: None,
+            op: Some(Operation::Span),
+            proc_stack: vec![ProcInfo::new("foo5".to_string(), 0, 1)],
+        },
+        VmStatePartial {
+            clk: 3,
+            asmop: Some(AsmOpInfo::new("push.4".to_string(), 1, 1)),
+            op: Some(Operation::Push(Felt::new(4))),
+            proc_stack: vec![ProcInfo::new("foo5".to_string(), 0, 1)],
+        },
+        VmStatePartial {
+            clk: 4,
+            asmop: None,
+            op: Some(Operation::Noop),
+            proc_stack: vec![ProcInfo::new("foo5".to_string(), 0, 1)],
+        },
+        VmStatePartial {
+            clk: 5,
+            asmop: None,
+            op: Some(Operation::End),
+            proc_stack: vec![ProcInfo::new("foo5".to_string(), 0, 1)],
+        },
+        VmStatePartial {
+            clk: 6,
+            asmop: None,
+            op: Some(Operation::End),
+            proc_stack: vec![ProcInfo::new("foo5".to_string(), 0, 1)],
+        },
+    ];
+    let vm_state = build_vm_state(vm_state_iterator);
+    assert_eq!(expected_vm_state, vm_state);
+}
+
+#[test]
+fn imported_proc() {
+    let source = "
+        use.std::math::u64
+        begin exec.u64::checked_xor end";
+    let test = build_debug_test!(source);
+    let vm_state_iterator = test.execute_iter();
+    let expected_vm_state = vec![
+        VmStatePartial {
+            clk: 0,
+            asmop: None,
+            op: None,
+            proc_stack: vec![],
+        },
+        VmStatePartial {
+            clk: 1,
+            asmop: None,
+            op: Some(Operation::Span),
+            proc_stack: vec![],
+        },
+        VmStatePartial {
+            clk: 2,
+            asmop: Some(AsmOpInfo::new("swap".to_string(), 1, 1)),
+            op: Some(Operation::Swap),
+            proc_stack: vec![ProcInfo::new("u64::checked_xor".to_string(), 0, 2)],
+        },
+        VmStatePartial {
+            clk: 3,
+            asmop: Some(AsmOpInfo::new("movup.3".to_string(), 1, 1)),
+            op: Some(Operation::MovUp3),
+            proc_stack: vec![ProcInfo::new("u64::checked_xor".to_string(), 0, 2)],
+        },
+        VmStatePartial {
+            clk: 4,
+            asmop: Some(AsmOpInfo::new("u32checked_xor".to_string(), 1, 1)),
+            op: Some(Operation::U32xor),
+            proc_stack: vec![ProcInfo::new("u64::checked_xor".to_string(), 0, 2)],
+        },
+        VmStatePartial {
+            clk: 5,
+            asmop: Some(AsmOpInfo::new("swap".to_string(), 1, 1)),
+            op: Some(Operation::Swap),
+            proc_stack: vec![ProcInfo::new("u64::checked_xor".to_string(), 0, 2)],
+        },
+        VmStatePartial {
+            clk: 6,
+            asmop: Some(AsmOpInfo::new("movup.2".to_string(), 1, 1)),
+            op: Some(Operation::MovUp2),
+            proc_stack: vec![ProcInfo::new("u64::checked_xor".to_string(), 0, 2)],
+        },
+        VmStatePartial {
+            clk: 7,
+            asmop: Some(AsmOpInfo::new("u32checked_xor".to_string(), 1, 1)),
+            op: Some(Operation::U32xor),
+            proc_stack: vec![ProcInfo::new("u64::checked_xor".to_string(), 0, 2)],
+        },
+        VmStatePartial {
+            clk: 8,
+            asmop: None,
+            op: Some(Operation::End),
+            proc_stack: vec![],
+        },
+    ];
+    let vm_state = build_vm_state(vm_state_iterator);
+    assert_eq!(expected_vm_state, vm_state);
+}

--- a/processor/src/decorators/mod.rs
+++ b/processor/src/decorators/mod.rs
@@ -17,9 +17,16 @@ impl Process {
                         .append_asmop(self.system.clk(), assembly_op.clone());
                 }
             }
+            Decorator::ProcMarker(_) => {
+                if self.decoder.in_debug_mode() {
+                    self.decoder
+                        .append_proc_marker(self.system.clk(), decorator.clone());
+                }
+            }
         }
         Ok(())
     }
+
     // ADVICE INJECTION
     // --------------------------------------------------------------------------------------------
 

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -49,7 +49,7 @@ pub use errors::ExecutionError;
 mod utils;
 
 mod debug;
-pub use debug::{AsmOpInfo, VmState, VmStateIterator};
+pub use debug::{AsmOpInfo, ProcInfo, VmState, VmStateIterator};
 
 // TYPE ALIASES
 // ================================================================================================


### PR DESCRIPTION
This PR adds `ProcMarker` decorator to executing programs that helps adding context to running programs about whether an operation is part of a procedure. A procedure stack of currently executing procedures is added to the `VmState`.
Edit: Also removes AsmOp decorator for advice injection operations.