### PR TITLE
Documentation changes

### DIFF
--- a/docs/src/design/decoder/main.md
+++ b/docs/src/design/decoder/main.md
@@ -487,7 +487,7 @@ Operation batch flags (denoted as $c_0, c_1, c_2$), encode the number of groups 
 
 * `(1, 0, 0)` - $8$ groups. Groups in $h_1, ... h_7$ are added to the op group table.
 * `(0, 1, 0)` - $4$ groups. Groups in $h_1, ... h_3$ are added to the op group table
-* `(0, 0, 1)` - $2$ groups. Groups in $h_1, h_2$ are added to the op group table.
+* `(0, 0, 1)` - $2$ groups. Groups in $h_1$ is added to the op group table.
 * `(0, 1, 1)` - $1$ group. Nothing is added to the op group table
 * `(0, 0, 0)` - not a `SPAN` or `RESPAN` operation.
 

--- a/docs/src/design/decoder/main.md
+++ b/docs/src/design/decoder/main.md
@@ -439,7 +439,7 @@ The above steps are repeated until the top of the stack becomes $0$, at which po
 
 #### Skipping the loop
 
-If the top of the stack is $0$, the VM still executes the `LOOP` operation. But unlike in the case when we need to entre the loop, the VM sets `is_loop` flag to $0$ in the block stack table, and does not add any rows to the block hash table. The last point means that the only possible operation to be executed after the `LOOP` operation is the `END` operation. This is illustrated in the diagram below.
+If the top of the stack is $0$, the VM still executes the `LOOP` operation. But unlike in the case when we need to enter the loop, the VM sets `is_loop` flag to $0$ in the block stack table, and does not add any rows to the block hash table. The last point means that the only possible operation to be executed after the `LOOP` operation is the `END` operation. This is illustrated in the diagram below.
 
 ![decoder_loop_skipping](../../assets/design/decoder/decoder_loop_skipping.png)
 

--- a/docs/src/user_docs/assembly/io_operations.md
+++ b/docs/src/user_docs/assembly/io_operations.md
@@ -38,6 +38,8 @@ In both case the values must still encode valid field elements.
 | adv_loadw <br> - *(1 cycle)*     | [0, 0, 0, 0, ... ] | [A, ... ] | $A \leftarrow tape.next(4)$ <br> Removes the next word (4 elements) from the advice tape and overwrites the top four stack elements with it. <br> Fails if the advice tape has fewer than $4$ values. |
 | adv_pipe <br> - *(2 cycles)*     | [S2, S1, S0, a, ... ] | [T2, T1, T0, b, ... ] | $[T_0, T_1, T_2] \leftarrow permute(S_0, S_1 + tape.next(4), S_2 + tape.next(4))$ <br> $b \leftarrow a + 2$ <br> Removes the next two words (8 elements) from the advice tape, inserts them into memory sequentially starting from address $a$, then adds them to the top 8 elements of the stack and applies a Rescue Prime permutation to the top 12 elements of the stack. At the end of the operation, the address is incremented by $2$. <br> Fails if the advice tape has fewer than $8$ values. |
 
+> **Note**: The opcodes above always push data onto the stack so that the first element is placed deepest in the stack. For example, if the data on the tape is `a,b,c,d` and you use the opcode `adv_push.4`, the data will be `d,c,b,a` on your stack. This is also the behavior of the other opcodes.
+
 ### Random access memory
 
  As mentioned above, there are two ways to access memory in Miden VM. The first way is via memory addresses using the instructions listed below. The addresses are absolute - i.e., they don't depend on the procedure context. Memory addresses can be in the range $[0, 2^{32})$.


### PR DESCRIPTION
Small changes:

- fixes a typo and an error
- adds details about the element order when using tape operations