### PR TITLE
Assembly constants

### DIFF
--- a/assembly/src/lib.rs
+++ b/assembly/src/lib.rs
@@ -22,6 +22,7 @@ use procedures::{CallSet, Procedure};
 pub use procedures::{ProcedureId, ProcedureName};
 
 mod parsers;
+use parsers::PROCEDURE_LABEL_PARSER;
 pub use parsers::{parse_module, parse_program, ModuleAst, ProcedureAst, ProgramAst};
 
 mod serde;
@@ -31,9 +32,7 @@ mod tokens;
 use tokens::{Token, TokenStream};
 
 mod errors;
-pub use errors::{
-    AssemblyError, LibraryError, ParsingError, ProcedureNameError, SerializationError,
-};
+pub use errors::{AssemblyError, LabelError, LibraryError, ParsingError, SerializationError};
 
 mod assembler;
 pub use assembler::Assembler;
@@ -67,8 +66,8 @@ const MAX_U32_ROTATE_VALUE: u8 = 31;
 /// The maximum number of bits allowed for the exponent parameter for exponentiation instructions.
 const MAX_EXP_BITS: u8 = 64;
 
-/// The maximum length of a procedure's name.
-const MAX_PROC_NAME_LEN: u8 = 100;
+/// The maximum length of a constant or procedure's label.
+const MAX_LABEL_LEN: u8 = 100;
 
 /// The required length of the hexadecimal representation for an input value when more than one hex
 /// input is provided to `push` masm operation without period separators.

