### PR TITLE
Automatic fixes from clippy

### DIFF
--- a/assembly/src/tests.rs
+++ b/assembly/src/tests.rs
@@ -37,7 +37,7 @@ fn single_span() {
     let source = "begin push.1 push.2 add end";
     let program = assembler.compile(source).unwrap();
     let expected = "begin span pad incr push(2) add end end";
-    assert_eq!(expected, format!("{}", program));
+    assert_eq!(expected, format!("{program}"));
 }
 
 #[test]
@@ -54,7 +54,7 @@ fn span_and_simple_if() {
                 if.true span add end else span mul end end \
             end \
         end";
-    assert_eq!(expected, format!("{}", program));
+    assert_eq!(expected, format!("{program}"));
 
     // if without else
     let source = "begin push.2 push.3 if.true add end end";
@@ -66,7 +66,7 @@ fn span_and_simple_if() {
                 if.true span add end else span noop end end \
             end \
         end";
-    assert_eq!(expected, format!("{}", program));
+    assert_eq!(expected, format!("{program}"));
 }
 
 // NESTED CONTROL BLOCKS
@@ -107,7 +107,7 @@ fn nested_control_blocks() {
             span push(3) add end \
             end \
         end";
-    assert_eq!(expected, format!("{}", program));
+    assert_eq!(expected, format!("{program}"));
 }
 
 // PROGRAMS WITH PROCEDURES
@@ -119,7 +119,7 @@ fn program_with_one_procedure() {
     let source = "proc.foo push.3 push.7 mul end begin push.2 push.3 add exec.foo end";
     let program = assembler.compile(source).unwrap();
     let expected = "begin span push(2) push(3) add push(3) push(7) mul end end";
-    assert_eq!(expected, format!("{}", program));
+    assert_eq!(expected, format!("{program}"));
 }
 
 #[test]
@@ -134,7 +134,7 @@ fn program_with_nested_procedure() {
         span push(2) push(4) add push(3) push(7) mul \
         push(11) push(5) push(3) push(7) mul add neg add \
         end end";
-    assert_eq!(expected, format!("{}", program));
+    assert_eq!(expected, format!("{program}"));
 }
 
 #[test]
@@ -164,7 +164,7 @@ fn program_with_proc_locals() {
                 push(18446744069414584320) fmpupdate \
             end \
         end";
-    assert_eq!(expected, format!("{}", program));
+    assert_eq!(expected, format!("{program}"));
 }
 
 #[test]
@@ -227,14 +227,13 @@ fn program_with_one_import() {
     let assembler = super::Assembler::default().with_library(&DummyLibrary::default()).unwrap();
     let source = format!(
         r#"
-        use.{}::{}
+        use.{NAMESPACE}::{MODULE}
         begin
             push.4 push.3
             exec.u256::iszero_unsafe
-        end"#,
-        NAMESPACE, MODULE
+        end"#
     );
-    let program = assembler.compile(&source).unwrap();
+    let program = assembler.compile(source).unwrap();
     let expected = "\
         begin \
             span \
@@ -249,7 +248,7 @@ fn program_with_one_import() {
                 swap eqz and \
             end \
         end";
-    assert_eq!(expected, format!("{}", program));
+    assert_eq!(expected, format!("{program}"));
 }
 
 #[test]
@@ -284,7 +283,7 @@ fn comment_simple() {
     let source = "begin # simple comment \n push.1 push.2 add end";
     let program = assembler.compile(source).unwrap();
     let expected = "begin span pad incr push(2) add end end";
-    assert_eq!(expected, format!("{}", program));
+    assert_eq!(expected, format!("{program}"));
 }
 
 #[test]
@@ -324,7 +323,7 @@ fn comment_in_nested_control_blocks() {
             span push(3) add end \
             end \
         end";
-    assert_eq!(expected, format!("{}", program));
+    assert_eq!(expected, format!("{program}"));
 }
 
 #[test]
@@ -333,7 +332,7 @@ fn comment_before_program() {
     let source = " # starting comment \n begin push.1 push.2 add end";
     let program = assembler.compile(source).unwrap();
     let expected = "begin span pad incr push(2) add end end";
-    assert_eq!(expected, format!("{}", program));
+    assert_eq!(expected, format!("{program}"));
 }
 
 #[test]
@@ -342,7 +341,7 @@ fn comment_after_program() {
     let source = "begin push.1 push.2 add end # closing comment";
     let program = assembler.compile(source).unwrap();
     let expected = "begin span pad incr push(2) add end end";
-    assert_eq!(expected, format!("{}", program));
+    assert_eq!(expected, format!("{program}"));
 }
 
 // ERRORS

--- a/miden/tests/integration/helpers/mod.rs
+++ b/miden/tests/integration/helpers/mod.rs
@@ -171,7 +171,7 @@ impl Test {
             assert!(miden::verify(program.hash(), &pub_inputs, &outputs, proof).is_err());
         } else {
             let result = miden::verify(program.hash(), &pub_inputs, &outputs, proof);
-            assert!(result.is_ok(), "error: {:?}", result);
+            assert!(result.is_ok(), "error: {result:?}");
         }
     }
 

