### PR TITLE
feat(processor): advice provider as exec argument

### DIFF
--- a/core/src/inputs/mod.rs
+++ b/core/src/inputs/mod.rs
@@ -90,10 +90,10 @@ impl ProgramInputs {
         })
     }
 
-    /// Returns [ProgramInputs] with no input values.
-    pub fn none() -> Self {
+    /// Returns [ProgramInputs] with empty values and sets.
+    pub fn empty() -> Self {
         Self {
-            advice_tape: Vec::new(),
+            advice_tape: vec![],
             advice_map: BTreeMap::new(),
             advice_sets: BTreeMap::new(),
         }

--- a/miden/benches/program_execution.rs
+++ b/miden/benches/program_execution.rs
@@ -1,5 +1,5 @@
 use criterion::{criterion_group, criterion_main, Criterion};
-use miden::{execute, Assembler, ProgramInputs, StackInputs};
+use miden::{execute, Assembler, MemAdviceProvider, StackInputs};
 use std::time::Duration;
 use stdlib::StdLibrary;
 
@@ -18,7 +18,7 @@ fn program_execution(c: &mut Criterion) {
             .with_library(&StdLibrary::default())
             .expect("failed to load stdlib");
         let program = assembler.compile(source).expect("Failed to compile test source.");
-        bench.iter(|| execute(&program, StackInputs::empty(), &ProgramInputs::none()));
+        bench.iter(|| execute(&program, StackInputs::empty(), MemAdviceProvider::empty()));
     });
 
     group.finish();

--- a/miden/src/cli/prove.rs
+++ b/miden/src/cli/prove.rs
@@ -1,5 +1,5 @@
 use super::data::{InputFile, OutputFile, ProgramFile, ProofFile};
-use miden::ProofOptions;
+use miden::{MemAdviceProvider, ProofOptions};
 use std::{io::Write, path::PathBuf, time::Instant};
 use structopt::StructOpt;
 
@@ -57,12 +57,13 @@ impl ProveCmd {
         let now = Instant::now();
 
         // fetch the stack and program inputs from the arguments
-        let program_inputs = input_data.get_program_inputs()?;
         let stack_inputs = input_data.get_stack_inputs()?;
+        let program_inputs = input_data.get_program_inputs()?;
+        let advice_provider = MemAdviceProvider::from(program_inputs);
 
         // execute program and generate proof
         let (outputs, proof) =
-            prover::prove(&program, stack_inputs, &program_inputs, &self.get_proof_security())
+            prover::prove(&program, stack_inputs, advice_provider, &self.get_proof_security())
                 .map_err(|err| format!("Failed to prove program - {:?}", err))?;
 
         println!(

--- a/miden/src/examples/fibonacci.rs
+++ b/miden/src/examples/fibonacci.rs
@@ -1,13 +1,13 @@
 use super::Example;
 use miden::{
     math::{Felt, FieldElement, StarkField},
-    Assembler, Program, ProgramInputs, StackInputs,
+    Assembler, MemAdviceProvider, Program, StackInputs,
 };
 
 // EXAMPLE BUILDER
 // ================================================================================================
 
-pub fn get_example(n: usize) -> Example {
+pub fn get_example(n: usize) -> Example<MemAdviceProvider> {
     // generate the program and expected results
     let program = generate_fibonacci_program(n);
     let expected_result = vec![compute_fibonacci(n).as_int()];
@@ -19,7 +19,7 @@ pub fn get_example(n: usize) -> Example {
     Example {
         program,
         stack_inputs: StackInputs::try_from_values([0, 1]).unwrap(),
-        program_inputs: ProgramInputs::none(),
+        advice_provider: MemAdviceProvider::empty(),
         expected_result,
         num_outputs: 1,
     }

--- a/miden/src/lib.rs
+++ b/miden/src/lib.rs
@@ -5,8 +5,8 @@
 
 pub use assembly::{Assembler, AssemblyError, ParsingError};
 pub use processor::{
-    execute, execute_iter, utils, AsmOpInfo, ExecutionError, ExecutionTrace, Operation,
-    StackInputs, VmState, VmStateIterator,
+    execute, execute_iter, utils, AdviceProvider, AsmOpInfo, ExecutionError, ExecutionTrace,
+    MemAdviceProvider, Operation, StackInputs, VmState, VmStateIterator,
 };
 pub use prover::{
     math, prove, AdviceSet, AdviceSetError, Digest, FieldExtension, HashFunction, InputError,

--- a/miden/src/repl/mod.rs
+++ b/miden/src/repl/mod.rs
@@ -1,7 +1,7 @@
 use super::ProgramError;
 use miden::{
     math::{Felt, StarkField},
-    ProgramInputs, StackInputs, Word,
+    MemAdviceProvider, StackInputs, Word,
 };
 use processor::Process;
 use rustyline::{error::ReadlineError, Editor};
@@ -268,9 +268,9 @@ fn execute(program: String) -> Result<(Vec<(u64, Word)>, Vec<Felt>), ProgramErro
         .map_err(ProgramError::AssemblyError)?;
 
     let stack_inputs = StackInputs::empty();
-    let program_inputs = ProgramInputs::none();
+    let advice_provider = MemAdviceProvider::empty();
 
-    let mut process = Process::new_debug(program.kernel(), stack_inputs, program_inputs);
+    let mut process = Process::new_debug(program.kernel(), stack_inputs, advice_provider);
     let _program_outputs = process.execute(&program).map_err(ProgramError::ExecutionError);
 
     let (sys, _, stack, _, chiplets, _) = process.into_parts();

--- a/miden/src/tools/mod.rs
+++ b/miden/src/tools/mod.rs
@@ -1,6 +1,8 @@
 use super::{cli::InputFile, ProgramError};
 use core::fmt;
-use miden::{utils::collections::Vec, Assembler, Operation, ProgramInputs, StackInputs};
+use miden::{
+    utils::collections::Vec, AdviceProvider, Assembler, MemAdviceProvider, Operation, StackInputs,
+};
 use processor::AsmOpInfo;
 use std::{fs, path::PathBuf};
 use stdlib::StdLibrary;
@@ -31,10 +33,11 @@ impl Analyze {
         let input_data = InputFile::read(&self.input_file, &self.assembly_file)?;
 
         // fetch the stack and program inputs from the arguments
-        let program_inputs = input_data.get_program_inputs()?;
         let stack_inputs = input_data.get_stack_inputs()?;
+        let program_inputs = input_data.get_program_inputs()?;
+        let advice_provider = MemAdviceProvider::from(program_inputs);
 
-        let program_info: ProgramInfo = analyze(program.as_str(), stack_inputs, program_inputs)
+        let program_info: ProgramInfo = analyze(program.as_str(), stack_inputs, advice_provider)
             .expect("Could not retrieve program info");
 
         println!("{}", program_info);
@@ -146,18 +149,21 @@ impl fmt::Display for ProgramInfo {
 }
 
 /// Returns program analysis of a given program.
-pub fn analyze(
+pub fn analyze<A>(
     program: &str,
     stack_inputs: StackInputs,
-    program_inputs: ProgramInputs,
-) -> Result<ProgramInfo, ProgramError> {
+    advice_provider: A,
+) -> Result<ProgramInfo, ProgramError>
+where
+    A: AdviceProvider,
+{
     let program = Assembler::default()
         .with_debug_mode(true)
         .with_library(&StdLibrary::default())
         .map_err(ProgramError::AssemblyError)?
         .compile(program)
         .map_err(ProgramError::AssemblyError)?;
-    let vm_state_iterator = processor::execute_iter(&program, stack_inputs, &program_inputs);
+    let vm_state_iterator = processor::execute_iter(&program, stack_inputs, advice_provider);
     let mut program_info = ProgramInfo::default();
 
     for state in vm_state_iterator {
@@ -230,15 +236,15 @@ impl AsmOpStats {
 
 #[cfg(test)]
 mod tests {
-    use super::{AsmOpStats, ProgramInfo, StackInputs};
+    use super::{AsmOpStats, MemAdviceProvider, ProgramInfo, StackInputs};
 
     #[test]
     fn analyze_test() {
         let source =
             "proc.foo.1 loc_store.0 end begin mem_storew.1 dropw push.17 push.1 movdn.2 exec.foo end";
         let stack_inputs = StackInputs::empty();
-        let program_inputs = super::ProgramInputs::none();
-        let program_info = super::analyze(source, stack_inputs, program_inputs)
+        let advice_provider = MemAdviceProvider::empty();
+        let program_info = super::analyze(source, stack_inputs, advice_provider)
             .expect("analyze_test: Unexpected Error");
         let expected_program_info = ProgramInfo {
             total_vm_cycles: 23,
@@ -259,8 +265,8 @@ mod tests {
         let source = "begin div end";
         let stack_inputs = vec![1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
         let stack_inputs = StackInputs::try_from_values(stack_inputs).unwrap();
-        let program_inputs = super::ProgramInputs::none();
-        let program_info = super::analyze(source, stack_inputs, program_inputs);
+        let advice_provider = MemAdviceProvider::empty();
+        let program_info = super::analyze(source, stack_inputs, advice_provider);
         let expected_error = "Execution Error: DivideByZero(1)";
         assert_eq!(program_info.err().unwrap().to_string(), expected_error);
     }
@@ -269,8 +275,8 @@ mod tests {
     fn analyze_test_assembly_error() {
         let source = "proc.foo.1 loc_store.0 end mem_storew.1 dropw push.17 exec.foo end";
         let stack_inputs = StackInputs::empty();
-        let program_inputs = super::ProgramInputs::none();
-        let program_info = super::analyze(source, stack_inputs, program_inputs);
+        let advice_provider = MemAdviceProvider::empty();
+        let program_info = super::analyze(source, stack_inputs, advice_provider);
         let expected_error = "Assembly Error: ParsingError(\"unexpected token: expected 'begin' but was 'mem_storew.1'\")";
         assert_eq!(program_info.err().unwrap().to_string(), expected_error);
     }

--- a/miden/tests/integration/flow_control/mod.rs
+++ b/miden/tests/integration/flow_control/mod.rs
@@ -205,7 +205,7 @@ fn simple_syscall() {
         source: program_source.to_string(),
         kernel: Some(kernel_source.to_string()),
         stack_inputs: StackInputs::try_from_values([1, 2]).unwrap(),
-        advice_inputs: ProgramInputs::none(),
+        advice_inputs: ProgramInputs::empty(),
         in_debug_mode: false,
     };
     test.expect_stack(&[3]);

--- a/miden/tests/integration/operations/io_ops/env_ops.rs
+++ b/miden/tests/integration/operations/io_ops/env_ops.rs
@@ -148,7 +148,7 @@ fn caller() {
         source: program_source.to_string(),
         kernel: Some(kernel_source.to_string()),
         stack_inputs: StackInputs::try_from_values([1, 2, 3, 4, 5]).unwrap(),
-        advice_inputs: ProgramInputs::none(),
+        advice_inputs: ProgramInputs::empty(),
         in_debug_mode: false,
     };
     // top 4 elements should be overwritten with the hash of `bar` procedure, but the 5th

--- a/processor/src/advice/mem_provider.rs
+++ b/processor/src/advice/mem_provider.rs
@@ -17,7 +17,6 @@ pub struct MemAdviceProvider {
     sets: BTreeMap<[u8; 32], AdviceSet>,
 }
 
-// TODO remove if `ProgramInputs` is deprecated, or convert to `TryFrom`
 impl From<ProgramInputs> for MemAdviceProvider {
     fn from(inputs: ProgramInputs) -> Self {
         let (mut tape, values, sets) = inputs.into_parts();
@@ -28,6 +27,16 @@ impl From<ProgramInputs> for MemAdviceProvider {
             values,
             sets,
         }
+    }
+}
+
+impl MemAdviceProvider {
+    // CONSTRUCTORS
+    // --------------------------------------------------------------------------------------------
+
+    /// Creates a new memory advice provider with empty values and sets.
+    pub fn empty() -> Self {
+        Self::from(ProgramInputs::empty())
     }
 }
 

--- a/processor/src/advice/mod.rs
+++ b/processor/src/advice/mod.rs
@@ -40,6 +40,24 @@ pub use mem_provider::MemAdviceProvider;
 /// 3. Provide advice sets, that are mappings from a Merkle root its tree. The tree should yield
 ///    nodes & leaves, and will provide a Merkle path if a leaf is updated.
 pub trait AdviceProvider {
+    // ACCESSORS
+    // --------------------------------------------------------------------------------------------
+
+    /// Creates a "by reference" advice provider for this instance.
+    ///
+    /// The returned adapter also implements `AdviceProvider` and will simply mutably borrow this
+    /// instance.
+    fn by_ref(&mut self) -> &mut Self {
+        // this trait follows the same model as
+        // [io::Read](https://doc.rust-lang.org/std/io/trait.Read.html#method.by_ref).
+        //
+        // this approach allows the flexibility to take an advice provider either as owned or by
+        // mutable reference - both equally compatible with the trait requirements as we implement
+        // `AdviceProvider` for mutable references of any type that also implements advice
+        // provider.
+        self
+    }
+
     // ADVICE TAPE
     // --------------------------------------------------------------------------------------------
 
@@ -147,4 +165,60 @@ pub trait AdviceProvider {
     /// This is used to keep the state of the VM in sync with the state of the advice provider, and
     /// should be incrementally updated when called.
     fn advance_clock(&mut self);
+}
+
+impl<'a, T> AdviceProvider for &'a mut T
+where
+    T: AdviceProvider,
+{
+    fn read_tape(&mut self) -> Result<Felt, ExecutionError> {
+        T::read_tape(self)
+    }
+
+    fn read_tape_w(&mut self) -> Result<Word, ExecutionError> {
+        T::read_tape_w(self)
+    }
+
+    fn read_tape_dw(&mut self) -> Result<[Word; 2], ExecutionError> {
+        T::read_tape_dw(self)
+    }
+
+    fn write_tape(&mut self, value: Felt) {
+        T::write_tape(self, value)
+    }
+
+    fn write_tape_from_map(&mut self, key: Word) -> Result<(), ExecutionError> {
+        T::write_tape_from_map(self, key)
+    }
+
+    fn insert_into_map(&mut self, key: Word, values: Vec<Felt>) -> Result<(), ExecutionError> {
+        T::insert_into_map(self, key, values)
+    }
+
+    fn get_tree_node(&self, root: Word, depth: Felt, index: Felt) -> Result<Word, ExecutionError> {
+        T::get_tree_node(self, root, depth, index)
+    }
+
+    fn get_merkle_path(
+        &self,
+        root: Word,
+        depth: Felt,
+        index: Felt,
+    ) -> Result<Vec<Word>, ExecutionError> {
+        T::get_merkle_path(self, root, depth, index)
+    }
+
+    fn update_merkle_leaf(
+        &mut self,
+        root: Word,
+        index: Felt,
+        leaf_value: Word,
+        update_in_copy: bool,
+    ) -> Result<Vec<Word>, ExecutionError> {
+        T::update_merkle_leaf(self, root, index, leaf_value, update_in_copy)
+    }
+
+    fn advance_clock(&mut self) {
+        T::advance_clock(self)
+    }
 }

--- a/processor/src/decoder/tests.rs
+++ b/processor/src/decoder/tests.rs
@@ -4,7 +4,7 @@ use super::{
 };
 use crate::{
     decoder::block_stack::ExecutionContextInfo, utils::get_trace_len, ExecutionTrace, Felt, Kernel,
-    Operation, Process, ProgramInputs, Word,
+    MemAdviceProvider, Operation, Process, StackInputs, Word,
 };
 use rand_utils::rand_value;
 use vm_core::{
@@ -1482,10 +1482,10 @@ fn set_user_op_helpers_many() {
 // HELPER FUNCTIONS
 // ================================================================================================
 
-fn build_trace(stack: &[u64], program: &CodeBlock) -> (DecoderTrace, AuxTraceHints, usize) {
-    let stack = crate::StackInputs::try_from_values(stack.iter().copied()).unwrap();
-    let inputs = ProgramInputs::new(&[], vec![]).unwrap();
-    let mut process = Process::new(&Kernel::default(), stack, inputs);
+fn build_trace(stack_inputs: &[u64], program: &CodeBlock) -> (DecoderTrace, AuxTraceHints, usize) {
+    let stack_inputs = StackInputs::try_from_values(stack_inputs.iter().copied()).unwrap();
+    let advice_provider = MemAdviceProvider::empty();
+    let mut process = Process::new(&Kernel::default(), stack_inputs, advice_provider);
     process.execute_code_block(program, &CodeBlockTable::default()).unwrap();
 
     let (trace, aux_hints) = ExecutionTrace::test_finalize_trace(process);
@@ -1510,9 +1510,9 @@ fn build_call_trace(
         Some(ref proc) => Kernel::new(&[proc.hash()]),
         None => Kernel::default(),
     };
-    let inputs = ProgramInputs::new(&[], vec![]).unwrap();
-    let stack = crate::StackInputs::empty();
-    let mut process = Process::new(&kernel, stack, inputs);
+    let advice_provider = MemAdviceProvider::empty();
+    let stack_inputs = crate::StackInputs::empty();
+    let mut process = Process::new(&kernel, stack_inputs, advice_provider);
 
     // build code block table
     let mut cb_table = CodeBlockTable::default();

--- a/processor/src/decorators/mod.rs
+++ b/processor/src/decorators/mod.rs
@@ -272,7 +272,7 @@ mod tests {
         super::{Felt, FieldElement, Kernel, Operation, StarkField},
         Process,
     };
-    use crate::{StackInputs, Word};
+    use crate::{MemAdviceProvider, StackInputs, Word};
     use vm_core::{AdviceInjector, AdviceSet, Decorator, ProgramInputs};
 
     #[test]
@@ -289,9 +289,10 @@ mod tests {
             tree.depth() as u64,
         ];
 
-        let inputs = ProgramInputs::new(&[], vec![tree.clone()]).unwrap();
-        let stack = StackInputs::try_from_values(stack_inputs).unwrap();
-        let mut process = Process::new(&Kernel::default(), stack, inputs);
+        let stack_inputs = StackInputs::try_from_values(stack_inputs).unwrap();
+        let program_inputs = ProgramInputs::new(&[], vec![tree.clone()]).unwrap();
+        let advice_provider = MemAdviceProvider::from(program_inputs);
+        let mut process = Process::new(&Kernel::default(), stack_inputs, advice_provider);
         process.execute_op(Operation::Noop).unwrap();
 
         // inject the node into the advice tape

--- a/processor/src/operations/mod.rs
+++ b/processor/src/operations/mod.rs
@@ -172,9 +172,9 @@ impl Process<super::MemAdviceProvider> {
 
     /// Instantiates a new blank process for testing purposes. The stack in the process is
     /// initialized with the provided values.
-    fn new_dummy(stack: super::StackInputs) -> Self {
-        let inputs = super::ProgramInputs::new(&[], vec![]);
-        let mut process = Self::new(&Kernel::default(), stack, inputs.unwrap());
+    fn new_dummy(stack_inputs: super::StackInputs) -> Self {
+        let advice_provider = super::MemAdviceProvider::empty();
+        let mut process = Self::new(&Kernel::default(), stack_inputs, advice_provider);
         process.execute_op(Operation::Noop).unwrap();
         process
     }
@@ -187,9 +187,10 @@ impl Process<super::MemAdviceProvider> {
 
     /// Instantiates a new process with an advice tape for testing purposes.
     fn new_dummy_with_advice_tape(advice_tape: &[u64]) -> Self {
-        let inputs = super::ProgramInputs::new(advice_tape, vec![]).unwrap();
-        let stack = super::StackInputs::empty();
-        let mut process = Self::new(&Kernel::default(), stack, inputs);
+        let stack_inputs = super::StackInputs::empty();
+        let program_inputs = super::ProgramInputs::new(advice_tape, vec![]).unwrap();
+        let advice_provider = super::MemAdviceProvider::from(program_inputs);
+        let mut process = Self::new(&Kernel::default(), stack_inputs, advice_provider);
         process.execute_op(Operation::Noop).unwrap();
         process
     }
@@ -197,26 +198,27 @@ impl Process<super::MemAdviceProvider> {
     /// Instantiates a new blank process with one decoder trace row for testing purposes. This
     /// allows for setting helpers in the decoder when executing operations during tests.
     fn new_dummy_with_decoder_helpers_and_empty_stack() -> Self {
-        let stack = super::StackInputs::empty();
-        Self::new_dummy_with_decoder_helpers(stack)
+        let stack_inputs = super::StackInputs::empty();
+        Self::new_dummy_with_decoder_helpers(stack_inputs)
     }
 
     /// Instantiates a new blank process with one decoder trace row for testing purposes. This
     /// allows for setting helpers in the decoder when executing operations during tests.
     ///
     /// The stack in the process is initialized with the provided values.
-    fn new_dummy_with_decoder_helpers(stack: super::StackInputs) -> Self {
-        let inputs = super::ProgramInputs::new(&[], vec![]);
-        Self::new_dummy_with_inputs_and_decoder_helpers(stack, inputs.unwrap())
+    fn new_dummy_with_decoder_helpers(stack_inputs: super::StackInputs) -> Self {
+        let program_inputs = super::ProgramInputs::empty();
+        Self::new_dummy_with_inputs_and_decoder_helpers(stack_inputs, program_inputs)
     }
 
     /// Instantiates a new process having Program inputs along with one decoder trace row
     /// for testing purposes.
     fn new_dummy_with_inputs_and_decoder_helpers(
-        stack: super::StackInputs,
-        input: super::ProgramInputs,
+        stack_inputs: super::StackInputs,
+        program_inputs: super::ProgramInputs,
     ) -> Self {
-        let mut process = Self::new(&Kernel::default(), stack, input);
+        let advice_provider = super::MemAdviceProvider::from(program_inputs);
+        let mut process = Self::new(&Kernel::default(), stack_inputs, advice_provider);
         process.decoder.add_dummy_trace_row();
         process.execute_op(Operation::Noop).unwrap();
         process

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -1,7 +1,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use air::{ProcessorAir, PublicInputs};
-use processor::{math::Felt, ExecutionTrace};
+use processor::{math::Felt, AdviceProvider, ExecutionTrace};
 use prover::Prover;
 
 #[cfg(feature = "std")]
@@ -33,16 +33,19 @@ pub use prover::StarkProof;
 ///
 /// # Errors
 /// Returns an error if program execution or STARK proof generation fails for any reason.
-pub fn prove(
+pub fn prove<A>(
     program: &Program,
     stack_inputs: StackInputs,
-    advice_inputs: &ProgramInputs,
+    advice_provider: A,
     options: &ProofOptions,
-) -> Result<(ProgramOutputs, StarkProof), ExecutionError> {
+) -> Result<(ProgramOutputs, StarkProof), ExecutionError>
+where
+    A: AdviceProvider,
+{
     // execute the program to create an execution trace
     #[cfg(feature = "std")]
     let now = Instant::now();
-    let trace = processor::execute(program, stack_inputs.clone(), advice_inputs)?;
+    let trace = processor::execute(program, stack_inputs.clone(), advice_provider)?;
     #[cfg(feature = "std")]
     debug!(
         "Generated execution trace of {} columns and {} steps in {} ms",


### PR DESCRIPTION
This commit introduces the advice trait as argument of the execute function of the processor. It will, downstream, impact on the prover and miden binaries.

Currently, there is no mechanism to serialize a generic instance of the advice provider to a file so it can be reconstructed for CLI applications. The only use-case is to have in-memory, default implementation of the advice provider, so it is using hardcoded `MemAdviceProvider`.

The examples are also falling back to in-memory provider so we don't add complexity and require them to serialize a generic advice provider.

closes #409