### PR TITLE
feat(processor): add advice source

### DIFF
--- a/processor/src/advice/mem_provider.rs
+++ b/processor/src/advice/mem_provider.rs
@@ -1,6 +1,6 @@
 use super::{
-    AdviceInputs, AdviceProvider, AdviceSet, BTreeMap, ExecutionError, Felt, IntoBytes, StarkField,
-    Vec, Word,
+    AdviceInputs, AdviceProvider, AdviceSet, AdviceSource, BTreeMap, ExecutionError, Felt,
+    IntoBytes, StarkField, Vec, Word,
 };
 
 // MEMORY ADVICE PROVIDER
@@ -58,18 +58,22 @@ impl AdviceProvider for MemAdviceProvider {
         Ok([word0, word1])
     }
 
-    fn write_tape(&mut self, value: Felt) {
-        self.tape.push(value);
-    }
+    fn write_tape(&mut self, source: AdviceSource) -> Result<(), ExecutionError> {
+        match source {
+            AdviceSource::Value(value) => {
+                self.tape.push(value);
+                Ok(())
+            }
 
-    fn write_tape_from_map(&mut self, key: Word) -> Result<(), ExecutionError> {
-        let values = self
-            .values
-            .get(&key.into_bytes())
-            .ok_or(ExecutionError::AdviceKeyNotFound(key))?;
-        self.tape.extend(values.iter().rev());
-
-        Ok(())
+            AdviceSource::Map { key } => {
+                let values = self
+                    .values
+                    .get(&key.into_bytes())
+                    .ok_or(ExecutionError::AdviceKeyNotFound(key))?;
+                self.tape.extend(values.iter().rev());
+                Ok(())
+            }
+        }
     }
 
     fn insert_into_map(&mut self, key: Word, values: Vec<Felt>) -> Result<(), ExecutionError> {

--- a/processor/src/advice/mod.rs
+++ b/processor/src/advice/mod.rs
@@ -13,6 +13,9 @@ pub use inputs::AdviceInputs;
 mod mem_provider;
 pub use mem_provider::MemAdviceProvider;
 
+mod source;
+pub use source::AdviceSource;
+
 // ADVICE PROVIDER
 // ================================================================================================
 
@@ -88,21 +91,8 @@ pub trait AdviceProvider {
     /// Returns an error if the advice tape does not contain two words.
     fn read_tape_dw(&mut self) -> Result<[Word; 2], ExecutionError>;
 
-    /// Writes the provided value at the head of the advice tape.
-    fn write_tape(&mut self, value: Felt);
-
-    /// Fetch a keyed tape from the values map, reversing and appending it to the advice tape.
-    ///
-    /// Note: this operation shouldn't consume the map element so it can be called multiple times
-    /// for the same key.
-    ///
-    /// # Example
-    /// Given an advice map `[a,b,c]`, and a map `x |-> [d,e,f]`, a call `write_tape_from_map(x)`
-    /// will result in `[a,b,c,f,e,d]` for the advice tape, and will preserve `x |-> [d,e,f]`.
-    ///
-    /// # Errors
-    /// Returns an error if the key was not found in a key-value map.
-    fn write_tape_from_map(&mut self, key: Word) -> Result<(), ExecutionError>;
+    /// Writes values specified by the source to the head of the advice tape.
+    fn write_tape(&mut self, source: AdviceSource) -> Result<(), ExecutionError>;
 
     /// Maps a key to a value list to be yielded by `write_tape_from_map`.
     ///
@@ -186,12 +176,8 @@ where
         T::read_tape_dw(self)
     }
 
-    fn write_tape(&mut self, value: Felt) {
-        T::write_tape(self, value)
-    }
-
-    fn write_tape_from_map(&mut self, key: Word) -> Result<(), ExecutionError> {
-        T::write_tape_from_map(self, key)
+    fn write_tape(&mut self, source: AdviceSource) -> Result<(), ExecutionError> {
+        T::write_tape(self, source)
     }
 
     fn insert_into_map(&mut self, key: Word, values: Vec<Felt>) -> Result<(), ExecutionError> {

--- a/processor/src/advice/source.rs
+++ b/processor/src/advice/source.rs
@@ -1,0 +1,24 @@
+use super::{Felt, Word};
+
+// ADVICE SOURCE
+// ================================================================================================
+
+/// Placeholder for advice provider tape mutation.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum AdviceSource {
+    /// Writes a single value to the head of the advice tape.
+    Value(Felt),
+
+    /// Fetch a keyed tape from the values map, reversing and appending it to the advice tape.
+    ///
+    /// Note: this operation shouldn't consume the map element so it can be called multiple times
+    /// for the same key.
+    ///
+    /// # Example
+    /// Given an advice tape `[a,b,c]`, and a map `x |-> [d,e,f]`, a call `write_tape_from_map(x)`
+    /// will result in `[a,b,c,f,e,d]` for the advice tape, and will preserve `x |-> [d,e,f]`.
+    ///
+    /// # Errors
+    /// Returns an error if the key was not found in the key-value map.
+    Map { key: Word },
+}

--- a/processor/src/decorators/mod.rs
+++ b/processor/src/decorators/mod.rs
@@ -1,4 +1,7 @@
-use super::{AdviceInjector, AdviceProvider, Decorator, ExecutionError, Felt, Process, StarkField};
+use super::{
+    AdviceInjector, AdviceProvider, AdviceSource, Decorator, ExecutionError, Felt, Process,
+    StarkField,
+};
 use vm_core::{utils::collections::Vec, FieldElement, QuadExtension, WORD_LEN, ZERO};
 use winterfell::math::fft;
 
@@ -72,10 +75,10 @@ where
 
         // write the node into the advice tape with first element written last so that it can be
         // removed first
-        self.advice_provider.write_tape(node[3]);
-        self.advice_provider.write_tape(node[2]);
-        self.advice_provider.write_tape(node[1]);
-        self.advice_provider.write_tape(node[0]);
+        self.advice_provider.write_tape(AdviceSource::Value(node[3]))?;
+        self.advice_provider.write_tape(AdviceSource::Value(node[2]))?;
+        self.advice_provider.write_tape(AdviceSource::Value(node[1]))?;
+        self.advice_provider.write_tape(AdviceSource::Value(node[0]))?;
 
         Ok(())
     }
@@ -110,10 +113,10 @@ where
         let (q_hi, q_lo) = u64_to_u32_elements(quotient);
         let (r_hi, r_lo) = u64_to_u32_elements(remainder);
 
-        self.advice_provider.write_tape(r_hi);
-        self.advice_provider.write_tape(r_lo);
-        self.advice_provider.write_tape(q_hi);
-        self.advice_provider.write_tape(q_lo);
+        self.advice_provider.write_tape(AdviceSource::Value(r_hi))?;
+        self.advice_provider.write_tape(AdviceSource::Value(r_lo))?;
+        self.advice_provider.write_tape(AdviceSource::Value(q_hi))?;
+        self.advice_provider.write_tape(AdviceSource::Value(q_lo))?;
 
         Ok(())
     }
@@ -126,7 +129,7 @@ where
     /// Returns an error if the required key was not found in the key-value map.
     fn inject_map_value(&mut self) -> Result<(), ExecutionError> {
         let top_word = self.stack.get_top_word();
-        self.advice_provider.write_tape_from_map(top_word)?;
+        self.advice_provider.write_tape(AdviceSource::Map { key: top_word })?;
 
         Ok(())
     }
@@ -186,8 +189,8 @@ where
         let elm_arr = [inv_elm];
         let coeffs = Ext2Element::as_base_elements(&elm_arr);
 
-        self.advice_provider.write_tape(coeffs[1]);
-        self.advice_provider.write_tape(coeffs[0]);
+        self.advice_provider.write_tape(AdviceSource::Value(coeffs[1]))?;
+        self.advice_provider.write_tape(AdviceSource::Value(coeffs[0]))?;
 
         Ok(())
     }
