### PR TITLE
Fix clippy warning about needless borrows

### DIFF
--- a/air/src/lib.rs
+++ b/air/src/lib.rs
@@ -263,10 +263,10 @@ impl Serializable for PublicInputs {
 
         // write program outputs.
         let stack = self.outputs.stack().iter().map(|v| Felt::new(*v)).collect::<Vec<_>>();
-        target.write(&stack);
+        target.write(stack);
 
         let overflow_addrs =
             self.outputs.overflow_addrs().iter().map(|v| Felt::new(*v)).collect::<Vec<_>>();
-        target.write(&overflow_addrs);
+        target.write(overflow_addrs);
     }
 }


### PR DESCRIPTION
Clippy [complained](https://github.com/0xPolygonMiden/miden-vm/actions/runs/3829167260/jobs/6517287374):

```
error: the borrowed expression implements the required traits
   --> air/src/lib.rs:266:22
    |
266 |         target.write(&stack);
    |                      ^^^^^^ help: change this to: `stack`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow
    = note: `-D clippy::needless-borrow` implied by `-D clippy::all`

error: the borrowed expression implements the required traits
   --> air/src/lib.rs:270:22
    |
270 |         target.write(&overflow_addrs);
    |                      ^^^^^^^^^^^^^^^ help: change this to: `overflow_addrs`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow
```

So let's fix this.