### PR TITLE
Repeat statements with u32 parameters

### DIFF
--- a/assembly/src/parsers/nodes.rs
+++ b/assembly/src/parsers/nodes.rs
@@ -9,7 +9,7 @@ use core::fmt;
 pub enum Node {
     Instruction(Instruction),
     IfElse(Vec<Node>, Vec<Node>),
-    Repeat(u16, Vec<Node>),
+    Repeat(u32, Vec<Node>),
     While(Vec<Node>),
 }
 

--- a/assembly/src/parsers/serde/deserialization.rs
+++ b/assembly/src/parsers/serde/deserialization.rs
@@ -18,7 +18,7 @@ impl Deserializable for Node {
             ))
         } else if first_byte == OpCode::Repeat as u8 {
             bytes.read_u8()?;
-            Ok(Node::Repeat(bytes.read_u16()?, Deserializable::read_from(bytes)?))
+            Ok(Node::Repeat(bytes.read_u32()?, Deserializable::read_from(bytes)?))
         } else if first_byte == OpCode::While as u8 {
             bytes.read_u8()?;
             Ok(Node::While(Deserializable::read_from(bytes)?))

--- a/assembly/src/parsers/serde/serialization.rs
+++ b/assembly/src/parsers/serde/serialization.rs
@@ -14,7 +14,7 @@ impl Serializable for Node {
             }
             Self::Repeat(times, nodes) => {
                 OpCode::Repeat.write_into(target)?;
-                target.write_u16(*times);
+                target.write_u32(*times);
                 nodes.write_into(target)
             }
             Self::While(nodes) => {

--- a/assembly/src/tokens/mod.rs
+++ b/assembly/src/tokens/mod.rs
@@ -163,12 +163,12 @@ impl<'a> Token<'a> {
         }
     }
 
-    pub fn parse_repeat(&self) -> Result<u16, ParsingError> {
+    pub fn parse_repeat(&self) -> Result<u32, ParsingError> {
         assert_eq!(Self::REPEAT, self.parts[0], "not a repeat");
         match self.num_parts() {
             0 => unreachable!(),
             1 => Err(ParsingError::missing_param(self)),
-            2 => self.parts[1].parse::<u16>().map_err(|_| ParsingError::invalid_param(self, 1)),
+            2 => self.parts[1].parse::<u32>().map_err(|_| ParsingError::invalid_param(self, 1)),
             _ => Err(ParsingError::extra_param(self)),
         }
     }


### PR DESCRIPTION
This PR enabled `repeat` statements with `u32` parameter specifying the number of iteration (before this PR, this was limited to `u16`).