### PR TITLE
feat: implement Deserializable for ProgramInfo

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -23,3 +23,7 @@ std = ["math/std", "winter-utils/std"]
 math = { package = "winter-math", version = "0.5", default-features = false }
 crypto = { package = "miden-crypto", version = "0.1", default-features = false }
 winter-utils = { package = "winter-utils", version = "0.5", default-features = false }
+
+[dev-dependencies]
+proptest = "1.1.0"
+rand_utils = { version = "0.5", package = "winter-rand-utils" }

--- a/core/src/program/info.rs
+++ b/core/src/program/info.rs
@@ -1,4 +1,7 @@
-use super::{ByteWriter, Digest, Kernel, Program, Serializable};
+use super::{
+    ByteReader, ByteWriter, Deserializable, DeserializationError, Digest, Kernel, Program,
+    Serializable,
+};
 
 // PROGRAM INFO
 // ================================================================================================
@@ -64,5 +67,16 @@ impl Serializable for ProgramInfo {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
         self.program_hash.write_into(target);
         <Kernel as Serializable>::write_into(&self.kernel, target);
+    }
+}
+
+impl Deserializable for ProgramInfo {
+    fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
+        let program_hash = source.read()?;
+        let kernel = source.read()?;
+        Ok(Self {
+            program_hash,
+            kernel,
+        })
     }
 }

--- a/core/src/program/tests.rs
+++ b/core/src/program/tests.rs
@@ -1,0 +1,39 @@
+use super::{Deserializable, Digest, Felt, Kernel, ProgramInfo, Serializable};
+use crate::Word;
+use proptest::prelude::*;
+use rand_utils::prng_array;
+
+proptest! {
+    #[test]
+    fn arbitrary_program_info_serialization_works(
+        kernel_count in prop::num::u8::ANY,
+        ref seed in any::<[u8; 32]>()
+    ) {
+        let program_hash = digest_from_seed(*seed);
+        let kernel: Vec<Digest> = (0..kernel_count)
+            .scan(*seed, |seed, _| {
+                *seed = prng_array(*seed);
+                Some(digest_from_seed(*seed))
+            })
+            .collect();
+        let kernel = Kernel::new(&kernel);
+        let program_info = ProgramInfo::new(program_hash, kernel);
+        let bytes = program_info.to_bytes();
+        let deser = ProgramInfo::read_from_bytes(&bytes).unwrap();
+        assert_eq!(program_info, deser);
+    }
+}
+
+// HELPER FUNCTIONS
+// --------------------------------------------------------------------------------------------
+
+fn digest_from_seed(seed: [u8; 32]) -> Digest {
+    let mut digest = Word::default();
+    digest.iter_mut().enumerate().for_each(|(i, d)| {
+        *d = <[u8; 8]>::try_from(&seed[i * 8..(i + 1) * 8])
+            .map(u64::from_le_bytes)
+            .map(Felt::new)
+            .unwrap()
+    });
+    digest.into()
+}


### PR DESCRIPTION
Currently, `ProgramInfo` implements only `Serializable`. It is so to keep the coupling between winter-utils and miden minimal, as the serialization traits are defined in winterfell.

However, this might create some challenges for consumers of miden-vm as they might have to deserialize the struct, such as when representing the type within other targets (i.e. WASM).

This commit introduces Deserializable for Kernel and ProgramInfo.

related issue: #731 