### PR TITLE
Introduce `hash` assembly instruction

### DIFF
--- a/assembly/src/assembler/instruction/mod.rs
+++ b/assembly/src/assembler/instruction/mod.rs
@@ -290,6 +290,7 @@ impl Assembler {
             Instruction::AdvExt2INTT => span.add_decorator(Decorator::Advice(Ext2INTT)),
 
             // ----- cryptographic instructions ---------------------------------------------------
+            Instruction::Hash => crypto_ops::hash(span),
             Instruction::HPerm => span.add_op(HPerm),
             Instruction::HMerge => crypto_ops::hmerge(span),
             Instruction::MTreeGet => crypto_ops::mtree_get(span),

--- a/assembly/src/parsers/context.rs
+++ b/assembly/src/parsers/context.rs
@@ -491,6 +491,7 @@ impl ParserContext {
             "adv" => adv_ops::parse_adv_inject(op),
 
             // ----- cryptographic operations -----------------------------------------------------
+            "hash" => simple_instruction(op, Hash),
             "hmerge" => simple_instruction(op, HMerge),
             "hperm" => simple_instruction(op, HPerm),
 

--- a/assembly/src/parsers/nodes.rs
+++ b/assembly/src/parsers/nodes.rs
@@ -261,6 +261,7 @@ pub enum Instruction {
     AdvExt2INTT,
 
     // ----- cryptographic operations -------------------------------------------------------------
+    Hash,
     HMerge,
     HPerm,
     MTreeGet,
@@ -522,6 +523,7 @@ impl fmt::Display for Instruction {
             Self::AdvExt2INTT => write!(f, "adv.ext2intt"),
 
             // ----- cryptographic operations -----------------------------------------------------
+            Self::Hash => write!(f, "hash"),
             Self::HMerge => write!(f, "hmerge"),
             Self::HPerm => write!(f, "hperm"),
             Self::MTreeGet => write!(f, "mtree_get"),

--- a/assembly/src/parsers/serde/deserialization.rs
+++ b/assembly/src/parsers/serde/deserialization.rs
@@ -319,6 +319,7 @@ impl Deserializable for Instruction {
             OpCode::AdvExt2INTT => Ok(Instruction::AdvExt2INTT),
 
             // ----- cryptographic operations -----------------------------------------------------
+            OpCode::Hash => Ok(Instruction::Hash),
             OpCode::HMerge => Ok(Instruction::HMerge),
             OpCode::HPerm => Ok(Instruction::HPerm),
             OpCode::MTreeGet => Ok(Instruction::MTreeGet),

--- a/assembly/src/parsers/serde/mod.rs
+++ b/assembly/src/parsers/serde/mod.rs
@@ -257,18 +257,19 @@ pub enum OpCode {
     AdvExt2INTT = 227,
 
     // ----- cryptographic operations -------------------------------------------------------------
-    HMerge = 228,
-    HPerm = 229,
-    MTreeGet = 230,
-    MTreeSet = 231,
-    MTreeCwm = 232,
+    Hash = 228,
+    HMerge = 229,
+    HPerm = 230,
+    MTreeGet = 231,
+    MTreeSet = 232,
+    MTreeCwm = 233,
 
     // ----- exec / call --------------------------------------------------------------------------
-    ExecLocal = 233,
-    ExecImported = 234,
-    CallLocal = 235,
-    CallImported = 236,
-    SysCall = 237,
+    ExecLocal = 234,
+    ExecImported = 235,
+    CallLocal = 236,
+    CallImported = 237,
+    SysCall = 238,
 
     // ----- control flow -------------------------------------------------------------------------
     IfElse = 253,

--- a/assembly/src/parsers/serde/serialization.rs
+++ b/assembly/src/parsers/serde/serialization.rs
@@ -436,6 +436,7 @@ impl Serializable for Instruction {
             Self::AdvExt2INTT => OpCode::AdvExt2INTT.write_into(target)?,
 
             // ----- cryptographic operations -----------------------------------------------------
+            Self::Hash => OpCode::Hash.write_into(target)?,
             Self::HMerge => OpCode::HMerge.write_into(target)?,
             Self::HPerm => OpCode::HPerm.write_into(target)?,
             Self::MTreeGet => OpCode::MTreeGet.write_into(target)?,

--- a/docs/src/user_docs/assembly/cryptographic_operations.md
+++ b/docs/src/user_docs/assembly/cryptographic_operations.md
@@ -6,6 +6,7 @@ Miden assembly provides a set of instructions for performing common cryptographi
 
 | Instruction    | Stack_input     | Stack_output   | Notes                                      |
 | -------------- | --------------- | -------------- | ------------------------------------------ |
+| hash <br> - *(20 cycles)*  | [A, ...] | [B, ...] | $\{B\} \leftarrow hash(A)$ <BR> where, $hash()$ computes a 1-to-1 Rescue Prime Optimized hash. |
 | hperm  <br> - *(1 cycle)*      | [C, B, A, ...]  | [F, E, D, ...] | $\{D, E, F\} \leftarrow permute(A, B, C)$ <br> where, $permute()$ computes a Rescue Prime Optimized permutation. |
 | hmerge  <br> - *(16 cycles)*        | [B, A, ...]     | [C, ...]       | $C \leftarrow hash(A,B)$ <br> where, $hash()$ computes a 2-to-1 Rescue Prime Optimized hash. |
 | mtree_get  <br> - *(9 cycles)*     | [d, i, R, ...]  | [V, R, ...] |  Verifies that a Merkle tree with root $R$ opens to node $V$ at depth $d$ and index $i$. Merkle tree with root $R$ must be present in the advice provider, otherwise execution fails. |

--- a/miden/tests/integration/operations/crypto_ops.rs
+++ b/miden/tests/integration/operations/crypto_ops.rs
@@ -11,6 +11,20 @@ use crate::helpers::crypto::{init_merkle_leaf, init_merkle_leaves};
 // ================================================================================================
 
 #[test]
+fn hash() {
+    let asm_op = "hash";
+
+    // --- test hashing 4 random values -----------------------------------------------------------
+    let random_values = rand_vector::<u64>(4);
+    let expected = build_expected_hash(&random_values);
+
+    let test = build_op_test!(asm_op, &random_values);
+    let last_state = test.get_last_stack_state();
+
+    assert_eq!(expected, &last_state[..4]);
+}
+
+#[test]
 fn hperm() {
     let asm_op = "hperm";
 


### PR DESCRIPTION
Introduce a new assembly instruction `hash` which performs a 1-to-1 hash using an Rpo permutation.  This PR migrates the 1-to-1 hashing logic from [this](https://github.com/0xPolygonMiden/miden-vm/blob/9092607c758183cee571713638faeab200e1fda7/stdlib/asm/crypto/hashes/rescue_prime.masm) masm script with a modification to the way in which the capacity register is instantiated.  The first element is instantiated to 0 in accordance with the new Rpo hashing rules. 