### PR TITLE
feat(processor): add program info

### DIFF
--- a/air/src/lib.rs
+++ b/air/src/lib.rs
@@ -5,10 +5,9 @@
 extern crate alloc;
 
 use vm_core::{
-    chiplets::hasher::Digest,
     utils::{collections::Vec, ByteWriter, Serializable},
-    ExtensionOf, StackInputs, StackOutputs, CLK_COL_IDX, FMP_COL_IDX, ONE, STACK_TRACE_OFFSET,
-    ZERO,
+    ExtensionOf, ProgramInfo, StackInputs, StackOutputs, CLK_COL_IDX, FMP_COL_IDX, ONE,
+    STACK_TRACE_OFFSET, ZERO,
 };
 use winter_air::{
     Air, AirContext, Assertion, AuxTraceRandElements, EvaluationFrame,
@@ -246,19 +245,19 @@ impl Air for ProcessorAir {
 
 #[derive(Debug)]
 pub struct PublicInputs {
-    program_hash: Digest,
+    program_info: ProgramInfo,
     stack_inputs: StackInputs,
     stack_outputs: StackOutputs,
 }
 
 impl PublicInputs {
     pub fn new(
-        program_hash: Digest,
+        program_info: ProgramInfo,
         stack_inputs: StackInputs,
         stack_outputs: StackOutputs,
     ) -> Self {
         Self {
-            program_hash,
+            program_info,
             stack_inputs,
             stack_outputs,
         }
@@ -267,19 +266,8 @@ impl PublicInputs {
 
 impl Serializable for PublicInputs {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
-        target.write(self.program_hash.as_elements());
-        target.write(self.stack_inputs.values());
-
-        // write program outputs.
-        let stack = self.stack_outputs.stack().iter().map(|v| Felt::new(*v)).collect::<Vec<_>>();
-        target.write(stack);
-
-        let overflow_addrs = self
-            .stack_outputs
-            .overflow_addrs()
-            .iter()
-            .map(|v| Felt::new(*v))
-            .collect::<Vec<_>>();
-        target.write(overflow_addrs);
+        self.program_info.write_into(target);
+        self.stack_inputs.write_into(target);
+        self.stack_outputs.write_into(target);
     }
 }

--- a/assembly/src/parsers/mod.rs
+++ b/assembly/src/parsers/mod.rs
@@ -1,6 +1,6 @@
 use super::{
-    errors::SerializationError, AbsolutePath, BTreeMap, ByteReader, ByteWriter, Deserializable,
-    Felt, ParsingError, ProcedureId, ProcedureName, Serializable, String, ToString, Token,
+    AbsolutePath, BTreeMap, ByteReader, ByteWriter, Deserializable, Felt, ParsingError,
+    ProcedureId, ProcedureName, Serializable, SerializationError, String, ToString, Token,
     TokenStream, Vec,
 };
 use core::{fmt::Display, ops::RangeBounds};

--- a/core/src/inputs/mod.rs
+++ b/core/src/inputs/mod.rs
@@ -3,7 +3,10 @@ use super::{
     errors::{AdviceSetError, InputError},
     Felt, FieldElement, Word,
 };
-use winter_utils::collections::{vec, Vec};
+use winter_utils::{
+    collections::{vec, Vec},
+    ByteWriter, Serializable,
+};
 
 mod advice;
 pub use advice::AdviceSet;

--- a/core/src/inputs/stack.rs
+++ b/core/src/inputs/stack.rs
@@ -1,4 +1,4 @@
-use super::{vec, Felt, InputError, Vec};
+use super::{vec, ByteWriter, Felt, InputError, Serializable, Vec};
 use core::slice;
 
 // STACK INPUTS
@@ -63,5 +63,17 @@ impl IntoIterator for StackInputs {
 
     fn into_iter(self) -> Self::IntoIter {
         self.values.into_iter()
+    }
+}
+
+impl Serializable for StackInputs {
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        // TODO the length of the stack, by design, will not be greater than `u32::MAX`. however,
+        // we must define a common serialization format as we might diverge from the implementation
+        // here and the one provided by default from winterfell.
+
+        debug_assert!(self.values.len() <= u32::MAX as usize);
+        target.write_u32(self.values.len() as u32);
+        self.values.iter().copied().for_each(|v| target.write(v));
     }
 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -18,7 +18,7 @@ pub use math::{
 };
 
 mod program;
-pub use program::{blocks as code_blocks, CodeBlockTable, Kernel, Program};
+pub use program::{blocks as code_blocks, CodeBlockTable, Kernel, Program, ProgramInfo};
 
 mod operations;
 pub use operations::{

--- a/core/src/program/info.rs
+++ b/core/src/program/info.rs
@@ -1,0 +1,68 @@
+use super::{ByteWriter, Digest, Kernel, Program, Serializable};
+
+// PROGRAM INFO
+// ================================================================================================
+
+/// A program information set consisting of its MAST root and set of kernel procedure roots used
+/// for its compilation.
+///
+/// This will be used as public inputs of the proof so we bind its verification to the kernel and
+/// root used to execute the program. This way, we extend the correctness of the proof to the
+/// security guarantees provided by the kernel. We also allow the user to easily prove the
+/// membership of a given kernel procedure for a given proof, without compromising its
+/// zero-knowledge properties.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ProgramInfo {
+    program_hash: Digest,
+    kernel: Kernel,
+}
+
+impl ProgramInfo {
+    // CONSTRUCTORS
+    // --------------------------------------------------------------------------------------------
+
+    /// Creates a new instance of a program info.
+    pub const fn new(program_hash: Digest, kernel: Kernel) -> Self {
+        Self {
+            program_hash,
+            kernel,
+        }
+    }
+
+    // PUBLIC ACCESSORS
+    // --------------------------------------------------------------------------------------------
+
+    /// Returns the program hash computed from its code block root.
+    pub const fn program_hash(&self) -> &Digest {
+        &self.program_hash
+    }
+
+    /// Returns the program kernel used during the compilation.
+    pub const fn kernel(&self) -> &Kernel {
+        &self.kernel
+    }
+
+    /// Returns the list of procedures of the kernel used during the compilation.
+    pub fn kernel_procedures(&self) -> &[Digest] {
+        self.kernel.proc_hashes()
+    }
+}
+
+impl From<Program> for ProgramInfo {
+    fn from(program: Program) -> Self {
+        let Program { root, kernel, .. } = program;
+        let program_hash = root.hash();
+
+        Self {
+            program_hash,
+            kernel,
+        }
+    }
+}
+
+impl Serializable for ProgramInfo {
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        self.program_hash.write_into(target);
+        <Kernel as Serializable>::write_into(&self.kernel, target);
+    }
+}

--- a/miden/README.md
+++ b/miden/README.md
@@ -21,7 +21,7 @@ Currently, there are 3 ways to get values onto the stack:
 
 The stack is provided to Miden VM via `StackInputs` struct. These are public inputs of the execution, and should also be provided to the verifier. The secret inputs of the program are provided via `AdviceProvider` instances. There is one in-memory advice provider that can be commonly used for operations that won't require persistence: `MemAdviceProvider`.
 
-Values remaining on the stack after a program is executed can be returned as program outputs. You can specify exactly how many values (from the top of the stack) should be returned. Currently, the maximum number of outputs is limited to 16.
+Values remaining on the stack after a program is executed can be returned as stack outputs. You can specify exactly how many values (from the top of the stack) should be returned. Currently, the maximum number of outputs is limited to 16.
 
 Having only 16 elements to describe public inputs and outputs of a program may seem limiting, however, just 4 elements are sufficient to represent a root of a Merkle tree or a sequential hash of elements. Both of these can be expanded into an arbitrary number of values by supplying the actual values non-deterministically via the advice provider.
 
@@ -95,7 +95,7 @@ let program = assembler.compile("begin push.3 push.5 add end").unwrap();
 let (outputs, proof) = prove(
     &program,
     StackInputs::default(),       // we won't provide any inputs
-    MemAdviceProvider::default(), //
+    MemAdviceProvider::default(), // we won't provide advice inputs
     &ProofOptions::default(),     // we'll be using default options
 )
 .unwrap();
@@ -187,7 +187,7 @@ let (outputs, proof) = miden::prove(
 )
 .unwrap();
 
-// fetch the stack, truncating to the first element
+// fetch the stack outputs, truncating to the first element
 let stack = outputs.stack_truncated(1);
 
 // the output should be the 50th Fibonacci number

--- a/miden/src/cli/verify.rs
+++ b/miden/src/cli/verify.rs
@@ -1,4 +1,5 @@
 use super::data::{InputFile, OutputFile, ProgramHash, ProofFile};
+use miden::{Kernel, ProgramInfo};
 use std::{path::PathBuf, time::Instant};
 use structopt::StructOpt;
 
@@ -43,8 +44,12 @@ impl VerifyCmd {
         println!("verifying program...");
         let now = Instant::now();
 
+        // TODO accept kernel as CLI argument
+        let kernel = Kernel::default();
+        let program_info = ProgramInfo::new(program_hash, kernel);
+
         // verify proof
-        verifier::verify(program_hash, stack_inputs, outputs_data.stack_outputs(), proof)
+        verifier::verify(program_info, stack_inputs, outputs_data.stack_outputs(), proof)
             .map_err(|err| format!("Program failed verification! - {}", err))?;
 
         println!("Verification complete in {} ms", now.elapsed().as_millis());

--- a/miden/src/examples/mod.rs
+++ b/miden/src/examples/mod.rs
@@ -1,4 +1,4 @@
-use miden::{AdviceProvider, Program, ProofOptions, StackInputs, StarkProof};
+use miden::{AdviceProvider, Program, ProgramInfo, ProofOptions, StackInputs, StarkProof};
 use std::io::Write;
 use std::time::Instant;
 use structopt::StructOpt;
@@ -90,7 +90,7 @@ impl ExampleOptions {
             //hex::encode(program.hash()), // TODO: include into message
             now.elapsed().as_millis()
         );
-        println!("Program output: {:?}", stack_outputs.stack_truncated(num_outputs));
+        println!("Stack outputs: {:?}", stack_outputs.stack_truncated(num_outputs));
         assert_eq!(
             expected_result,
             stack_outputs.stack_truncated(num_outputs),
@@ -107,7 +107,9 @@ impl ExampleOptions {
         // results in the expected output
         let proof = StarkProof::from_bytes(&proof_bytes).unwrap();
         let now = Instant::now();
-        match miden::verify(program.hash(), stack_inputs, stack_outputs, proof) {
+        let program_info = ProgramInfo::from(program);
+
+        match miden::verify(program_info, stack_inputs, stack_outputs, proof) {
             Ok(_) => println!("Execution verified in {} ms", now.elapsed().as_millis()),
             Err(err) => println!("Failed to verify execution: {}", err),
         }

--- a/miden/src/lib.rs
+++ b/miden/src/lib.rs
@@ -7,7 +7,8 @@
 pub use assembly::{Assembler, AssemblyError, ParsingError};
 pub use processor::{
     execute, execute_iter, utils, AdviceInputs, AdviceProvider, AsmOpInfo, ExecutionError,
-    ExecutionTrace, MemAdviceProvider, Operation, StackInputs, VmState, VmStateIterator,
+    ExecutionTrace, Kernel, MemAdviceProvider, Operation, ProgramInfo, StackInputs, VmState,
+    VmStateIterator,
 };
 pub use prover::{
     math, prove, AdviceSet, AdviceSetError, Digest, FieldExtension, HashFunction, InputError,

--- a/miden/src/repl/mod.rs
+++ b/miden/src/repl/mod.rs
@@ -270,7 +270,7 @@ fn execute(program: String) -> Result<(Vec<(u64, Word)>, Vec<Felt>), ProgramErro
     let stack_inputs = StackInputs::default();
     let advice_provider = MemAdviceProvider::default();
 
-    let mut process = Process::new_debug(program.kernel(), stack_inputs, advice_provider);
+    let mut process = Process::new_debug(program.kernel().clone(), stack_inputs, advice_provider);
     let _program_outputs = process.execute(&program).map_err(ProgramError::ExecutionError);
 
     let (sys, _, stack, _, chiplets, _) = process.into_parts();

--- a/miden/tests/integration/helpers/mod.rs
+++ b/miden/tests/integration/helpers/mod.rs
@@ -1,4 +1,4 @@
-pub use miden::{MemAdviceProvider, ProofOptions, StarkProof};
+pub use miden::{MemAdviceProvider, ProgramInfo, ProofOptions, StarkProof};
 pub use processor::{AdviceInputs, StackInputs};
 use processor::{ExecutionError, ExecutionTrace, Process, VmStateIterator};
 use proptest::prelude::*;
@@ -109,7 +109,7 @@ impl Test {
 
         // execute the test
         let mut process =
-            Process::new(program.kernel(), self.stack_inputs.clone(), advice_provider);
+            Process::new(program.kernel().clone(), self.stack_inputs.clone(), advice_provider);
         process.execute(&program).unwrap();
 
         // validate the memory state
@@ -177,11 +177,12 @@ impl Test {
         )
         .unwrap();
 
+        let program_info = ProgramInfo::from(program);
         if test_fail {
             stack_outputs.stack_mut()[0] += 1;
-            assert!(miden::verify(program.hash(), stack_inputs, stack_outputs, proof).is_err());
+            assert!(miden::verify(program_info, stack_inputs, stack_outputs, proof).is_err());
         } else {
-            let result = miden::verify(program.hash(), stack_inputs, stack_outputs, proof);
+            let result = miden::verify(program_info, stack_inputs, stack_outputs, proof);
             assert!(result.is_ok(), "error: {result:?}");
         }
     }

--- a/processor/src/chiplets/kernel_rom/mod.rs
+++ b/processor/src/chiplets/kernel_rom/mod.rs
@@ -37,6 +37,7 @@ type ProcHashBytes = [u8; 32];
 ///   column, these form tuples (index, procedure root) for all procedures in the kernel.
 pub struct KernelRom {
     access_map: BTreeMap<ProcHashBytes, ProcAccessInfo>,
+    kernel: Kernel,
     trace_len: usize,
 }
 
@@ -47,7 +48,8 @@ impl KernelRom {
     ///
     /// The kernel ROM is populated with all procedures from the provided kernel. For each
     /// procedure access count is set to 0.
-    pub fn new(kernel: &Kernel) -> Self {
+    pub fn new(kernel: Kernel) -> Self {
+        let trace_len = kernel.proc_hashes().len();
         let mut access_map = BTreeMap::new();
         for &proc_hash in kernel.proc_hashes() {
             access_map.insert(proc_hash.into(), ProcAccessInfo::new(proc_hash));
@@ -55,7 +57,8 @@ impl KernelRom {
 
         Self {
             access_map,
-            trace_len: kernel.proc_hashes().len(),
+            kernel,
+            trace_len,
         }
     }
 
@@ -110,6 +113,14 @@ impl KernelRom {
                 row += 1;
             }
         }
+    }
+
+    // PUBLIC ACCESSORS
+    // --------------------------------------------------------------------------------------------
+
+    /// Returns the underlying kernel for this ROM.
+    pub const fn kernel(&self) -> &Kernel {
+        &self.kernel
     }
 }
 

--- a/processor/src/chiplets/kernel_rom/tests.rs
+++ b/processor/src/chiplets/kernel_rom/tests.rs
@@ -12,14 +12,14 @@ const PROC2_HASH: Word = [ONE, ONE, ONE, ONE];
 #[test]
 fn kernel_rom_empty() {
     let kernel = Kernel::default();
-    let rom = KernelRom::new(&kernel);
+    let rom = KernelRom::new(kernel);
     assert_eq!(0, rom.trace_len());
 }
 
 #[test]
 fn kernel_rom_invalid_access() {
     let kernel = build_kernel();
-    let mut rom = KernelRom::new(&kernel);
+    let mut rom = KernelRom::new(kernel);
 
     // accessing procedure which is in the kernel should be fine
     assert!(rom.access_proc(PROC1_HASH.into()).is_ok());
@@ -31,7 +31,7 @@ fn kernel_rom_invalid_access() {
 #[test]
 fn kernel_rom_no_access() {
     let kernel = build_kernel();
-    let rom = KernelRom::new(&kernel);
+    let rom = KernelRom::new(kernel);
 
     let expected_trace_len = 2;
     assert_eq!(expected_trace_len, rom.trace_len());
@@ -63,7 +63,7 @@ fn kernel_rom_no_access() {
 #[test]
 fn kernel_rom_with_access() {
     let kernel = build_kernel();
-    let mut rom = KernelRom::new(&kernel);
+    let mut rom = KernelRom::new(kernel);
 
     // generate 5 access: 3 for proc1 and 2 for proc2
     rom.access_proc(PROC1_HASH.into()).unwrap();

--- a/processor/src/chiplets/mod.rs
+++ b/processor/src/chiplets/mod.rs
@@ -89,7 +89,7 @@ impl Chiplets {
     // CONSTRUCTOR
     // --------------------------------------------------------------------------------------------
     /// Returns a new [Chiplets] component instantiated with the provided Kernel.
-    pub fn new(kernel: &Kernel) -> Self {
+    pub fn new(kernel: Kernel) -> Self {
         Self {
             clk: 0,
             hasher: Hasher::default(),
@@ -132,6 +132,11 @@ impl Chiplets {
     /// Returns the index of the first row of the padding section of the execution trace.
     pub fn padding_start(&self) -> usize {
         self.kernel_rom_start() + self.kernel_rom.trace_len()
+    }
+
+    /// Returns the underlying kernel used to initilize this instance.
+    pub const fn kernel(&self) -> &Kernel {
+        self.kernel_rom.kernel()
     }
 
     // HASH CHIPLET ACCESSORS FOR OPERATIONS

--- a/processor/src/chiplets/tests.rs
+++ b/processor/src/chiplets/tests.rs
@@ -111,7 +111,7 @@ fn build_trace(
 ) -> (ChipletsTrace, usize) {
     let stack_inputs = StackInputs::try_from_values(stack_inputs.iter().copied()).unwrap();
     let advice_provider = MemAdviceProvider::default();
-    let mut process = Process::new(&kernel, stack_inputs, advice_provider);
+    let mut process = Process::new(kernel, stack_inputs, advice_provider);
     let program = CodeBlock::new_span(operations);
     process.execute_code_block(&program, &CodeBlockTable::default()).unwrap();
 

--- a/processor/src/decoder/tests.rs
+++ b/processor/src/decoder/tests.rs
@@ -1485,7 +1485,7 @@ fn set_user_op_helpers_many() {
 fn build_trace(stack_inputs: &[u64], program: &CodeBlock) -> (DecoderTrace, AuxTraceHints, usize) {
     let stack_inputs = StackInputs::try_from_values(stack_inputs.iter().copied()).unwrap();
     let advice_provider = MemAdviceProvider::default();
-    let mut process = Process::new(&Kernel::default(), stack_inputs, advice_provider);
+    let mut process = Process::new(Kernel::default(), stack_inputs, advice_provider);
     process.execute_code_block(program, &CodeBlockTable::default()).unwrap();
 
     let (trace, aux_hints) = ExecutionTrace::test_finalize_trace(process);
@@ -1512,7 +1512,7 @@ fn build_call_trace(
     };
     let advice_provider = MemAdviceProvider::default();
     let stack_inputs = crate::StackInputs::default();
-    let mut process = Process::new(&kernel, stack_inputs, advice_provider);
+    let mut process = Process::new(kernel, stack_inputs, advice_provider);
 
     // build code block table
     let mut cb_table = CodeBlockTable::default();

--- a/processor/src/decorators/mod.rs
+++ b/processor/src/decorators/mod.rs
@@ -292,7 +292,7 @@ mod tests {
         let stack_inputs = StackInputs::try_from_values(stack_inputs).unwrap();
         let advice_inputs = AdviceInputs::default().with_merkle_sets(vec![tree.clone()]).unwrap();
         let advice_provider = MemAdviceProvider::from(advice_inputs);
-        let mut process = Process::new(&Kernel::default(), stack_inputs, advice_provider);
+        let mut process = Process::new(Kernel::default(), stack_inputs, advice_provider);
         process.execute_op(Operation::Noop).unwrap();
 
         // inject the node into the advice tape

--- a/processor/src/operations/mod.rs
+++ b/processor/src/operations/mod.rs
@@ -174,7 +174,7 @@ impl Process<super::MemAdviceProvider> {
     /// initialized with the provided values.
     fn new_dummy(stack_inputs: super::StackInputs) -> Self {
         let advice_provider = super::MemAdviceProvider::default();
-        let mut process = Self::new(&Kernel::default(), stack_inputs, advice_provider);
+        let mut process = Self::new(Kernel::default(), stack_inputs, advice_provider);
         process.execute_op(Operation::Noop).unwrap();
         process
     }
@@ -192,7 +192,7 @@ impl Process<super::MemAdviceProvider> {
             .with_tape_values(advice_tape.iter().copied())
             .unwrap();
         let advice_provider = super::MemAdviceProvider::from(advice_inputs);
-        let mut process = Self::new(&Kernel::default(), stack_inputs, advice_provider);
+        let mut process = Self::new(Kernel::default(), stack_inputs, advice_provider);
         process.execute_op(Operation::Noop).unwrap();
         process
     }
@@ -220,7 +220,7 @@ impl Process<super::MemAdviceProvider> {
         advice_inputs: super::AdviceInputs,
     ) -> Self {
         let advice_provider = super::MemAdviceProvider::from(advice_inputs);
-        let mut process = Self::new(&Kernel::default(), stack_inputs, advice_provider);
+        let mut process = Self::new(Kernel::default(), stack_inputs, advice_provider);
         process.decoder.add_dummy_trace_row();
         process.execute_op(Operation::Noop).unwrap();
         process

--- a/processor/src/trace/tests/mod.rs
+++ b/processor/src/trace/tests/mod.rs
@@ -17,7 +17,7 @@ mod stack;
 pub fn build_trace_from_block(program: &CodeBlock, stack_inputs: &[u64]) -> ExecutionTrace {
     let stack_inputs = StackInputs::try_from_values(stack_inputs.iter().copied()).unwrap();
     let advice_provider = MemAdviceProvider::default();
-    let mut process = Process::new(&Kernel::default(), stack_inputs, advice_provider);
+    let mut process = Process::new(Kernel::default(), stack_inputs, advice_provider);
     process.execute_code_block(program, &CodeBlockTable::default()).unwrap();
     ExecutionTrace::new(process, StackOutputs::default())
 }
@@ -38,7 +38,7 @@ pub fn build_trace_from_ops_with_inputs(
     advice_inputs: AdviceInputs,
 ) -> ExecutionTrace {
     let advice_provider = MemAdviceProvider::from(advice_inputs);
-    let mut process = Process::new(&Kernel::default(), stack_inputs, advice_provider);
+    let mut process = Process::new(Kernel::default(), stack_inputs, advice_provider);
     let program = CodeBlock::new_span(operations);
     process.execute_code_block(&program, &CodeBlockTable::default()).unwrap();
     ExecutionTrace::new(process, StackOutputs::default())

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -135,10 +135,7 @@ impl Prover for ExecutionProver {
             "provided outputs do not match the execution trace"
         );
 
-        PublicInputs::new(
-            trace.program_hash(),
-            self.stack_inputs.clone(),
-            self.stack_outputs.clone(),
-        )
+        let program_info = trace.program_info().clone();
+        PublicInputs::new(program_info, self.stack_inputs.clone(), self.stack_outputs.clone())
     }
 }

--- a/verifier/src/lib.rs
+++ b/verifier/src/lib.rs
@@ -2,7 +2,7 @@
 
 use air::{ProcessorAir, PublicInputs};
 use core::fmt;
-use vm_core::StackInputs;
+use vm_core::{ProgramInfo, StackInputs};
 use winterfell::VerifierError;
 
 // EXPORTS
@@ -36,13 +36,13 @@ mod math {
 /// # Errors
 /// Returns an error if the provided proof does not prove a correct execution of the program.
 pub fn verify(
-    program_hash: Digest,
+    program_info: ProgramInfo,
     stack_inputs: StackInputs,
     stack_outputs: StackOutputs,
     proof: StarkProof,
 ) -> Result<(), VerificationError> {
     // build public inputs and try to verify the proof
-    let pub_inputs = PublicInputs::new(program_hash, stack_inputs, stack_outputs);
+    let pub_inputs = PublicInputs::new(program_info, stack_inputs, stack_outputs);
     winterfell::verify::<ProcessorAir>(proof, pub_inputs).map_err(VerificationError::VerifierError)
 }
 


### PR DESCRIPTION
This commit introduces `ProgramInfo`, a structure that will bind both the program hash and the used kernel to the generated zk proof.

It will use the kernel procedures as public inputs of the proof so the security guarantees provided by the kernel can be extended to any state transition with a valid proof. It will also allow efficient queries for members of the kernel.

The CLI currently doesn't support kernel as argument as it will only take the code root hash of a given program. It is currently using as fallback and empty/default kernel.

related issue #409