### PR TITLE
Procedure length, check before cast

### DIFF
--- a/assembly/src/errors.rs
+++ b/assembly/src/errors.rs
@@ -525,7 +525,7 @@ pub enum LabelError {
     EmptyLabel,
     InvalidFirstLetter(String),
     InvalidChars(String),
-    LabelTooLong(String, u8),
+    LabelTooLong(String, usize),
     Uppercase(String),
 }
 
@@ -542,7 +542,7 @@ impl LabelError {
         Self::InvalidFirstLetter(label.to_string())
     }
 
-    pub fn label_too_long(label: &str, max_len: u8) -> Self {
+    pub fn label_too_long(label: &str, max_len: usize) -> Self {
         Self::LabelTooLong(label.to_string(), max_len)
     }
 

--- a/assembly/src/lib.rs
+++ b/assembly/src/lib.rs
@@ -68,7 +68,7 @@ const MAX_U32_ROTATE_VALUE: u8 = 31;
 const MAX_EXP_BITS: u8 = 64;
 
 /// The maximum length of a constant or procedure's label.
-const MAX_LABEL_LEN: u8 = 100;
+const MAX_LABEL_LEN: usize = 100;
 
 /// The required length of the hexadecimal representation for an input value when more than one hex
 /// input is provided to `push` masm operation without period separators.

--- a/assembly/src/parsers/labels.rs
+++ b/assembly/src/parsers/labels.rs
@@ -25,7 +25,7 @@ pub const PROCEDURE_LABEL_PARSER: LabelParser = LabelParser {
 /// Struct that specifies the rules for parsing labels.
 pub struct LabelParser {
     pub caps: bool,
-    pub max_len: u8,
+    pub max_len: usize,
     pub numbers_letters_underscore: bool,
     pub start_with_letter: bool,
 }
@@ -39,7 +39,7 @@ impl LabelParser {
         if label.is_empty() {
             // label cannot be empty
             return Err(LabelError::empty_label());
-        } else if label.len() > self.max_len as usize {
+        } else if label.len() > self.max_len {
             // label cannot be more than 100 characters long
             return Err(LabelError::label_too_long(&label, self.max_len));
         } else if self.start_with_letter && !label.chars().next().unwrap().is_ascii_alphabetic() {

--- a/assembly/src/procedures/mod.rs
+++ b/assembly/src/procedures/mod.rs
@@ -1,6 +1,6 @@
 use super::{
     crypto::hash::Blake3_192, AbsolutePath, BTreeSet, ByteReader, ByteWriter, CodeBlock,
-    Deserializable, LabelError, Serializable, SerializationError, String, ToString, MAX_LABEL_LEN,
+    Deserializable, LabelError, Serializable, SerializationError, String, ToString,
     MODULE_PATH_DELIM, PROCEDURE_LABEL_PARSER,
 };
 use core::{
@@ -162,12 +162,14 @@ impl AsRef<str> for ProcedureName {
 impl Serializable for ProcedureName {
     fn write_into(&self, target: &mut ByteWriter) -> Result<(), SerializationError> {
         let name_bytes = self.name.as_bytes();
-        let num_bytes = name_bytes.len() as u8;
-        if num_bytes > MAX_LABEL_LEN {
-            return Err(SerializationError::LengthTooLong);
-        }
+        let num_bytes = name_bytes.len();
 
-        target.write_u8(num_bytes);
+        debug_assert!(
+            PROCEDURE_LABEL_PARSER.parse_label(self.name.clone()).is_ok(),
+            "The constructor should ensure the length is within limits"
+        );
+
+        target.write_u8(num_bytes as u8);
         target.write_bytes(name_bytes);
         Ok(())
     }
@@ -314,7 +316,7 @@ impl ops::Deref for CallSet {
 
 #[cfg(test)]
 mod test {
-    use super::{LabelError, ProcedureName, MAX_LABEL_LEN};
+    use super::{super::MAX_LABEL_LEN, LabelError, ProcedureName};
 
     #[test]
     fn test_procedure_name_max_len() {

--- a/assembly/src/procedures/mod.rs
+++ b/assembly/src/procedures/mod.rs
@@ -311,3 +311,19 @@ impl ops::Deref for CallSet {
         &self.0
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::{LabelError, ProcedureName, MAX_LABEL_LEN};
+
+    #[test]
+    fn test_procedure_name_max_len() {
+        assert!(ProcedureName::try_from("a".to_owned()).is_ok());
+
+        let long = "a".repeat(256);
+        assert_eq!(
+            ProcedureName::try_from(long.clone()),
+            Err(LabelError::LabelTooLong(long, MAX_LABEL_LEN))
+        );
+    }
+}


### PR DESCRIPTION
## Describe your changes

numeric casts truncate the data, so the comparison should be done against the `usize` and then converted to the smaller representation.

Note: This is not user observable issue, the `TryFrom` implementation checks the length already. This adds a test to make sure that is not lost and makes it clearer to someone reading the code that this was thought of.

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.