### PR TITLE
Add control block domain to MAST hashing

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -21,6 +21,6 @@ std = ["math/std", "winter-utils/std", "winter-crypto/std"]
 
 [dependencies]
 math = { package = "winter-math", version = "0.4.2", default-features = false }
-crypto = { package = "miden-crypto", version = "0.1.0" }
+crypto = { package = "miden-crypto", version = "0.1.1", default-features = false }
 winter-crypto = { package = "winter-crypto", version = "0.4.2", default-features = false }
 winter-utils = { package = "winter-utils", version = "0.4.2", default-features = false }

--- a/core/src/chiplets/hasher.rs
+++ b/core/src/chiplets/hasher.rs
@@ -34,6 +34,9 @@ pub const STATE_COL_RANGE: Range<usize> = create_range(ROW_COL_IDX + 1, STATE_WI
 /// Number of field elements in the capacity portion of the hasher's state.
 pub const CAPACITY_LEN: usize = STATE_WIDTH - RATE_LEN;
 
+/// The index of the capacity register where the domain is set when initializing the hasher.
+pub const CAPACITY_DOMAIN_IDX: usize = 1;
+
 /// The capacity portion of the hasher state in the execution trace, located in 4 .. 8 columns.
 pub const CAPACITY_COL_RANGE: Range<usize> = Range {
     start: STATE_COL_RANGE.start,
@@ -130,6 +133,12 @@ pub fn merge(values: &[Digest; 2]) -> Digest {
     Hasher::merge(values)
 }
 
+/// Returns a hash of two digests with a specified domain.
+#[inline(always)]
+pub fn merge_in_domain(values: &[Digest; 2], domain: Felt) -> Digest {
+    Hasher::merge_in_domain(values, domain)
+}
+
 /// Returns a hash of the provided list of field elements.
 #[inline(always)]
 pub fn hash_elements(elements: &[Felt]) -> Digest {
@@ -186,7 +195,18 @@ pub fn init_state(init_values: &[Felt; RATE_LEN], padding_flag: Felt) -> [Felt; 
 /// the Rescue Prime Optimized padding rule.
 #[inline(always)]
 pub fn init_state_from_words(w1: &Word, w2: &Word) -> [Felt; STATE_WIDTH] {
-    [ZERO, ZERO, ZERO, ZERO, w1[0], w1[1], w1[2], w1[3], w2[0], w2[1], w2[2], w2[3]]
+    init_state_from_words_with_domain(w1, w2, ZERO)
+}
+
+/// Initializes hasher state with elements from the provided words.  Sets the second element of the
+/// capacity register to the provided domain.  All other elements of the capacity register are set to 0.
+#[inline(always)]
+pub fn init_state_from_words_with_domain(
+    w1: &Word,
+    w2: &Word,
+    domain: Felt,
+) -> [Felt; STATE_WIDTH] {
+    [ZERO, domain, ZERO, ZERO, w1[0], w1[1], w1[2], w1[3], w2[0], w2[1], w2[2], w2[3]]
 }
 
 /// Absorbs the specified values into the provided state by overwriting the corresponding elements

--- a/core/src/program/blocks/join_block.rs
+++ b/core/src/program/blocks/join_block.rs
@@ -1,4 +1,4 @@
-use super::{fmt, hasher, Box, CodeBlock, Digest};
+use super::{fmt, hasher, Box, CodeBlock, Digest, Felt, Operation};
 
 // JOIN BLOCKS
 // ================================================================================================
@@ -7,7 +7,6 @@ use super::{fmt, hasher, Box, CodeBlock, Digest};
 /// When the VM executes a Join block, it executes joined blocks in sequence one after the other.
 ///
 /// Hash of a Join block is computed by hashing a concatenation of the hashes of joined blocks.
-/// TODO: update hashing methodology to make it different from Split block.
 #[derive(Clone, Debug)]
 pub struct Join {
     body: Box<[CodeBlock; 2]>,
@@ -15,11 +14,16 @@ pub struct Join {
 }
 
 impl Join {
+    // CONSTANTS
+    // --------------------------------------------------------------------------------------------
+    /// The domain of the join block (used for control block hashing).
+    pub const DOMAIN: Felt = Felt::new(Operation::Join.op_code() as u64);
+
     // CONSTRUCTOR
     // --------------------------------------------------------------------------------------------
     /// Returns a new [Join] block instantiated with the specified code blocks.
     pub fn new(body: [CodeBlock; 2]) -> Self {
-        let hash = hasher::merge(&[body[0].hash(), body[1].hash()]);
+        let hash = hasher::merge_in_domain(&[body[0].hash(), body[1].hash()], Self::DOMAIN);
         Self {
             body: Box::new(body),
             hash,

--- a/core/src/program/blocks/loop_block.rs
+++ b/core/src/program/blocks/loop_block.rs
@@ -1,4 +1,4 @@
-use super::{fmt, hasher, Box, CodeBlock, Digest};
+use super::{fmt, hasher, Box, CodeBlock, Digest, Felt, Operation};
 
 // LOOP BLOCK
 // ================================================================================================
@@ -19,11 +19,16 @@ pub struct Loop {
 }
 
 impl Loop {
+    // CONSTANTS
+    // --------------------------------------------------------------------------------------------
+    /// The domain of the loop block (used for control block hashing).
+    pub const DOMAIN: Felt = Felt::new(Operation::Loop.op_code() as u64);
+
     // CONSTRUCTOR
     // --------------------------------------------------------------------------------------------
     /// Returns a new [Loop] bock instantiated with the specified body.
     pub fn new(body: CodeBlock) -> Self {
-        let hash = hasher::merge(&[body.hash(), Digest::default()]);
+        let hash = hasher::merge_in_domain(&[body.hash(), Digest::default()], Self::DOMAIN);
         Self {
             body: Box::new(body),
             hash,

--- a/core/src/program/blocks/mod.rs
+++ b/core/src/program/blocks/mod.rs
@@ -95,6 +95,18 @@ impl CodeBlock {
             CodeBlock::Proxy(block) => block.hash(),
         }
     }
+
+    /// Returns the domain of the code block
+    pub fn domain(&self) -> Felt {
+        match self {
+            CodeBlock::Call(block) => block.domain(),
+            CodeBlock::Join(_) => Join::DOMAIN,
+            CodeBlock::Loop(_) => Loop::DOMAIN,
+            CodeBlock::Span(_) => Span::DOMAIN,
+            CodeBlock::Split(_) => Split::DOMAIN,
+            CodeBlock::Proxy(_) => panic!("Can't fetch `domain` for a `Proxy` block!"),
+        }
+    }
 }
 
 impl fmt::Display for CodeBlock {

--- a/core/src/program/blocks/span_block.rs
+++ b/core/src/program/blocks/span_block.rs
@@ -43,6 +43,11 @@ pub struct Span {
 }
 
 impl Span {
+    // CONSTANTS
+    // --------------------------------------------------------------------------------------------
+    /// The domain of the span block (used for control block hashing).
+    pub const DOMAIN: Felt = Felt::ZERO;
+
     // CONSTRUCTOR
     // --------------------------------------------------------------------------------------------
     /// Returns a new [Span] block instantiated with the specified operations.

--- a/core/src/program/blocks/split_block.rs
+++ b/core/src/program/blocks/split_block.rs
@@ -1,4 +1,4 @@
-use super::{fmt, hasher, Box, CodeBlock, Digest};
+use super::{fmt, hasher, Box, CodeBlock, Digest, Felt, Operation};
 
 // SPLIT BLOCK
 // ================================================================================================
@@ -18,11 +18,16 @@ pub struct Split {
 }
 
 impl Split {
+    // CONSTANTS
+    // --------------------------------------------------------------------------------------------
+    /// The domain of the split block (used for control block hashing).
+    pub const DOMAIN: Felt = Felt::new(Operation::Split.op_code() as u64);
+
     // CONSTRUCTOR
     // --------------------------------------------------------------------------------------------
     /// Returns a new [Split] block instantiated with the specified true and false branches.
     pub fn new(t_branch: CodeBlock, f_branch: CodeBlock) -> Self {
-        let hash = hasher::merge(&[t_branch.hash(), f_branch.hash()]);
+        let hash = hasher::merge_in_domain(&[t_branch.hash(), f_branch.hash()], Self::DOMAIN);
         Self {
             branches: Box::new([t_branch, f_branch]),
             hash,

--- a/processor/src/chiplets/hasher/mod.rs
+++ b/processor/src/chiplets/hasher/mod.rs
@@ -4,10 +4,11 @@ use super::{
 };
 use vm_core::{
     chiplets::hasher::{
-        absorb_into_state, get_digest, init_state, init_state_from_words, Digest, Selectors,
-        HASH_CYCLE_LEN, LINEAR_HASH, LINEAR_HASH_LABEL, MP_VERIFY, MP_VERIFY_LABEL, MR_UPDATE_NEW,
-        MR_UPDATE_NEW_LABEL, MR_UPDATE_OLD, MR_UPDATE_OLD_LABEL, RETURN_HASH, RETURN_HASH_LABEL,
-        RETURN_STATE, RETURN_STATE_LABEL, STATE_WIDTH, TRACE_WIDTH,
+        absorb_into_state, get_digest, init_state, init_state_from_words,
+        init_state_from_words_with_domain, Digest, Selectors, HASH_CYCLE_LEN, LINEAR_HASH,
+        LINEAR_HASH_LABEL, MP_VERIFY, MP_VERIFY_LABEL, MR_UPDATE_NEW, MR_UPDATE_NEW_LABEL,
+        MR_UPDATE_OLD, MR_UPDATE_OLD_LABEL, RETURN_HASH, RETURN_HASH_LABEL, RETURN_STATE,
+        RETURN_STATE_LABEL, STATE_WIDTH, TRACE_WIDTH,
     },
     utils::collections::BTreeMap,
 };
@@ -140,11 +141,12 @@ impl Hasher {
         &mut self,
         h1: Word,
         h2: Word,
+        domain: Felt,
         expected_hash: Digest,
         lookups: &mut Vec<HasherLookup>,
     ) -> (Felt, Word) {
         let addr = self.trace.next_row_addr();
-        let mut state = init_state_from_words(&h1, &h2);
+        let mut state = init_state_from_words_with_domain(&h1, &h2, domain);
 
         // add the lookup for the hash initialization.
         let lookup = self.get_lookup(LINEAR_HASH_LABEL, ZERO, HasherLookupContext::Start);

--- a/processor/src/chiplets/hasher/tests.rs
+++ b/processor/src/chiplets/hasher/tests.rs
@@ -660,7 +660,8 @@ fn hash_memoization_control_blocks() {
 
     let mut lookups = Vec::new();
     // builds the trace of the join block.
-    let (_, final_state) = hasher.hash_control_block(h1, h2, expected_hash, &mut lookups);
+    let (_, final_state) =
+        hasher.hash_control_block(h1, h2, join_block.domain(), expected_hash, &mut lookups);
 
     let lookup_start_addr = 1;
     let expected_lookups_len = 2;
@@ -693,7 +694,8 @@ fn hash_memoization_control_blocks() {
 
     let mut lookups = Vec::new();
     // builds the hash execution trace of the first split block from scratch.
-    let (addr, final_state) = hasher.hash_control_block(h1, h2, expected_hash, &mut lookups);
+    let (addr, final_state) =
+        hasher.hash_control_block(h1, h2, split1_block.domain(), expected_hash, &mut lookups);
 
     let lookup_start_addr = 9;
     let expected_lookups_len = 2;
@@ -732,7 +734,8 @@ fn hash_memoization_control_blocks() {
     let mut lookups = Vec::new();
     // builds the hash execution trace of the second split block by copying it from the trace of
     // the first split block.
-    let (addr, final_state) = hasher.hash_control_block(h1, h2, expected_hash, &mut lookups);
+    let (addr, final_state) =
+        hasher.hash_control_block(h1, h2, split2_block.domain(), expected_hash, &mut lookups);
 
     let lookup_start_addr = 17;
     let expected_lookups_len = 2;
@@ -857,7 +860,8 @@ fn hash_memoization_span_blocks_check(span_block: CodeBlock) {
 
     let mut lookups = Vec::new();
     // builds the trace of the Join1 block.
-    let (_, final_state) = hasher.hash_control_block(h1, h2, expected_hash, &mut lookups);
+    let (_, final_state) =
+        hasher.hash_control_block(h1, h2, join1_block.domain(), expected_hash, &mut lookups);
 
     let lookup_start_addr = 1;
     let expected_lookups_len = 2;
@@ -887,7 +891,8 @@ fn hash_memoization_span_blocks_check(span_block: CodeBlock) {
     let expected_hash = join2_block.hash();
 
     let mut lookups = Vec::new();
-    let (_, final_state) = hasher.hash_control_block(h1, h2, expected_hash, &mut lookups);
+    let (_, final_state) =
+        hasher.hash_control_block(h1, h2, join2_block.domain(), expected_hash, &mut lookups);
 
     let lookup_start_addr = 9;
     let expected_lookups_len = 2;

--- a/processor/src/chiplets/mod.rs
+++ b/processor/src/chiplets/mod.rs
@@ -237,9 +237,16 @@ impl Chiplets {
     /// hash(h1, h2) against the provided `expected_result`.
     ///
     /// It returns the row address of the execution trace at which the hash computation started.
-    pub fn hash_control_block(&mut self, h1: Word, h2: Word, expected_hash: Digest) -> Felt {
+    pub fn hash_control_block(
+        &mut self,
+        h1: Word,
+        h2: Word,
+        domain: Felt,
+        expected_hash: Digest,
+    ) -> Felt {
         let mut lookups = Vec::new();
-        let (addr, result) = self.hasher.hash_control_block(h1, h2, expected_hash, &mut lookups);
+        let (addr, result) =
+            self.hasher.hash_control_block(h1, h2, domain, expected_hash, &mut lookups);
 
         // make sure the result computed by the hasher is the same as the expected block hash
         debug_assert_eq!(expected_hash, result.into());

--- a/processor/src/decoder/mod.rs
+++ b/processor/src/decoder/mod.rs
@@ -53,7 +53,9 @@ where
         // row addr + 7.
         let child1_hash = block.first().hash().into();
         let child2_hash = block.second().hash().into();
-        let addr = self.chiplets.hash_control_block(child1_hash, child2_hash, block.hash());
+        let addr =
+            self.chiplets
+                .hash_control_block(child1_hash, child2_hash, Join::DOMAIN, block.hash());
 
         // start decoding the JOIN block; this appends a row with JOIN operation to the decoder
         // trace. when JOIN operation is executed, the rest of the VM state does not change
@@ -86,7 +88,9 @@ where
         // row addr + 7.
         let child1_hash = block.on_true().hash().into();
         let child2_hash = block.on_false().hash().into();
-        let addr = self.chiplets.hash_control_block(child1_hash, child2_hash, block.hash());
+        let addr =
+            self.chiplets
+                .hash_control_block(child1_hash, child2_hash, Split::DOMAIN, block.hash());
 
         // start decoding the SPLIT block. this appends a row with SPLIT operation to the decoder
         // trace. we also pop the value off the top of the stack and return it.
@@ -120,7 +124,9 @@ where
         // hasher is used as the ID of the block; the result of the hash is expected to be in
         // row addr + 7.
         let body_hash = block.body().hash().into();
-        let addr = self.chiplets.hash_control_block(body_hash, [ZERO; 4], block.hash());
+        let addr =
+            self.chiplets
+                .hash_control_block(body_hash, [ZERO; 4], Loop::DOMAIN, block.hash());
 
         // start decoding the LOOP block; this appends a row with LOOP operation to the decoder
         // trace, but if the value on the top of the stack is not ONE, the block is not marked
@@ -169,7 +175,9 @@ where
         // returned by the hasher is used as the ID of the block; the result of the hash is
         // expected to be in row addr + 7.
         let fn_hash = block.fn_hash().into();
-        let addr = self.chiplets.hash_control_block(fn_hash, [ZERO; 4], block.hash());
+        let addr =
+            self.chiplets
+                .hash_control_block(fn_hash, [ZERO; 4], block.domain(), block.hash());
 
         // start new execution context for the operand stack. this has the effect of resetting
         // stack depth to 16.

--- a/processor/src/trace/tests/chiplets/hasher.rs
+++ b/processor/src/trace/tests/chiplets/hasher.rs
@@ -8,8 +8,8 @@ use core::ops::Range;
 use vm_core::{
     chiplets::{
         hasher::{
-            apply_permutation, init_state_from_words, HasherState, Selectors, CAPACITY_LEN,
-            DIGEST_RANGE, HASH_CYCLE_LEN, LINEAR_HASH, LINEAR_HASH_LABEL, MP_VERIFY,
+            apply_permutation, init_state_from_words, HasherState, Selectors, CAPACITY_DOMAIN_IDX,
+            CAPACITY_LEN, DIGEST_RANGE, HASH_CYCLE_LEN, LINEAR_HASH, LINEAR_HASH_LABEL, MP_VERIFY,
             MP_VERIFY_LABEL, MR_UPDATE_NEW, MR_UPDATE_NEW_LABEL, MR_UPDATE_OLD,
             MR_UPDATE_OLD_LABEL, RETURN_HASH, RETURN_HASH_LABEL, RETURN_STATE, RETURN_STATE_LABEL,
             STATE_WIDTH,
@@ -17,6 +17,7 @@ use vm_core::{
         HASHER_NODE_INDEX_COL_IDX, HASHER_ROW_COL_IDX, HASHER_STATE_COL_RANGE, HASHER_TRACE_OFFSET,
     },
     code_blocks::CodeBlock,
+    decoder::{NUM_OP_BITS, OP_BITS_OFFSET},
     utils::range,
     AdviceSet, StarkField, Word, DECODER_TRACE_OFFSET,
 };
@@ -28,6 +29,10 @@ const DECODER_HASHER_STATE_RANGE: Range<usize> = range(
     DECODER_TRACE_OFFSET + vm_core::decoder::HASHER_STATE_OFFSET,
     vm_core::decoder::NUM_HASHER_COLUMNS,
 );
+
+/// Location of operation bits columns relative to the main trace.
+pub const DECODER_OP_BITS_RANGE: Range<usize> =
+    range(DECODER_TRACE_OFFSET + OP_BITS_OFFSET, NUM_OP_BITS);
 
 // TESTS
 // ================================================================================================
@@ -53,7 +58,7 @@ pub fn b_chip_span() {
 
     // initialize the request state.
     let mut state = [ZERO; STATE_WIDTH];
-    fill_state_from_decoder(&trace, &mut state, 0);
+    fill_state_from_decoder_with_domain(&trace, &mut state, 0);
     // request the initialization of the span hash
     let request_init =
         build_expected(&alphas, LINEAR_HASH_LABEL, state, [ZERO; STATE_WIDTH], ONE, ZERO);
@@ -118,7 +123,7 @@ pub fn b_chip_span_with_respan() {
 
     // initialize the request state.
     let mut state = [ZERO; STATE_WIDTH];
-    fill_state_from_decoder(&trace, &mut state, 0);
+    fill_state_from_decoder_with_domain(&trace, &mut state, 0);
     // request the initialization of the span hash
     let request_init =
         build_expected(&alphas, LINEAR_HASH_LABEL, state, [ZERO; STATE_WIDTH], ONE, ZERO);
@@ -146,7 +151,8 @@ pub fn b_chip_span_with_respan() {
     apply_permutation(&mut state);
     let prev_state = state;
     // get the state with the next absorbed batch.
-    absorb_state_from_decoder(&trace, &mut state, 9);
+    fill_state_from_decoder(&trace, &mut state, 9);
+
     let request_respan =
         build_expected(&alphas, LINEAR_HASH_LABEL, prev_state, state, Felt::new(8), ZERO);
     expected *= request_respan.inv();
@@ -204,7 +210,7 @@ pub fn b_chip_merge() {
 
     // initialize the request state.
     let mut split_state = [ZERO; STATE_WIDTH];
-    fill_state_from_decoder(&trace, &mut split_state, 0);
+    fill_state_from_decoder_with_domain(&trace, &mut split_state, 0);
     // request the initialization of the span hash
     let split_init =
         build_expected(&alphas, LINEAR_HASH_LABEL, split_state, [ZERO; STATE_WIDTH], ONE, ZERO);
@@ -217,7 +223,7 @@ pub fn b_chip_merge() {
     // at cycle 1 the initialization of the span block hash for the false branch is requested by the
     // decoder
     let mut f_branch_state = [ZERO; STATE_WIDTH];
-    fill_state_from_decoder(&trace, &mut f_branch_state, 1);
+    fill_state_from_decoder_with_domain(&trace, &mut f_branch_state, 1);
     // request the initialization of the false branch hash
     let f_branch_init = build_expected(
         &alphas,
@@ -316,7 +322,7 @@ pub fn b_chip_permutation() {
 
     // initialize the request state.
     let mut span_state = [ZERO; STATE_WIDTH];
-    fill_state_from_decoder(&trace, &mut span_state, 0);
+    fill_state_from_decoder_with_domain(&trace, &mut span_state, 0);
     // request the initialization of the span hash
     let span_init =
         build_expected(&alphas, LINEAR_HASH_LABEL, span_state, [ZERO; STATE_WIDTH], ONE, ZERO);
@@ -430,7 +436,7 @@ fn b_chip_mpverify() {
 
     // initialize the request state.
     let mut span_state = [ZERO; STATE_WIDTH];
-    fill_state_from_decoder(&trace, &mut span_state, 0);
+    fill_state_from_decoder_with_domain(&trace, &mut span_state, 0);
     // request the initialization of the span hash
     let span_init =
         build_expected(&alphas, LINEAR_HASH_LABEL, span_state, [ZERO; STATE_WIDTH], ONE, ZERO);
@@ -631,17 +637,47 @@ fn get_label_from_selectors(selectors: Selectors) -> Option<u8> {
 
 /// Populates the provided HasherState with the state stored in the decoder's execution trace at the
 /// specified row.
+fn fill_state_from_decoder_with_domain(
+    trace: &ExecutionTrace,
+    state: &mut HasherState,
+    row: usize,
+) {
+    let domain = extract_control_block_domain_from_trace(trace, row);
+    state[CAPACITY_DOMAIN_IDX] = domain;
+
+    fill_state_from_decoder(trace, state, row);
+}
+
+/// Populates the provided HasherState with the state stored in the decoder's execution trace at the
+/// specified row.
 fn fill_state_from_decoder(trace: &ExecutionTrace, state: &mut HasherState, row: usize) {
     for (i, col_idx) in DECODER_HASHER_STATE_RANGE.enumerate() {
         state[CAPACITY_LEN + i] = trace.main_trace.get_column(col_idx)[row];
     }
 }
 
-/// Absorbs the elements specified in the decoder's execution trace helper columns at the specified
-/// row into the provided HasherState.
-fn absorb_state_from_decoder(trace: &ExecutionTrace, state: &mut HasherState, row: usize) {
-    for (i, col_idx) in DECODER_HASHER_STATE_RANGE.enumerate() {
-        state[CAPACITY_LEN + i] = trace.main_trace.get_column(col_idx)[row];
+/// Extract the control block domain from the execution trace.  This is achieved
+/// by calculating the op code as [bit_0 * 2**0 + bit_1 * 2**1 + ... + bit_6 * 2**6]
+fn extract_control_block_domain_from_trace(trace: &ExecutionTrace, row: usize) -> Felt {
+    // calculate the op code
+    let opcode_value = DECODER_OP_BITS_RANGE.rev().fold(0u8, |result, bit_index| {
+        let op_bit = trace.main_trace.get_column(bit_index)[row].as_int() as u8;
+        (result << 1) ^ op_bit
+    });
+
+    // opcode values that represent control block initialization (excluding span)
+    let control_block_initializers = [
+        Operation::Call.op_code(),
+        Operation::Join.op_code(),
+        Operation::Loop.op_code(),
+        Operation::Split.op_code(),
+        Operation::SysCall.op_code(),
+    ];
+
+    if control_block_initializers.contains(&opcode_value) {
+        Felt::from(opcode_value)
+    } else {
+        Felt::ZERO
     }
 }
 


### PR DESCRIPTION
This PR adds a domain specifier to the second element of the capacity register when hashing control blocks using Rescue prime optimised in Miden.  This is to avoid hash collisions of different programs when constructing a MAST.   The domain is calculated using bitwise composition of the opcode bits as such `[bit_0 * 2**0 + bit_1 * 2**1 + ... + bit_6 * 2**6 + 1]`.

closes: #605 

- [x] Implement domain separation for control block hashing.
- [x] Investigate communication bus logic (hasher chiplet)
- [x] Investigate and update communication bus constraints and value calculation in decoder (deferred to follow-up PR)