### PR TITLE
Add process accessors

### DIFF
--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -439,4 +439,34 @@ where
             self.advice_provider,
         )
     }
+
+    /// Returns the process system.
+    pub fn system(&self) -> &System {
+        &self.system
+    }
+
+    /// Returns the process decoder.
+    pub fn decoder(&self) -> &Decoder {
+        &self.decoder
+    }
+
+    /// Returns the process stack.
+    pub fn stack(&self) -> &Stack {
+        &self.stack
+    }
+
+    /// Returns the process range checker.
+    pub fn range(&self) -> &RangeChecker {
+        &self.range
+    }
+
+    /// Returns the process chiplets.
+    pub fn chiplets(&self) -> &Chiplets {
+        &self.chiplets
+    }
+
+    /// Returns the process advice provider.
+    pub fn advice_provider(&self) -> &A {
+        &self.advice_provider
+    }
 }


### PR DESCRIPTION
## Describe your changes

The `Process` already has a method called `into_parts` that returns a tuple with each of these elements. However that makes for awkward code when only one element is necessary, e.g.:

```rust
    let stack_output = process.into_parts().2.build_stack_outputs();
    let final_stack = stack_output.stack();
```

This PR adds individual accessors, to remove the tuple indexing above and make the code a tiny bit clearer:

```rust
    let stack_output = process.stack().build_stack_outputs();
    let final_stack = stack_output.stack();
```

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.