@@ -246,8 +249,8 @@ where
         let twiddles = fft::get_inv_twiddles::<Felt>(in_evaluations_len);
         fft::interpolate_poly::<Felt, Ext2Element>(&mut poly, &twiddles);
 
-        for i in Ext2Element::as_base_elements(&poly[..out_poly_len]).iter().rev() {
-            self.advice_provider.write_tape(*i);
+        for i in Ext2Element::as_base_elements(&poly[..out_poly_len]).iter().rev().copied() {
+            self.advice_provider.write_tape(AdviceSource::Value(i))?;
         }
 
         Ok(())

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -38,7 +38,7 @@ mod range;
 use range::RangeChecker;
 
 mod advice;
-pub use advice::{AdviceInputs, AdviceProvider, MemAdviceProvider};
+pub use advice::{AdviceInputs, AdviceProvider, AdviceSource, MemAdviceProvider};
 
 mod chiplets;
 use chiplets::Chiplets;

--- a/processor/src/operations/io_ops.rs
+++ b/processor/src/operations/io_ops.rs
@@ -263,6 +263,7 @@ mod tests {
         super::{Operation, STACK_TOP_SIZE},
         AdviceProvider, Felt, Process,
     };
+    use crate::AdviceSource;
     use vm_core::{utils::ToElements, Word, ONE, ZERO};
 
     #[test]
@@ -482,9 +483,9 @@ mod tests {
         let word2 = [26, 25, 24, 23];
         let word1_felts: Word = word1.to_elements().try_into().unwrap();
         let word2_felts: Word = word2.to_elements().try_into().unwrap();
-        for element in word2_felts.iter().rev().chain(word1_felts.iter().rev()) {
+        for element in word2_felts.iter().rev().chain(word1_felts.iter().rev()).copied() {
             // reverse the word order, since elements are pushed onto the advice tape.
-            process.advice_provider.write_tape(*element);
+            process.advice_provider.write_tape(AdviceSource::Value(element)).unwrap();
         }
 
         // arrange the stack such that:


### PR DESCRIPTION
This commit introduces `[AdviceSource]` as enum to wrap the possible variants that can be used as input for the advice provider.

This new type can be extended in the future to have more complex structures such as signatures or batched field elements.

related issue: #409