--- a/assembly/src/parsers/context.rs
+++ b/assembly/src/parsers/context.rs
@@ -1,6 +1,6 @@
 use super::{
-    adv_ops, field_ops, io_ops, stack_ops, u32_ops, AbsolutePath, Instruction, LocalProcMap, Node,
-    ParsingError, ProcedureAst, ProcedureId, Token, TokenStream,
+    adv_ops, field_ops, io_ops, stack_ops, u32_ops, AbsolutePath, Instruction, LocalConstMap,
+    LocalProcMap, Node, ParsingError, ProcedureAst, ProcedureId, Token, TokenStream,
 };
 use vm_core::utils::{
     collections::{BTreeMap, Vec},
@@ -15,6 +15,7 @@ use vm_core::utils::{
 pub struct ParserContext {
     pub imports: BTreeMap<String, AbsolutePath>,
     pub local_procs: LocalProcMap,
+    pub local_constants: LocalConstMap,
 }
 
 impl ParserContext {
@@ -462,7 +463,7 @@ impl ParserContext {
             "cdropw" => simple_instruction(op, CDropW),
 
             // ----- input / output operations ----------------------------------------------------
-            "push" => io_ops::parse_push(op),
+            "push" => io_ops::parse_push(op, &self.local_constants),
 
             "sdepth" => simple_instruction(op, Sdepth),
             "locaddr" => io_ops::parse_locaddr(op),
@@ -500,6 +501,9 @@ impl ParserContext {
             "exec" => self.parse_exec(op),
             "call" => self.parse_call(op),
             "syscall" => self.parse_syscall(op),
+
+            // ----- constant statements ----------------------------------------------------------
+            "const" => Err(ParsingError::const_invalid_scope(op)),
 
             // ----- catch all --------------------------------------------------------------------
             _ => Err(ParsingError::invalid_op(op)),

--- a/assembly/src/parsers/labels.rs
+++ b/assembly/src/parsers/labels.rs
@@ -1,0 +1,63 @@
+use super::{LabelError, MAX_LABEL_LEN};
+
+// LABEL PARSERS
+// ================================================================================================
+
+/// Constant label parser
+pub const CONSTANT_LABEL_PARSER: LabelParser = LabelParser {
+    caps: true,
+    max_len: MAX_LABEL_LEN,
+    numbers_letters_underscore: true,
+    start_with_letter: true,
+};
+
+/// Procedure label parser
+pub const PROCEDURE_LABEL_PARSER: LabelParser = LabelParser {
+    caps: false,
+    max_len: MAX_LABEL_LEN,
+    numbers_letters_underscore: true,
+    start_with_letter: true,
+};
+
+// LABEL PARSER IMPLEMENTATION
+// ================================================================================================
+
+/// Struct that specifies the rules for parsing labels.
+pub struct LabelParser {
+    pub caps: bool,
+    pub max_len: u8,
+    pub numbers_letters_underscore: bool,
+    pub start_with_letter: bool,
+}
+
+impl LabelParser {
+    /// Parses a label and verifies that is passes label conventions.
+    /// This is used for procedures and constants.
+    ///
+    /// Returns an error if label violates the rules.
+    pub fn parse_label(&self, label: String) -> Result<String, LabelError> {
+        if label.is_empty() {
+            // label cannot be empty
+            return Err(LabelError::empty_label());
+        } else if label.len() > self.max_len as usize {
+            // label cannot be more than 100 characters long
+            return Err(LabelError::label_too_long(&label, self.max_len));
+        } else if self.start_with_letter && !label.chars().next().unwrap().is_ascii_alphabetic() {
+            // label must start with a letter
+            return Err(LabelError::invalid_fist_letter(&label));
+        } else if self.numbers_letters_underscore
+            && !label.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+        {
+            // label can consists only of numbers, letters, and underscores
+            return Err(LabelError::invalid_label(&label));
+        } else if self.caps
+            && !label
+                .chars()
+                .all(|c| !c.is_alphabetic() || (c.is_alphabetic() && c.is_uppercase()))
+        {
+            // all letters must be uppercase
+            return Err(LabelError::must_be_uppercase(&label));
+        }
+        Ok(label)
+    }
+}

--- a/assembly/src/tokens/mod.rs
+++ b/assembly/src/tokens/mod.rs
@@ -29,6 +29,7 @@ impl<'a> Token<'a> {
     // CONTROL TOKENS
     // --------------------------------------------------------------------------------------------
 
+    pub const CONST: &'static str = "const";
     pub const USE: &'static str = "use";
     pub const WHILE: &'static str = "while";
 
@@ -37,7 +38,7 @@ impl<'a> Token<'a> {
     /// Returns a new token created from the specified string and position.
     ///
     /// # Panics
-    /// Panic is the `token` parameter is an empty string.
+    /// Panic if the `token` parameter is an empty string.
     pub fn new(token: &'a str, pos: usize) -> Self {
         assert!(!token.is_empty(), "token cannot be an empty string");
         Self {

--- a/docs/src/user_docs/assembly/code_organization.md
+++ b/docs/src/user_docs/assembly/code_organization.md
@@ -92,6 +92,24 @@ In the above example we import `std::math::u64` module from the [standard librar
 
 The set of modules which can be imported by a program can be specified via a Module Provider when instantiating the [Miden Assembler](https://crates.io/crates/miden-assembly) used to compile the program.
 
+### Constants
+Miden assembly supports constant declarations. These constants are scoped to the module they are defined in and can be used as immediate parameters for Miden assembly instructions. Currently only `push` instruction supports this.
+
+Constants must be declared right after module imports and before any procedures or program bodies. A constant's name must start with an upper-case letter and can contain any combination of numbers, upper-case ASCII letters, and underscores (`_`). The number of characters in a constant name cannot exceed 100.
+
+```
+use.std::math::u64
+
+const.CONSTANT_1=100
+const.CONSTANT_2=200
+
+begin
+    push.CONSTANT_1.CONSTANT_2
+    exec.u64::checked_add
+end
+
+```
+
 ### Comments
 Miden assembly allows annotating code with simple comments. There are two types of comments: single-line comments which start with a `#` (pound) character, and documentation comments which start with `#!` characters. For example:
 ```


### PR DESCRIPTION
This PR adds basic functionality that allows for the declaration of constants.  The current implementation allows for constants to be defined below imports and above any procedures / begin bodies.  The constants are scoped to the file they are defined in.  At the current point in time constants are only available to the push operation.

Example:
```
const.ONE_TWO=12
const.FIVE_SIX=56

begin
    push.ONE_TWO.FIVE_SIX
    mul
end
```
