### PR TITLE
Test Decorator for Computing iNTT over Quadratic Extension Field

### DIFF
--- a/miden/Cargo.toml
+++ b/miden/Cargo.toml
@@ -67,3 +67,4 @@ sha2 = "0.10"
 sha3 = "0.10"
 test-case = "2.2.2"
 vm-core = { package = "miden-core", path = "../core", version = "0.4", default-features = false }
+winterfell = { package = "winter-prover", version = "0.4.2", default-features = false }

--- a/miden/tests/integration/stdlib/crypto/fri.rs
+++ b/miden/tests/integration/stdlib/crypto/fri.rs
@@ -1,0 +1,79 @@
+use super::{build_test, Felt};
+use test_case::test_case;
+use vm_core::{FieldElement, QuadExtension, StarkField};
+use winterfell::math::fft;
+
+type Ext2Element = QuadExtension<Felt>;
+
+#[test_case(8, 1; "poly_8 |> evaluated_8 |> interpolated_8")]
+#[test_case(8, 2; "poly_8 |> evaluated_16 |> interpolated_8")]
+#[test_case(8, 4; "poly_8 |> evaluated_32 |> interpolated_8")]
+#[test_case(8, 8; "poly_8 |> evaluated_64 |> interpolated_8")]
+#[test_case(16, 1; "poly_16 |> evaluated_16 |> interpolated_16")]
+#[test_case(16, 2; "poly_16 |> evaluated_32 |> interpolated_16")]
+#[test_case(16, 4; "poly_16 |> evaluated_64 |> interpolated_16")]
+#[test_case(16, 8; "poly_16 |> evaluated_128 |> interpolated_16")]
+fn test_decorator_ext2intt(in_poly_len: usize, blowup: usize) {
+    // requirements
+    assert!((in_poly_len > 1) && in_poly_len.is_power_of_two());
+    assert!((blowup > 0) && blowup.is_power_of_two());
+
+    let eval_len = in_poly_len * blowup;
+    let eval_mem_req = (eval_len * 2) / 4;
+    let out_mem_req = (in_poly_len * 2) / 4;
+
+    let source = format!(
+        "
+    proc.helper.{}
+        locaddr.{}
+        repeat.{}
+            movdn.4
+            dup.4
+            mem_storew
+            dropw
+            sub.1
+        end
+        drop
+        
+        locaddr.0
+        push.{}
+        push.{}
+
+        adv.ext2intt
+
+        push.0
+        dropw
+
+        repeat.{}
+            push.0.0.0.0
+            adv_loadw
+        end
+    end
+
+    begin
+        exec.helper
+    end
+    ",
+        eval_mem_req,
+        eval_mem_req - 1,
+        eval_mem_req,
+        eval_len,
+        in_poly_len,
+        out_mem_req
+    );
+
+    let poly = rand_utils::rand_vector::<QuadExtension<Felt>>(in_poly_len);
+    let twiddles = fft::get_twiddles(poly.len());
+    let evals = fft::evaluate_poly_with_offset(&poly, &twiddles, Felt::ONE, blowup);
+
+    let ifelts = Ext2Element::as_base_elements(&evals);
+    let iu64s = ifelts.iter().map(|v| v.as_int()).collect::<Vec<u64>>();
+    let ou64s = Ext2Element::as_base_elements(&poly)
+        .iter()
+        .rev()
+        .map(|v| v.as_int())
+        .collect::<Vec<u64>>();
+
+    let test = build_test!(source, &iu64s);
+    test.expect_stack(&ou64s);
+}

--- a/miden/tests/integration/stdlib/crypto/mod.rs
+++ b/miden/tests/integration/stdlib/crypto/mod.rs
@@ -4,5 +4,6 @@ use crate::helpers::{Felt, STACK_TOP_SIZE};
 mod blake3;
 mod ecdsa_secp256k1;
 mod falcon;
+mod fri;
 mod keccak256;
 mod sha256;


### PR DESCRIPTION
This PR adds necessary test cases to ensure that `adv.ext2intt` is correctly implemented ( was added in #598 ). 