--- a/miden/tests/integration/operations/decorators/asmop.rs
+++ b/miden/tests/integration/operations/decorators/asmop.rs
@@ -372,7 +372,7 @@ fn build_vm_state(vm_state_iterator: VmStateIterator) -> Vec<VmStatePartial> {
     let mut vm_state = Vec::new();
     for state in vm_state_iterator {
         vm_state.push(VmStatePartial {
-            clk: state.as_ref().unwrap().clk as u32,
+            clk: state.as_ref().unwrap().clk,
             asmop: state.as_ref().unwrap().asmop.clone(),
             op: state.as_ref().unwrap().op,
         });

--- a/miden/tests/integration/operations/field_ops.rs
+++ b/miden/tests/integration/operations/field_ops.rs
@@ -72,7 +72,7 @@ fn add() {
 
 #[test]
 fn add_b() {
-    let build_asm_op = |param: u64| format!("add.{}", param);
+    let build_asm_op = |param: u64| format!("add.{param}");
 
     // --- simple case ----------------------------------------------------------------------------
     let test = build_op_test!(build_asm_op(2), &[1]);
@@ -120,7 +120,7 @@ fn sub() {
 
 #[test]
 fn sub_b() {
-    let build_asm_op = |param: u64| format!("sub.{}", param);
+    let build_asm_op = |param: u64| format!("sub.{param}");
 
     // --- simple case ----------------------------------------------------------------------------
     let test = build_op_test!(build_asm_op(2), &[3]);
@@ -164,7 +164,7 @@ fn mul() {
 
 #[test]
 fn mul_b() {
-    let build_asm_op = |param: u64| format!("mul.{}", param);
+    let build_asm_op = |param: u64| format!("mul.{param}");
 
     // --- simple cases ---------------------------------------------------------------------------
     let test = build_op_test!(build_asm_op(0), &[1]);
@@ -212,7 +212,7 @@ fn div() {
 
 #[test]
 fn div_b() {
-    let build_asm_op = |param: u64| format!("div.{}", param);
+    let build_asm_op = |param: u64| format!("div.{param}");
 
     // --- simple cases ---------------------------------------------------------------------------
     let test = build_op_test!(build_asm_op(1), &[0]);
@@ -331,7 +331,7 @@ fn pow2_fail() {
 
 #[test]
 fn exp_bits_length() {
-    let build_asm_op = |param: u64| format!("exp.u{}", param);
+    let build_asm_op = |param: u64| format!("exp.u{param}");
 
     //---------------------- exp with parameter containing bits length ----------------------------
 
@@ -345,7 +345,7 @@ fn exp_bits_length() {
 
 #[test]
 fn exp_bits_length_fail() {
-    let build_asm_op = |param: u64| format!("exp.u{}", param);
+    let build_asm_op = |param: u64| format!("exp.u{param}");
 
     //---------------------- exp containing more bits than specified in the parameter ------------
 
@@ -366,7 +366,7 @@ fn exp_bits_length_fail() {
 
 #[test]
 fn exp_small_pow() {
-    let build_asm_op = |param: u64| format!("exp.{}", param);
+    let build_asm_op = |param: u64| format!("exp.{param}");
 
     let base = rand_value::<u64>();
     let pow = 7;
@@ -582,7 +582,7 @@ proptest! {
         test.prop_expect_stack(&[expected as u64])?;
 
         // b provided as a parameter
-        let asm_op = format!("{}.{}", asm_op, b);
+        let asm_op = format!("{asm_op}.{b}");
         let test = build_op_test!(&asm_op, &[a]);
         test.prop_expect_stack(&[expected as u64])?;
     }
@@ -609,12 +609,12 @@ proptest! {
         test.prop_expect_stack(&[Felt::MODULUS - expected])?;
 
         // b provided as a parameter
-        let asm_op_b = format!("{}.{}", asm_op, b);
+        let asm_op_b = format!("{asm_op}.{b}");
         let test = build_op_test!(&asm_op_b, &[a]);
         test.prop_expect_stack(&[expected])?;
 
         // underflow by a provided as a parameter
-        let asm_op_b = format!("{}.{}", asm_op, a);
+        let asm_op_b = format!("{asm_op}.{a}");
         let test = build_op_test!(asm_op_b, &[b]);
         test.prop_expect_stack(&[Felt::MODULUS - expected])?;
     }
@@ -631,7 +631,7 @@ proptest! {
         test.prop_expect_stack(&[expected as u64])?;
 
         // b provided as a parameter
-        let asm_op = format!("{}.{}", asm_op, b);
+        let asm_op = format!("{asm_op}.{b}");
         let test = build_op_test!(&asm_op, &[a]);
         test.prop_expect_stack(&[expected as u64])?;
     }
@@ -648,7 +648,7 @@ proptest! {
         test.prop_expect_stack(&[expected as u64])?;
 
         // b provided as a parameter
-        let asm_op = format!("{}.{}", asm_op, b);
+        let asm_op = format!("{asm_op}.{b}");
         let test = build_op_test!(&asm_op, &[a]);
         test.prop_expect_stack(&[expected as u64])?;
     }
@@ -682,7 +682,7 @@ proptest! {
         let asm_op = "pow2";
         let expected = 2_u64.wrapping_pow(b);
 
-        build_op_test!(asm_op, &[b as u64]).prop_expect_stack(&[expected as u64])?;
+        build_op_test!(asm_op, &[b as u64]).prop_expect_stack(&[expected])?;
     }
 
     #[test]
@@ -700,7 +700,7 @@ proptest! {
 
         //----------------------- exp with parameter containing pow ----------------
 
-        let build_asm_op = |param: u64| format!("exp.{}", param);
+        let build_asm_op = |param: u64| format!("exp.{param}");
         let base = a;
         let pow = b;
         let expected = Felt::new(base).exp(pow);

--- a/miden/tests/integration/operations/io_ops/adv_ops.rs
+++ b/miden/tests/integration/operations/io_ops/adv_ops.rs
@@ -9,7 +9,7 @@ fn adv_push() {
     let asm_op = "adv_push";
     let advice_tape = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
     let test_n = |n: usize| {
-        let source = format!("{}.{}", asm_op, n);
+        let source = format!("{asm_op}.{n}");
         let mut final_stack = vec![0; n];
         final_stack.copy_from_slice(&advice_tape[..n]);
         final_stack.reverse();

--- a/miden/tests/integration/operations/io_ops/constant_ops.rs
+++ b/miden/tests/integration/operations/io_ops/constant_ops.rs
@@ -28,12 +28,12 @@ fn push_many() {
     let base_op = "push";
 
     // --- multiple values with separators --------------------------------------------------------
-    let asm_op = format!("{}.17.0x13.23", base_op);
+    let asm_op = format!("{base_op}.17.0x13.23");
     let test = build_op_test!(asm_op);
     test.expect_stack(&[23, 19, 17]);
 
     // --- push the maximum number of decimal values (16) -------------------------------------
-    let asm_op = format!("{}.16.17.18.19.20.21.22.23.24.25.26.27.28.29.30.31", base_op);
+    let asm_op = format!("{base_op}.16.17.18.19.20.21.22.23.24.25.26.27.28.29.30.31");
     let mut expected = Vec::with_capacity(16);
     for i in (16..32).rev() {
         expected.push(i);
@@ -43,7 +43,7 @@ fn push_many() {
     test.expect_stack(&expected);
 
     // --- push hexadecimal values with period separators between values ----------------------
-    let asm_op = format!("{}.0x0A.0x64.0x03E8.0x2710.0x0186A0", base_op);
+    let asm_op = format!("{base_op}.0x0A.0x64.0x03E8.0x2710.0x0186A0");
     let mut expected = Vec::with_capacity(5);
     for i in (1..=5).rev() {
         expected.push(10_u64.pow(i));
@@ -53,7 +53,7 @@ fn push_many() {
     test.expect_stack(&expected);
 
     // --- push a mixture of decimal and single-element hexadecimal values --------------------
-    let asm_op = format!("{}.2.4.8.0x10.0x20.0x40.128.0x0100", base_op);
+    let asm_op = format!("{base_op}.2.4.8.0x10.0x20.0x40.128.0x0100");
     let mut expected = Vec::with_capacity(8);
     for i in (1_u32..=8).rev() {
         expected.push(2_u64.pow(i));
@@ -68,13 +68,13 @@ fn push_without_separator() {
     let base_op = "push";
 
     // --- multiple values as a hexadecimal string ------------------------------------------------
-    let asm_op = format!("{}.0x0000000000004321000000000000dcba", base_op);
+    let asm_op = format!("{base_op}.0x0000000000004321000000000000dcba");
 
     let test = build_op_test!(asm_op);
     test.expect_stack(&[56506, 17185]);
 
     // --- push the maximum number of hexadecimal values without separators (16) ------------------
-    let asm_op =    format!("{}.0x0000000000000000000000000000000100000000000000020000000000000003000000000000000400000000000000050000000000000006000000000000000700000000000000080000000000000009000000000000000A000000000000000B000000000000000C000000000000000D000000000000000E000000000000000F", base_op);
+    let asm_op =    format!("{base_op}.0x0000000000000000000000000000000100000000000000020000000000000003000000000000000400000000000000050000000000000006000000000000000700000000000000080000000000000009000000000000000A000000000000000B000000000000000C000000000000000D000000000000000E000000000000000F");
     let mut expected = Vec::with_capacity(16);
     for i in (0..16).rev() {
         expected.push(i);

--- a/miden/tests/integration/operations/io_ops/env_ops.rs
+++ b/miden/tests/integration/operations/io_ops/env_ops.rs
@@ -21,7 +21,7 @@ fn sdepth() {
 
     // --- overflowed stack -----------------------------------------------------------------------
     // push 2 values to increase the lenth of the stack beyond 16
-    let source = format!("begin push.1 push.1 {} end", test_op);
+    let source = format!("begin push.1 push.1 {test_op} end");
     let test = build_test!(&source, &[0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7]);
     test.expect_stack(&[18, 1, 1, 7, 6, 5, 4, 3, 2, 1, 0, 7, 6, 5, 4, 3]);
 }

--- a/miden/tests/integration/operations/io_ops/mem_ops.rs
+++ b/miden/tests/integration/operations/io_ops/mem_ops.rs
@@ -14,7 +14,7 @@ fn mem_load() {
     test.expect_stack(&[0]);
 
     // --- read from uninitialized memory - address provided as a parameter -----------------------
-    let asm_op = format!("{}.{}", asm_op, addr);
+    let asm_op = format!("{asm_op}.{addr}");
     let test = build_op_test!(&asm_op);
     test.expect_stack(&[0]);
 
@@ -36,7 +36,7 @@ fn mem_store() {
     test.expect_stack_and_memory(&[3, 2, 1], addr, &[4, 0, 0, 0]);
 
     // --- address provided as a parameter --------------------------------------------------------
-    let asm_op = format!("{}.{}", asm_op, addr);
+    let asm_op = format!("{asm_op}.{addr}");
     let test = build_op_test!(&asm_op, &[1, 2, 3, 4]);
     test.expect_stack_and_memory(&[3, 2, 1], addr, &[4, 0, 0, 0]);
 }
@@ -54,7 +54,7 @@ fn mem_loadw() {
     test.expect_stack(&[0, 0, 0, 0]);
 
     // --- read from uninitialized memory - address provided as a parameter -----------------------
-    let asm_op = format!("{}.{}", asm_op, addr);
+    let asm_op = format!("{asm_op}.{addr}");
 
     let test = build_op_test!(asm_op, &[5, 6, 7, 8]);
     test.expect_stack(&[0, 0, 0, 0]);
@@ -78,7 +78,7 @@ fn mem_storew() {
     test.expect_stack_and_memory(&[4, 3, 2, 1], addr, &[1, 2, 3, 4]);
 
     // --- address provided as a parameter --------------------------------------------------------
-    let asm_op = format!("{}.{}", asm_op, addr);
+    let asm_op = format!("{asm_op}.{addr}");
     let test = build_op_test!(&asm_op, &[1, 2, 3, 4]);
     test.expect_stack_and_memory(&[4, 3, 2, 1], addr, &[1, 2, 3, 4]);
 

--- a/miden/tests/integration/operations/u32_ops/arithmetic_ops.rs
+++ b/miden/tests/integration/operations/u32_ops/arithmetic_ops.rs
@@ -51,7 +51,7 @@ fn u32checked_add_fail() {
 
 #[test]
 fn u32checked_add_b() {
-    let build_asm_op = |param: u16| format!("u32checked_add.{}", param);
+    let build_asm_op = |param: u16| format!("u32checked_add.{param}");
 
     // --- simple cases ----------------------------------------------------------------------------
     let test = build_op_test!(build_asm_op(2).as_str(), &[1]);
@@ -78,7 +78,7 @@ fn u32checked_add_b() {
 
 #[test]
 fn u32checked_add_b_fail() {
-    let build_asm_op = |param: u64| format!("u32checked_add.{}", param);
+    let build_asm_op = |param: u64| format!("u32checked_add.{param}");
 
     // should fail during execution if a >= 2^32.
     let test = build_op_test!(build_asm_op(0).as_str(), &[U32_BOUND]);
@@ -132,7 +132,7 @@ fn u32wrapping_add() {
 
 #[test]
 fn u32wrapping_add_b() {
-    let build_asm_op = |param: u64| format!("u32wrapping_add.{}", param);
+    let build_asm_op = |param: u64| format!("u32wrapping_add.{param}");
 
     // --- (a + b) < 2^32 -------------------------------------------------------------------------
     let test = build_op_test!(build_asm_op(2), &[1]);
@@ -321,7 +321,7 @@ fn u32checked_sub_fail() {
 
 #[test]
 fn u32checked_sub_b() {
-    let build_asm_op = |param: u32| format!("u32checked_sub.{}", param);
+    let build_asm_op = |param: u32| format!("u32checked_sub.{param}");
 
     // --- simple cases ---------------------------------------------------------------------------
     let test = build_op_test!(build_asm_op(1).as_str(), &[2]);
@@ -349,7 +349,7 @@ fn u32checked_sub_b() {
 
 #[test]
 fn u32checked_sub_b_fail() {
-    let build_asm_op = |param: u64| format!("u32checked_sub.{}", param);
+    let build_asm_op = |param: u64| format!("u32checked_sub.{param}");
 
     // should fail during execution if a >= 2^32.
     let test = build_op_test!(build_asm_op(0).as_str(), &[U32_BOUND]);
@@ -396,7 +396,7 @@ fn u32wrapping_sub() {
 
 #[test]
 fn u32wrapping_sub_b() {
-    let build_asm_op = |param: u64| format!("u32wrapping_sub.{}", param);
+    let build_asm_op = |param: u64| format!("u32wrapping_sub.{param}");
 
     // --- a > b -------------------------------------------------------------------------
     let test = build_op_test!(build_asm_op(1), &[2]);
@@ -518,7 +518,7 @@ fn u32checked_mul_fail() {
 
 #[test]
 fn u32checked_mul_b() {
-    let build_asm_op = |param: u16| format!("u32checked_mul.{}", param);
+    let build_asm_op = |param: u16| format!("u32checked_mul.{param}");
 
     // --- simple cases ---------------------------------------------------------------------------
     let test = build_op_test!(build_asm_op(0).as_str(), &[1]);
@@ -537,7 +537,7 @@ fn u32checked_mul_b() {
 
     let expected: u64 = a as u64 * b as u64;
     let test = build_op_test!(build_asm_op(b).as_str(), &[a as u64]);
-    test.expect_stack(&[expected as u64]);
+    test.expect_stack(&[expected]);
 
     // --- test that the rest of the stack isn't affected -----------------------------------------
     let c = rand_value::<u64>();
@@ -547,7 +547,7 @@ fn u32checked_mul_b() {
 
 #[test]
 fn u32checked_mul_b_fail() {
-    let build_asm_op = |param: u64| format!("u32checked_mul.{}", param);
+    let build_asm_op = |param: u64| format!("u32checked_mul.{param}");
 
     // should fail during execution if a >= 2^32.
     let test = build_op_test!(build_asm_op(0).as_str(), &[U32_BOUND]);
@@ -594,7 +594,7 @@ fn u32wrapping_mul() {
 
 #[test]
 fn u32wrapping_mul_b() {
-    let build_asm_op = |param: u64| format!("u32wrapping_mul.{}", param);
+    let build_asm_op = |param: u64| format!("u32wrapping_mul.{param}");
 
     // --- no overflow ----------------------------------------------------------------------------
     // c = a * b and d should be unset, since there was no arithmetic overflow.
@@ -731,7 +731,7 @@ fn u32checked_div_fail() {
 
 #[test]
 fn u32checked_div_b() {
-    let build_asm_op = |param: u32| format!("u32checked_div.{}", param);
+    let build_asm_op = |param: u32| format!("u32checked_div.{param}");
 
     // --- simple cases ---------------------------------------------------------------------------
     let test = build_op_test!(build_asm_op(1).as_str(), &[0]);
@@ -760,12 +760,12 @@ fn u32checked_div_b() {
     // --- test that the rest of the stack isn't affected -----------------------------------------
     let c = rand_value::<u64>();
     let test = build_op_test!(build_asm_op(b).as_str(), &[c, a as u64]);
-    test.expect_stack(&[expected as u64, c]);
+    test.expect_stack(&[expected, c]);
 }
 
 #[test]
 fn u32checked_div_b_fail() {
-    let build_asm_op = |param: u64| format!("u32checked_div.{}", param);
+    let build_asm_op = |param: u64| format!("u32checked_div.{param}");
 
     // should fail during execution if a >= 2^32.
     let test = build_op_test!(build_asm_op(1).as_str(), &[U32_BOUND]);
@@ -825,7 +825,7 @@ fn u32checked_mod_fail() {
 
 #[test]
 fn u32checked_mod_b() {
-    let build_asm_op = |param: u32| format!("u32checked_mod.{}", param);
+    let build_asm_op = |param: u32| format!("u32checked_mod.{param}");
 
     // --- simple cases ---------------------------------------------------------------------------
     let test = build_op_test!(build_asm_op(5).as_str(), &[10]);
@@ -858,7 +858,7 @@ fn u32checked_mod_b() {
 
 #[test]
 fn u32checked_mod_b_fail() {
-    let build_asm_op = |param: u64| format!("u32checked_mod.{}", param);
+    let build_asm_op = |param: u64| format!("u32checked_mod.{param}");
 
     // should fail during execution if a >= 2^32.
     let test = build_op_test!(build_asm_op(1).as_str(), &[U32_BOUND]);
@@ -917,7 +917,7 @@ fn u32checked_divmod_fail() {
 
 #[test]
 fn u32checked_divmod_b() {
-    let build_asm_op = |param: u32| format!("u32checked_divmod.{}", param);
+    let build_asm_op = |param: u32| format!("u32checked_divmod.{param}");
 
     // --- simple cases ---------------------------------------------------------------------------
     let test = build_op_test!(build_asm_op(1).as_str(), &[0]);
@@ -953,7 +953,7 @@ fn u32checked_divmod_b() {
 
 #[test]
 fn u32checked_divmod_b_fail() {
-    let build_asm_op = |param: u64| format!("u32checked_divmod.{}", param);
+    let build_asm_op = |param: u64| format!("u32checked_divmod.{param}");
 
     // should fail during execution if a >= 2^32.
     let test = build_op_test!(build_asm_op(1).as_str(), &[U32_BOUND]);
@@ -1000,7 +1000,7 @@ proptest! {
         test.prop_expect_stack(&[expected])?;
 
         // b provided as a parameter.
-        let asm_op = format!("{}.{}", asm_op, b);
+        let asm_op = format!("{asm_op}.{b}");
         let test = build_op_test!(&asm_op, &[a as u64]);
         test.prop_expect_stack(&[expected])?;
     }
@@ -1049,7 +1049,7 @@ proptest! {
         test.prop_expect_stack(&[expected as u64])?;
 
         // b provided as a parameter.
-        let asm_op = format!("{}.{}", asm_op, b);
+        let asm_op = format!("{asm_op}.{b}");
         let test = build_op_test!(&asm_op, &[a as u64]);
         test.prop_expect_stack(&[expected as u64])?;
 
@@ -1082,7 +1082,7 @@ proptest! {
         test.prop_expect_stack(&[expected])?;
 
         // b provided as a parameter
-        let asm_op = format!("{}.{}", asm_op, b);
+        let asm_op = format!("{asm_op}.{b}");
         let test = build_op_test!(&asm_op, &[a as u64]);
         test.prop_expect_stack(&[expected])?;
     }
@@ -1115,7 +1115,7 @@ proptest! {
         let e = madd / U32_BOUND;
 
         let test = build_op_test!(asm_op, &[c as u64, a as u64, b as u64]);
-        test.prop_expect_stack(&[e, d as u64])?;
+        test.prop_expect_stack(&[e, d])?;
     }
 
     #[test]
@@ -1129,18 +1129,18 @@ proptest! {
         test.prop_expect_stack(&[expected])?;
 
         // b provided as a parameter.
-        let asm_op = format!("{}.{}", asm_op, b);
+        let asm_op = format!("{asm_op}.{b}");
         let test = build_op_test!(&asm_op, &[a as u64]);
         test.prop_expect_stack(&[expected])?;
 
         // unchecked version should produce the same result for valid values.
         let asm_op = "u32unchecked_div";
         let test = build_op_test!(&asm_op, &[a as u64, b as u64]);
-        test.prop_expect_stack(&[expected as u64])?;
+        test.prop_expect_stack(&[expected])?;
 
-        let asm_op = format!("{}.{}", asm_op, b);
+        let asm_op = format!("{asm_op}.{b}");
         let test = build_op_test!(&asm_op, &[a as u64]);
-        test.prop_expect_stack(&[expected as u64])?;
+        test.prop_expect_stack(&[expected])?;
     }
 
     #[test]
@@ -1154,7 +1154,7 @@ proptest! {
         test.prop_expect_stack(&[expected as u64])?;
 
         // b provided as a parameter
-        let asm_op = format!("{}.{}", base_op, b);
+        let asm_op = format!("{base_op}.{b}");
         let test = build_op_test!(&asm_op, &[a as u64]);
         test.prop_expect_stack(&[expected as u64])?;
 
@@ -1163,7 +1163,7 @@ proptest! {
         let test = build_op_test!(&asm_op, &[a as u64, b as u64]);
         test.prop_expect_stack(&[expected as u64])?;
 
-        let asm_op = format!("{}.{}", asm_op, b);
+        let asm_op = format!("{asm_op}.{b}");
         let test = build_op_test!(&asm_op, &[a as u64]);
         test.prop_expect_stack(&[expected as u64])?;
     }
@@ -1180,7 +1180,7 @@ proptest! {
         test.prop_expect_stack(&[rem, quot])?;
 
         // b provided as a parameter.
-        let asm_op = format!("{}.{}", asm_op, b);
+        let asm_op = format!("{asm_op}.{b}");
         let test = build_op_test!(&asm_op, &[a as u64]);
         test.prop_expect_stack(&[rem, quot])?;
 
@@ -1189,7 +1189,7 @@ proptest! {
         let test = build_op_test!(&asm_op, &[a as u64, b as u64]);
         test.prop_expect_stack(&[rem, quot])?;
 
-        let asm_op = format!("{}.{}", asm_op, b);
+        let asm_op = format!("{asm_op}.{b}");
         let test = build_op_test!(&asm_op, &[a as u64]);
         test.prop_expect_stack(&[rem, quot])?;
     }

--- a/miden/tests/integration/operations/u32_ops/bitwise_ops.rs
+++ b/miden/tests/integration/operations/u32_ops/bitwise_ops.rs
@@ -216,7 +216,7 @@ fn u32checked_shl_fail() {
 fn u32checked_shl_b() {
     // left shift: pops a from the stack and pushes (a * 2^b) mod 2^32 for a provided value b
     let op_base = "u32checked_shl";
-    let get_asm_op = |b: u32| format!("{}.{}", op_base, b);
+    let get_asm_op = |b: u32| format!("{op_base}.{b}");
 
     // --- test simple case -----------------------------------------------------------------------
     let a = 1_u32;
@@ -295,7 +295,7 @@ fn u32unchecked_shl() {
 fn u32unchecked_shl_b() {
     // left shift: pops a from the stack and pushes (a * 2^b) mod 2^32 for a provided value b
     let op_base = "u32unchecked_shl";
-    let get_asm_op = |b: u32| format!("{}.{}", op_base, b);
+    let get_asm_op = |b: u32| format!("{op_base}.{b}");
 
     // --- test simple case -----------------------------------------------------------------------
     let a = 1_u32;
@@ -380,7 +380,7 @@ fn u32checked_shr_fail() {
 fn u32checked_shr_b() {
     // right shift: pops a from the stack and pushes a / 2^b for a provided value b
     let op_base = "u32checked_shr";
-    let get_asm_op = |b: u32| format!("{}.{}", op_base, b);
+    let get_asm_op = |b: u32| format!("{op_base}.{b}");
 
     // --- test simple case -----------------------------------------------------------------------
     let a = 4_u32;
@@ -459,7 +459,7 @@ fn u32unchecked_shr() {
 fn u32unchecked_shr_b() {
     // right shift: pops a from the stack and pushes a / 2^b for a provided value b
     let op_base = "u32unchecked_shr";
-    let get_asm_op = |b: u32| format!("{}.{}", op_base, b);
+    let get_asm_op = |b: u32| format!("{op_base}.{b}");
 
     // --- test simple case -----------------------------------------------------------------------
     let a = 4_u32;
@@ -542,7 +542,7 @@ fn u32checked_rotl() {
 fn u32checked_rotl_b() {
     // Computes c by rotating a 32-bit representation of a to the left by b bits.
     let op_base = "u32checked_rotl";
-    let get_asm_op = |b: u32| format!("{}.{}", op_base, b);
+    let get_asm_op = |b: u32| format!("{op_base}.{b}");
 
     // --- test simple case -----------------------------------------------------------------------
     let a = 1_u32;
@@ -700,7 +700,7 @@ fn u32checked_rotr_fail() {
 fn u32checked_rotr_b() {
     // Computes c by rotating a 32-bit representation of a to the right by b bits.
     let op_base = "u32checked_rotr";
-    let get_asm_op = |b: u32| format!("{}.{}", op_base, b);
+    let get_asm_op = |b: u32| format!("{op_base}.{b}");
 
     // --- test simple case -----------------------------------------------------------------------
     let a = 2_u32;
@@ -883,7 +883,7 @@ proptest! {
 
     #[test]
     fn u32checked_shl_b_proptest(a in any::<u32>(), b in 0_u32..32) {
-        let asm_opcode = format!("u32checked_shl.{}", b);
+        let asm_opcode = format!("u32checked_shl.{b}");
 
         // should execute left shift
         let expected = a << b;
@@ -903,7 +903,7 @@ proptest! {
 
     #[test]
     fn u32unchecked_shl_b_proptest(a in any::<u32>(), b in 0_u32..32) {
-        let asm_opcode = format!("u32unchecked_shl.{}", b);
+        let asm_opcode = format!("u32unchecked_shl.{b}");
 
         // should execute left shift
         let c = a.wrapping_shl(b);
@@ -923,7 +923,7 @@ proptest! {
 
     #[test]
     fn u32checked_shr_b_proptest(a in any::<u32>(), b in 0_u32..32) {
-        let asm_opcode = format!("u32checked_shr.{}", b);
+        let asm_opcode = format!("u32checked_shr.{b}");
 
         // should execute right shift
         let expected = a >> b;
@@ -943,7 +943,7 @@ proptest! {
     #[test]
     fn u32checked_rotl_b_proptest(a in any::<u32>(), b in 0_u32..32) {
         let op_base = "u32checked_rotl";
-        let asm_opcode = format!("{}.{}", op_base, b);
+        let asm_opcode = format!("{op_base}.{b}");
 
         // should execute left bit rotation
         let test = build_op_test!(asm_opcode, &[a as u64]);
@@ -962,7 +962,7 @@ proptest! {
     #[test]
     fn u32unchecked_rotl_b_proptest(a in any::<u32>(), b in 0_u32..32) {
         let op_base = "u32unchecked_rotl";
-        let asm_opcode = format!("{}.{}", op_base, b);
+        let asm_opcode = format!("{op_base}.{b}");
 
         // should execute left bit rotation
         let test = build_op_test!(asm_opcode, &[a as u64]);
@@ -981,7 +981,7 @@ proptest! {
     #[test]
     fn u32checked_rotr_b_proptest(a in any::<u32>(), b in 0_u32..32) {
         let op_base = "u32checked_rotr";
-        let asm_opcode = format!("{}.{}", op_base, b);
+        let asm_opcode = format!("{op_base}.{b}");
 
         // should execute right bit rotation
         let test = build_op_test!(asm_opcode, &[a as u64]);
@@ -1000,7 +1000,7 @@ proptest! {
     #[test]
     fn u32unchecked_rotr_b_proptest(a in any::<u32>(), b in 0_u32..32) {
         let op_base = "u32unchecked_rotr";
-        let asm_opcode = format!("{}.{}", op_base, b);
+        let asm_opcode = format!("{op_base}.{b}");
 
         // should execute right bit rotation
         let test = build_op_test!(asm_opcode, &[a as u64]);
@@ -1010,7 +1010,7 @@ proptest! {
     #[test]
     fn u32checked_popcount_proptest(a in any::<u32>()) {
         let asm_opcode = "u32checked_popcnt";
-        let expected = a.count_ones() as u32;
+        let expected = a.count_ones();
         let test = build_op_test!(asm_opcode, &[a as u64]);
         test.prop_expect_stack(&[expected as u64])?;
     }
@@ -1018,7 +1018,7 @@ proptest! {
     #[test]
     fn u32unchecked_popcount_proptest(a in any::<u32>()) {
         let asm_opcode = "u32unchecked_popcnt";
-        let expected = a.count_ones() as u32;
+        let expected = a.count_ones();
         let test = build_op_test!(asm_opcode, &[a as u64]);
         test.prop_expect_stack(&[expected as u64])?;
     }

--- a/miden/tests/integration/operations/u32_ops/comparison_ops.rs
+++ b/miden/tests/integration/operations/u32_ops/comparison_ops.rs
@@ -51,7 +51,7 @@ fn u32eq_fail() {
 
 #[test]
 fn u32checked_eq_b() {
-    let build_asm_op = |param: u32| format!("u32checked_eq.{}", param);
+    let build_asm_op = |param: u32| format!("u32checked_eq.{param}");
 
     // --- simple cases ---------------------------------------------------------------------------
     let test = build_op_test!(build_asm_op(1).as_str(), &[1]);
@@ -134,7 +134,7 @@ fn u32checked_neq_fail() {
 
 #[test]
 fn u32checked_neq_b() {
-    let build_asm_op = |param: u32| format!("u32checked_neq.{}", param);
+    let build_asm_op = |param: u32| format!("u32checked_neq.{param}");
 
     // --- simple cases ---------------------------------------------------------------------------
     let test = build_op_test!(build_asm_op(1).as_str(), &[1]);
@@ -354,7 +354,7 @@ proptest! {
         test.prop_expect_stack(&[expected])?;
 
         // b provided as a parameter
-        let asm_op = format!("{}.{}", asm_op, b);
+        let asm_op = format!("{asm_op}.{b}");
         let test = build_op_test!(&asm_op, &[a as u64]);
         test.prop_expect_stack(&[expected])?;
     }
@@ -371,7 +371,7 @@ proptest! {
         test.prop_expect_stack(&[expected])?;
 
         // b provided as a parameter
-        let asm_op = format!("{}.{}", asm_op, b);
+        let asm_op = format!("{asm_op}.{b}");
         let test = build_op_test!(&asm_op, &[a as u64]);
         test.prop_expect_stack(&[expected])?;
     }

--- a/miden/tests/integration/operations/u32_ops/mod.rs
+++ b/miden/tests/integration/operations/u32_ops/mod.rs
@@ -37,7 +37,7 @@ pub fn test_inputs_out_of_bounds(asm_op: &str, input_count: usize) {
 /// This helper function tests a provided assembly operation which takes a single parameter
 /// to ensure that it fails when that parameter is over the maximum allowed value (out of bounds).
 pub fn test_param_out_of_bounds(asm_op_base: &str, gt_max_value: u64) {
-    let asm_op = format!("{}.{}", asm_op_base, gt_max_value);
+    let asm_op = format!("{asm_op_base}.{gt_max_value}");
     let test = build_op_test!(&asm_op);
     test.expect_error(TestError::AssemblyError("parameter"));
 }

--- a/miden/tests/integration/stdlib/crypto/falcon.rs
+++ b/miden/tests/integration/stdlib/crypto/falcon.rs
@@ -1988,7 +1988,7 @@ fn test_falcon512_vector_squared_norm() {
             in_vec[(i << 2) ^ 3],
             in_vec[(i << 2) ^ 2],
             in_vec[(i << 2) ^ 1],
-            in_vec[(i << 2) ^ 0],
+            in_vec[(i << 2)],
             i
         )
         .unwrap();
@@ -2000,7 +2000,7 @@ fn test_falcon512_vector_squared_norm() {
 
         proc.wrapper.128
             # prepare input polynomial `f`
-            {}
+            {in_str}
 
             # prepare argument ( absolute memory address ) for computing squared norm 
             # of a vector ( read polynomial )
@@ -2010,15 +2010,14 @@ fn test_falcon512_vector_squared_norm() {
 
             # check for functional correctness ( using known answer test )
 
-            push.{}
+            push.{sqrd_norm}
             assert_eq
         end
 
         begin
             exec.wrapper
         end
-    ",
-        in_str, sqrd_norm
+    "
     );
 
     let test = build_test!(source, &[]);

--- a/miden/tests/integration/stdlib/crypto/keccak256.rs
+++ b/miden/tests/integration/stdlib/crypto/keccak256.rs
@@ -47,7 +47,7 @@ fn keccak256_2_to_1_hash() {
 
     // computing keccak256 of 64 -bytes input, on host CPU
     let mut hasher = Keccak256::new();
-    hasher.update(&i_digest);
+    hasher.update(i_digest);
     // producing 32 -bytes keccak256 digest
     let digest = hasher.finalize();
 

--- a/miden/tests/integration/stdlib/crypto/sha256.rs
+++ b/miden/tests/integration/stdlib/crypto/sha256.rs
@@ -25,7 +25,7 @@ fn sha256_2_to_1_hash() {
         .collect::<Vec<u64>>();
 
     let mut hasher = Sha256::new();
-    hasher.update(&ibytes);
+    hasher.update(ibytes);
 
     let obytes = hasher.finalize();
     let ofelts = group_slice_elements::<u8, 4>(&obytes)
@@ -54,7 +54,7 @@ fn sha256_1_to_1_hash() {
         .collect::<Vec<u64>>();
 
     let mut hasher = Sha256::new();
-    hasher.update(&ibytes);
+    hasher.update(ibytes);
 
     let obytes = hasher.finalize();
     let ofelts = group_slice_elements::<u8, 4>(&obytes)

--- a/miden/tests/integration/stdlib/math/ecgfp5/base_field.rs
+++ b/miden/tests/integration/stdlib/math/ecgfp5/base_field.rs
@@ -24,8 +24,8 @@ fn msquare(v: Felt, n: usize) -> Felt {
 fn legendre(v: Felt) -> Felt {
     let v0 = msquare(v, 31);
     let v1 = msquare(v0, 32);
-    let v2 = v1 / v0;
-    v2
+
+    v1 / v0
 }
 
 fn is_zero(a: Felt) -> Felt {
@@ -357,8 +357,7 @@ impl PartialEq for Ext5 {
         let flg3 = self.a3 == other.a3;
         let flg4 = self.a4 == other.a4;
 
-        let flg = flg0 & flg1 & flg2 & flg3 & flg4;
-        flg
+        flg0 & flg1 & flg2 & flg3 & flg4
     }
 
     fn ne(&self, other: &Self) -> bool {
@@ -368,8 +367,7 @@ impl PartialEq for Ext5 {
         let flg3 = self.a3 != other.a3;
         let flg4 = self.a4 != other.a4;
 
-        let flg = flg0 | flg1 | flg2 | flg3 | flg4;
-        flg
+        flg0 | flg1 | flg2 | flg3 | flg4
     }
 }
 

--- a/miden/tests/integration/stdlib/math/ecgfp5/group.rs
+++ b/miden/tests/integration/stdlib/math/ecgfp5/group.rs
@@ -176,30 +176,24 @@ impl Add for ECExt5 {
         Self {
             x: if rhs.point_at_infinity == Felt::ONE {
                 self.x
+            } else if self.point_at_infinity == Felt::ONE {
+                rhs.x
             } else {
-                if self.point_at_infinity == Felt::ONE {
-                    rhs.x
-                } else {
-                    x3
-                }
+                x3
             },
             y: if rhs.point_at_infinity == Felt::ONE {
                 self.y
+            } else if self.point_at_infinity == Felt::ONE {
+                rhs.y
             } else {
-                if self.point_at_infinity == Felt::ONE {
-                    rhs.y
-                } else {
-                    y3
-                }
+                y3
             },
             point_at_infinity: if rhs.point_at_infinity == Felt::ONE {
                 self.point_at_infinity
+            } else if self.point_at_infinity == Felt::ONE {
+                rhs.point_at_infinity
             } else {
-                if self.point_at_infinity == Felt::ONE {
-                    rhs.point_at_infinity
-                } else {
-                    inf3
-                }
+                inf3
             },
         }
     }

--- a/miden/tests/integration/stdlib/math/ntt512.rs
+++ b/miden/tests/integration/stdlib/math/ntt512.rs
@@ -28,7 +28,7 @@ fn generate_test_script_ntt512() -> String {
             polynomial[4 * i + 1],
             polynomial[4 * i]
         );
-        let _ = writeln!(polynomial_script, "loc_storew.{}", i);
+        let _ = writeln!(polynomial_script, "loc_storew.{i}");
         polynomial_script.push_str("dropw\n");
 
         check_result_script.push_str("dup\n");
@@ -53,7 +53,7 @@ fn generate_test_script_ntt512() -> String {
     proc.wrapper.128
         # prepare input vector
         
-        {}
+        {polynomial_script}
 
         # place starting absolute memory addresses on stack, where input vector is kept,
         # next addresses are computable using `add.1` instruction.
@@ -67,7 +67,7 @@ fn generate_test_script_ntt512() -> String {
         # where v = input vector
         #       v' = output vector holding result of iNTT(NTT(v))
 
-        {}
+        {check_result_script}
 
         drop
     end
@@ -75,8 +75,7 @@ fn generate_test_script_ntt512() -> String {
     begin
         exec.wrapper
     end
-    ",
-        polynomial_script, check_result_script
+    "
     );
     script
 }

--- a/miden/tests/integration/stdlib/math/poly512.rs
+++ b/miden/tests/integration/stdlib/math/poly512.rs
@@ -39,7 +39,7 @@ fn generate_test_script_add_zq() -> String {
             polynomial_1[4 * i]
         )
         .unwrap();
-        writeln!(polynomial_1_script, "loc_storew.{}", i).unwrap();
+        writeln!(polynomial_1_script, "loc_storew.{i}").unwrap();
         writeln!(polynomial_1_script, "dropw").unwrap();
 
         // fill script for polynomial 2
@@ -73,9 +73,9 @@ fn generate_test_script_add_zq() -> String {
         use.std::math::poly512
 
         proc.wrapper.384
-            {}
+            {polynomial_1_script}
 
-            {}
+            {polynomial_2_script}
 
             locaddr.256 # output
             locaddr.128 # input 1
@@ -83,14 +83,13 @@ fn generate_test_script_add_zq() -> String {
 
             exec.poly512::add_zq
 
-            {}
+            {check_result_script}
         end
 
         begin
             exec.wrapper
         end
-    ",
-        polynomial_1_script, polynomial_2_script, check_result_script
+    "
     );
     script
 }
@@ -122,7 +121,7 @@ fn generate_test_script_neg_zq() -> String {
             polynomial_1[4 * i]
         )
         .unwrap();
-        writeln!(polynomial_1_script, "loc_storew.{}", i).unwrap();
+        writeln!(polynomial_1_script, "loc_storew.{i}").unwrap();
         writeln!(polynomial_1_script, "dropw").unwrap();
 
         // fill script for checking the result
@@ -143,21 +142,20 @@ fn generate_test_script_neg_zq() -> String {
         use.std::math::poly512
 
         proc.wrapper.256
-            {}
+            {polynomial_1_script}
 
             locaddr.128 # output
             locaddr.0 # input 0
 
             exec.poly512::neg_zq
 
-            {}
+            {check_result_script}
         end
 
         begin
             exec.wrapper
         end
-    ",
-        polynomial_1_script, check_result_script
+    "
     );
     script
 }
@@ -193,7 +191,7 @@ fn generate_test_script_sub_zq() -> String {
             polynomial_1[4 * i]
         )
         .unwrap();
-        writeln!(polynomial_1_script, "loc_storew.{}", i).unwrap();
+        writeln!(polynomial_1_script, "loc_storew.{i}").unwrap();
         writeln!(polynomial_1_script, "dropw").unwrap();
 
         // fill script for polynomial 2
@@ -227,9 +225,9 @@ fn generate_test_script_sub_zq() -> String {
         use.std::math::poly512
 
         proc.wrapper.384
-            {}
+            {polynomial_1_script}
 
-            {}
+            {polynomial_2_script}
 
             locaddr.256 # output
             locaddr.128 # input 1
@@ -237,14 +235,13 @@ fn generate_test_script_sub_zq() -> String {
 
             exec.poly512::sub_zq
 
-            {}
+            {check_result_script}
         end
 
         begin
             exec.wrapper
         end
-    ",
-        polynomial_1_script, polynomial_2_script, check_result_script
+    "
     );
     script
 }
@@ -292,7 +289,7 @@ fn generate_test_script_mul_zq() -> String {
             polynomial_1[4 * i]
         )
         .unwrap();
-        writeln!(polynomial_1_script, "loc_storew.{}", i).unwrap();
+        writeln!(polynomial_1_script, "loc_storew.{i}").unwrap();
         writeln!(polynomial_1_script, "dropw").unwrap();
 
         // fill script for polynomial 2
@@ -326,9 +323,9 @@ fn generate_test_script_mul_zq() -> String {
         use.std::math::poly512
 
         proc.wrapper.384
-            {}
+            {polynomial_1_script}
 
-            {}
+            {polynomial_2_script}
 
             locaddr.256 # output
             locaddr.128 # input 1
@@ -336,14 +333,13 @@ fn generate_test_script_mul_zq() -> String {
 
             exec.poly512::mul_zq
 
-            {}
+            {check_result_script}
         end
 
         begin
             exec.wrapper
         end
-    ",
-        polynomial_1_script, polynomial_2_script, check_result_script
+    "
     );
     script
 }

--- a/miden/tests/integration/stdlib/math/secp256k1/scalar_field.rs
+++ b/miden/tests/integration/stdlib/math/secp256k1/scalar_field.rs
@@ -221,7 +221,7 @@ impl Mul for ScalarField {
 
         let mut one = Self::one().limbs;
         for i in 0..8 {
-            one[i] = one[i] * pc;
+            one[i] *= pc;
         }
 
         pc = 0;

--- a/miden/tests/integration/stdlib/math/u64_mod.rs
+++ b/miden/tests/integration/stdlib/math/u64_mod.rs
@@ -179,8 +179,8 @@ fn checked_sub_fail() {
     test.expect_error(TestError::ExecutionError("FailedAssertion"));
 
     // u32 limb assertion failure
-    let a0 = rand_value::<u64>() as u64;
-    let b0 = rand_value::<u64>() as u64;
+    let a0 = rand_value::<u64>();
+    let b0 = rand_value::<u64>();
     let a1 = U32_BOUND;
     let b1 = U32_BOUND;
 
@@ -1201,7 +1201,7 @@ proptest! {
 
         let (a1, a0) = split_u64(a);
         let (b1, b0) = split_u64(b);
-        let c = cmp::min(a, b) as u64;
+        let c = cmp::min(a, b);
         let (c1, c0) = split_u64(c);
         let source = "
             use.std::math::u64
@@ -1217,7 +1217,7 @@ proptest! {
 
         let (a1, a0) = split_u64(a);
         let (b1, b0) = split_u64(b);
-        let c = cmp::max(a, b) as u64;
+        let c = cmp::max(a, b);
         let (c1, c0) = split_u64(c);
         let source = "
             use.std::math::u64

--- a/processor/src/decoder/tests.rs
+++ b/processor/src/decoder/tests.rs
@@ -1594,7 +1594,7 @@ fn build_op_batch_flags(num_groups: usize) -> [Felt; NUM_OP_BATCH_FLAGS] {
         2 => OP_BATCH_2_GROUPS,
         4 => OP_BATCH_4_GROUPS,
         8 => OP_BATCH_8_GROUPS,
-        _ => panic!("invalid num groups: {}", num_groups),
+        _ => panic!("invalid num groups: {num_groups}"),
     }
 }
 

--- a/processor/src/stack/tests.rs
+++ b/processor/src/stack/tests.rs
@@ -380,8 +380,8 @@ fn build_stack(stack_inputs: &[u64]) -> StackTopState {
 
 /// Builds expected values of stack helper registers for the specified parameters.
 fn build_helpers(stack_depth: u64, next_overflow_addr: u64) -> StackHelpersState {
-    let b0 = Felt::new(stack_depth as u64);
-    let b1 = Felt::new(next_overflow_addr as u64);
+    let b0 = Felt::new(stack_depth);
+    let b1 = Felt::new(next_overflow_addr);
     let h0 = (b0 - Felt::new(STACK_TOP_SIZE as u64)).inv();
 
     [b0, b1, h0]


### PR DESCRIPTION
As part of CI/CD we are running

```
cargo clippy --all -- -D clippy::all -D warnings
```

Inspired by that, I asked clippy to also suggest a few additional
fixes to me to apply manually once:

```
cargo clippy --all --fix --allow-dirty -- -D clippy::all -D warnings
```

Most changes are quite trivial (but make the code a bit cleaner), but
have a look at `miden/tests/integration/stdlib/math/ecgfp5/group.rs` for
the one non-trivial refactor.