### PR TITLE
feat(assembly): Add Instruction and Node to API

### DIFF
--- a/assembly/src/lib.rs
+++ b/assembly/src/lib.rs
@@ -22,7 +22,9 @@ use procedures::{CallSet, Procedure};
 pub use procedures::{ProcedureId, ProcedureName};
 
 mod parsers;
-pub use parsers::{parse_module, parse_program, ModuleAst, ProcedureAst, ProgramAst};
+pub use parsers::{
+    parse_module, parse_program, Instruction, ModuleAst, Node, ProcedureAst, ProgramAst,
+};
 
 mod serde;
 pub use serde::{ByteReader, ByteWriter, Deserializable, Serializable};

--- a/assembly/src/parsers/mod.rs
+++ b/assembly/src/parsers/mod.rs
@@ -7,7 +7,7 @@ use core::{fmt::Display, ops::RangeBounds};
 
 mod nodes;
 use crate::utils::bound_into_included_u64;
-pub(crate) use nodes::{Instruction, Node};
+pub use nodes::{Instruction, Node};
 mod context;
 use context::ParserContext;
 


### PR DESCRIPTION
## Describe your changes
I'm working on migrating the Sway language to MidenVM and I want to use instruction enumeration directly as the opcode type in the Sway compiler. For this reason, I would like to include it in the API.


## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.