### PR TITLE
Optimize immediate sub

### DIFF
--- a/assembly/src/assembler/instruction/field_ops.rs
+++ b/assembly/src/assembler/instruction/field_ops.rs
@@ -28,6 +28,18 @@ pub fn add_imm(span: &mut SpanBuilder, imm: Felt) -> Result<Option<CodeBlock>, A
     }
 }
 
+/// Appends a sequence of operations to subtract an immediate value from the value at the top of the
+/// stack. Specifically, the sequences are:
+/// - if imm = 0: NOOP
+/// - otherwise: PUSH(-imm) ADD
+pub fn sub_imm(span: &mut SpanBuilder, imm: Felt) -> Result<Option<CodeBlock>, AssemblyError> {
+    if imm == ZERO {
+        span.add_op(Noop)
+    } else {
+        span.add_ops([Push(-imm), Add])
+    }
+}
+
 /// Appends a sequence of operations to multiply the value at the top of the stack by an immediate
 /// value. Specifically, the sequences are:
 /// - if imm = 0: DROP PAD

--- a/assembly/src/assembler/instruction/mod.rs
+++ b/assembly/src/assembler/instruction/mod.rs
@@ -45,7 +45,7 @@ impl Assembler {
             Instruction::Add => span.add_op(Add),
             Instruction::AddImm(imm) => field_ops::add_imm(span, *imm),
             Instruction::Sub => span.add_ops([Neg, Add]),
-            Instruction::SubImm(imm) => span.add_ops([Push(-*imm), Add]),
+            Instruction::SubImm(imm) => field_ops::sub_imm(span, *imm),
             Instruction::Mul => span.add_op(Mul),
             Instruction::MulImm(imm) => field_ops::mul_imm(span, *imm),
             Instruction::Div => span.add_ops([Inv, Mul]),


### PR DESCRIPTION
## Describe your changes

Follows the same pattern as immediate addition and when subtracting by zero translates to a `Nop` instead of two opcodes, saving one cycle on this edge case.

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.