### PR TITLE
docs: neq is always 2 cycles

### DIFF
--- a/docs/src/user_docs/assembly/field_operations.md
+++ b/docs/src/user_docs/assembly/field_operations.md
@@ -36,7 +36,7 @@ For instructions where one or more operands can be provided as immediate paramet
 | Instruction      | Stack_input | Stack_output   | Notes                         |
 | ---------------- | ----------- | -------------- | ----------------------------- |
 | eq <br> - *(1 cycle)*  <br> eq.*b* <br> - *(1-2 cycles)*   | [b, a, ...] | [c, ...]       | $c \leftarrow \begin{cases} 1, & \text{if}\ a=b \\ 0, & \text{otherwise}\ \end{cases}$ |
-| neq <br> - *(1 cycle)*  <br> neq.*b* <br> - *(1-2 cycles)*  | [b, a, ...] | [c, ...]       | $c \leftarrow \begin{cases} 1, & \text{if}\ a \ne b \\ 0, & \text{otherwise}\ \end{cases}$ |
+| neq <br> - *(2 cycle)*  <br> neq.*b* <br> - *(2-3 cycles)*  | [b, a, ...] | [c, ...]       | $c \leftarrow \begin{cases} 1, & \text{if}\ a \ne b \\ 0, & \text{otherwise}\ \end{cases}$ |
 | lt <br> - *(17 cycles)*               | [b, a, ...] | [c, ...]       | $c \leftarrow \begin{cases} 1, & \text{if}\ a < b \\ 0, & \text{otherwise}\ \end{cases}$ |
 | lte <br> - *(18 cycles)*              | [b, a, ...] | [c, ...]       | $c \leftarrow \begin{cases} 1, & \text{if}\ a \le b \\ 0, & \text{otherwise}\ \end{cases}$ |
 | gt <br> - *(18 cycles)*               | [b, a, ...] | [c, ...]       | $c \leftarrow \begin{cases} 1, & \text{if}\ a > b \\ 0, & \text{otherwise}\ \end{cases}$ |


### PR DESCRIPTION
## Describe your changes

`neq` is 2 cycles [ref](https://github.com/0xPolygonMiden/miden-vm/blob/main/assembly/src/assembler/instruction/mod.rs#L66)

`neq.imm` is 2/3 cycles [ref](https://github.com/0xPolygonMiden/miden-vm/blob/main/assembly/src/assembler/instruction/field_ops.rs#L217-L222)

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.