### PR TITLE
Enable debug mode on assembler for debugger

### DIFF
--- a/miden/src/cli/compile.rs
+++ b/miden/src/cli/compile.rs
@@ -17,7 +17,7 @@ impl CompileCmd {
         println!("============================================================");
 
         // load and compile program file
-        let program = ProgramFile::read(&self.assembly_file)?;
+        let program = ProgramFile::read(&self.assembly_file, false)?;
 
         // report program hash to user
         let program_hash: [u8; 32] = program.hash().into();

--- a/miden/src/cli/data.rs
+++ b/miden/src/cli/data.rs
@@ -164,7 +164,7 @@ pub struct ProgramFile;
 
 /// Helper methods to interact with masm program file
 impl ProgramFile {
-    pub fn read(path: &PathBuf) -> Result<Program, String> {
+    pub fn read(path: &PathBuf, debug: bool) -> Result<Program, String> {
         println!("Reading program file `{}`", path.display());
 
         // read program file to string
@@ -178,6 +178,7 @@ impl ProgramFile {
         let program = Assembler::default()
             .with_library(&StdLibrary::default())
             .map_err(|err| format!("Failed to load stdlib - {}", err))?
+            .with_debug_mode(debug)
             .compile(&program_file)
             .map_err(|err| format!("Failed to compile program - {}", err))?;
 

--- a/miden/src/cli/debug/mod.rs
+++ b/miden/src/cli/debug/mod.rs
@@ -30,7 +30,7 @@ impl DebugCmd {
         println!("============================================================");
 
         // load program from file and compile
-        let program = ProgramFile::read(&self.assembly_file)?;
+        let program = ProgramFile::read(&self.assembly_file, true)?;
 
         let program_hash: [u8; 32] = program.hash().into();
         println!("Debugging program with hash {}... ", hex::encode(program_hash));

--- a/miden/src/cli/prove.rs
+++ b/miden/src/cli/prove.rs
@@ -48,7 +48,7 @@ impl ProveCmd {
             .init();
 
         // load program from file and compile
-        let program = ProgramFile::read(&self.assembly_file)?;
+        let program = ProgramFile::read(&self.assembly_file, false)?;
 
         // load input data from file
         let input_data = InputFile::read(&self.input_file, &self.assembly_file)?;

--- a/miden/src/cli/run.rs
+++ b/miden/src/cli/run.rs
@@ -26,7 +26,7 @@ impl RunCmd {
         println!("============================================================");
 
         // load program from file and compile
-        let program = ProgramFile::read(&self.assembly_file)?;
+        let program = ProgramFile::read(&self.assembly_file, false)?;
 
         // load input data from file
         let input_data = InputFile::read(&self.input_file, &self.assembly_file)?;


### PR DESCRIPTION
This PR enables debug mode on the assembler for the debugger.  This enables the debugger to map VM execution to the corresponding assembly instruction and provide this information to the user.
