### PR TITLE
feat: add breakpoint instruction

### DIFF
--- a/assembly/src/assembler/context.rs
+++ b/assembly/src/assembler/context.rs
@@ -250,10 +250,17 @@ impl AssemblyContext {
     // HELPER METHODS
     // --------------------------------------------------------------------------------------------
 
-    /// Returns the context of the procedure currently being complied, or None if module or
+    /// Returns the context of the procedure currently being compiled, or None if module or
     /// procedure stacks are empty.
     fn current_proc_context(&self) -> Option<&ProcedureContext> {
         self.module_stack.last().and_then(|m| m.proc_stack.last())
+    }
+
+    /// Returns the name of the current procedure, or the reserved name for the main block.
+    pub(crate) fn current_context_name(&self) -> &str {
+        self.current_proc_context()
+            .map(|p| p.name().as_ref())
+            .expect("library compilation mode is currently not supported!")
     }
 }
 
@@ -476,6 +483,13 @@ impl ProcedureContext {
 
     pub fn is_main(&self) -> bool {
         self.name.is_main()
+    }
+
+    /// Returns the current context name.
+    ///
+    /// Check [AssemblyContext::current_context_name] for reference.
+    pub const fn name(&self) -> &ProcedureName {
+        &self.name
     }
 
     pub fn into_procedure(self, id: ProcedureId, code_root: CodeBlock) -> Procedure {

--- a/assembly/src/assembler/instruction/mod.rs
+++ b/assembly/src/assembler/instruction/mod.rs
@@ -34,7 +34,7 @@ impl Assembler {
         // this will allow us to map the instruction to the sequence of operations which were
         // executed as a part of this instruction.
         if self.in_debug_mode() {
-            span.track_instruction(instruction);
+            span.track_instruction(instruction, ctx);
         }
 
         let result = match instruction {
@@ -306,6 +306,15 @@ impl Assembler {
             Instruction::CallLocal(idx) => self.call_local(*idx, ctx),
             Instruction::CallImported(id) => self.call_imported(id, ctx),
             Instruction::SysCall(id) => self.syscall(id, ctx),
+
+            // ----- debug decorators -------------------------------------------------------------
+            Instruction::Breakpoint => {
+                if self.in_debug_mode() {
+                    span.add_op(Noop)?;
+                    span.track_instruction(instruction, ctx);
+                }
+                Ok(None)
+            }
         };
 
         // compute and update the cycle count of the instruction which just finished executing

--- a/assembly/src/assembler/span_builder.rs
+++ b/assembly/src/assembler/span_builder.rs
@@ -1,6 +1,6 @@
 use super::{
-    AssemblyError, BodyWrapper, Borrow, CodeBlock, Decorator, DecoratorList, Instruction,
-    Operation, ToString, Vec,
+    AssemblyContext, AssemblyError, BodyWrapper, Borrow, CodeBlock, Decorator, DecoratorList,
+    Instruction, Operation, ToString, Vec,
 };
 use vm_core::AssemblyOp;
 
@@ -102,8 +102,12 @@ impl SpanBuilder {
     ///
     /// This indicates that the provided instruction should be tracked and the cycle count for
     /// this instruction will be computed when the call to set_instruction_cycle_count() is made.
-    pub fn track_instruction(&mut self, instruction: &Instruction) {
-        let op = AssemblyOp::new(instruction.to_string(), 0);
+    pub fn track_instruction(&mut self, instruction: &Instruction, ctx: &mut AssemblyContext) {
+        let context_name = ctx.current_context_name().to_string();
+        let num_cycles = 0;
+        let op = instruction.to_string();
+        let should_break = instruction.should_break();
+        let op = AssemblyOp::new(context_name, num_cycles, op, should_break);
         self.push_decorator(Decorator::AsmOp(op));
         self.last_asmop_pos = self.decorators.len() - 1;
     }

--- a/assembly/src/parsers/context.rs
+++ b/assembly/src/parsers/context.rs
@@ -511,6 +511,9 @@ impl ParserContext {
             // ----- constant statements ----------------------------------------------------------
             "const" => Err(ParsingError::const_invalid_scope(op)),
 
+            // ----- debug decorators -------------------------------------------------------------
+            "breakpoint" => simple_instruction(op, Breakpoint),
+
             // ----- catch all --------------------------------------------------------------------
             _ => Err(ParsingError::invalid_op(op)),
         }

--- a/assembly/src/parsers/nodes.rs
+++ b/assembly/src/parsers/nodes.rs
@@ -277,6 +277,16 @@ pub enum Instruction {
     CallLocal(u16),
     CallImported(ProcedureId),
     SysCall(ProcedureId),
+
+    // ----- debug decorators ---------------------------------------------------------------------
+    Breakpoint,
+}
+
+impl Instruction {
+    /// Returns true if the instruction should yield a breakpoint.
+    pub const fn should_break(&self) -> bool {
+        matches!(self, Self::Breakpoint)
+    }
 }
 
 impl fmt::Display for Instruction {
@@ -543,6 +553,9 @@ impl fmt::Display for Instruction {
             Self::CallLocal(index) => write!(f, "call.{index}"),
             Self::CallImported(proc_id) => write!(f, "call.{proc_id}"),
             Self::SysCall(proc_id) => write!(f, "syscall.{proc_id}"),
+
+            // ----- debug decorators -------------------------------------------------------------
+            Self::Breakpoint => write!(f, "breakpoint"),
         }
     }
 }

--- a/assembly/src/parsers/serde/serialization.rs
+++ b/assembly/src/parsers/serde/serialization.rs
@@ -467,6 +467,11 @@ impl Serializable for Instruction {
                 OpCode::SysCall.write_into(target)?;
                 imported.write_into(target)?
             }
+
+            // ----- debug decorators -------------------------------------------------------------
+            Self::Breakpoint => {
+                // this is a transparent instruction and will not be encoded into the library
+            }
         }
         Ok(())
     }

--- a/core/src/operations/decorators/assembly_op.rs
+++ b/core/src/operations/decorators/assembly_op.rs
@@ -1,4 +1,5 @@
 use crate::utils::string::String;
+use core::fmt;
 
 // ASSEMBLY OP
 // ================================================================================================
@@ -6,25 +7,42 @@ use crate::utils::string::String;
 /// Contains information corresponding to an assembly instruction (only applicable in debug mode).
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct AssemblyOp {
-    op: String,
+    context_name: String,
     num_cycles: u8,
+    op: String,
+    should_break: bool,
 }
 
 impl AssemblyOp {
     /// Returns [AssemblyOp] instantiated with the specified assembly instruction string and number
     /// of cycles it takes to execute the assembly instruction.
-    pub fn new(op: String, num_cycles: u8) -> Self {
-        Self { op, num_cycles }
+    pub fn new(context_name: String, num_cycles: u8, op: String, should_break: bool) -> Self {
+        Self {
+            context_name,
+            num_cycles,
+            op,
+            should_break,
+        }
     }
 
-    /// Returns the assembly instruction corresponding to this decorator.
-    pub fn op(&self) -> &String {
-        &self.op
+    /// Returns the context name for this operation.
+    pub fn context_name(&self) -> &str {
+        &self.context_name
     }
 
     /// Returns the number of VM cycles taken to execute the assembly instruction of this decorator.
-    pub fn num_cycles(&self) -> u8 {
+    pub const fn num_cycles(&self) -> u8 {
         self.num_cycles
+    }
+
+    /// Returns the assembly instruction corresponding to this decorator.
+    pub fn op(&self) -> &str {
+        &self.op
+    }
+
+    /// Returns `true` if there is a breakpoint for the current operation.
+    pub const fn should_break(&self) -> bool {
+        self.should_break
     }
 
     // STATE MUTATORS
@@ -33,5 +51,15 @@ impl AssemblyOp {
     /// Change cycles corresponding to an AsmOp decorator to the specified number of cycles.
     pub fn set_num_cycles(&mut self, num_cycles: u8) {
         self.num_cycles = num_cycles;
+    }
+}
+
+impl fmt::Display for AssemblyOp {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "context={}, operation={}, cost={}",
+            self.context_name, self.op, self.num_cycles,
+        )
     }
 }

--- a/docs/src/intro/usage.md
+++ b/docs/src/intro/usage.md
@@ -65,23 +65,60 @@ This will dump the output of the program into the `fib.out` file. The output fil
 
 ### Miden Debugger
 
-The Miden debugger is a shell that allow for efficient debugging of miden assembly programs that are sourced from file.  A Miden assembly program file and inputs are specified when the debugger is instantiated.  The debugger allows the user to step through the execution of the program with clock cycle granularity and provides the ability for virtual machine state inspection at each clock cycle.  The Miden debugger supports the following commands:
+The Miden debugger is a command-line interface (CLI) application, inspired on [GNU gdb](https://sourceware.org/gdb/), that allows debugging of Miden assembly (MASM) programs. The debugger allows the user to step through the execution of the program, both forward and backward, either per clock cycle tick, or via breakpoints.
+
+The Miden debugger supports the following commands:
+
+| Command | Shortcut | Arguments | Description |
+| --- | --- | --- | --- |
+| next | n | count? | Steps `count` clock cycles. Will step `1` cycle of `count` is ommitted. |
+| continue | c | - | Executes the program until completion, failure or a breakpoint. |
+| back | b | count? | Backward step `count` clock cycles. Will back-step `1` cycle of `count` is ommitted. |
+| rewind | r | - | Executes the program backwards until the beginning, failure or a breakpoint. |
+| print | p | - | Displays the complete state of the virtual machine. |
+| print mem | p m | address? | Displays the memory value at `address`. If `address` is ommitted, didisplays all the memory values. |
+| print stack | p s | index? | Displays the stack value at `index`. If `index` is ommitted, displays all the stack values. |
+| clock | c | - | Displays the current clock cycle. |
+| quit | q | - | Quits the debugger. |
+| help | h | - | Displays the help message. |
+
+In order to start debugging, the user should provide a `MASM` program:
+
+```shell
+cargo run --features executable -- debug --assembly miden/examples/nprime/nprime.masm
+```
+
+The expected output is:
 
 ```
-!next        steps to the next clock cycle
-!play        executes program until completion or failure
-!play.n      executes n clock cycles
-!prev        steps to the previous clock cycle
-!rewind      rewinds program until beginning
-!rewind.n    rewinds n clock cycles
-!print       displays the complete state of the virtual machine
-!stack       displays the complete state of the stack
-!stack[i]    displays the stack element at index i
-!mem         displays the complete state of memory
-!mem[i]      displays memory at address i
-!clock       displays the current clock cycle
-!quit        quits the debugger
-!help        displays this message
+============================================================
+Debug program
+============================================================
+Reading program file `miden/examples/nprime/nprime.masm`
+Compiling program... done (16 ms)
+Debugging program with hash 11dbbddff27e26e48be3198133df8cbed6c5875d0fb
+606c9f037c7893fde4118... 
+Reading input file `miden/examples/nprime/nprime.inputs`
+Welcome! Enter `h` for help.
+>> 
+```
+
+In order to add a breakpoint, the user should insert a `breakpoint` instruction into the MASM file. This will generate a `Noop` operation that will be decorated with the debug break configuration. This is a provisory solution until the source mapping is implemented.
+
+The following example will halt on the third instruction of `foo`:
+
+```
+proc.foo
+    dup
+    dup.2
+    breakpoint
+    swap
+    add.1
+end
+
+begin
+    exec.foo
+end
 ```
 
 ### REPL

--- a/miden/src/cli/debug/command.rs
+++ b/miden/src/cli/debug/command.rs
@@ -3,8 +3,8 @@
 pub enum DebugCommand {
     Continue,
     Next(usize),
-    RewindAll,
-    Rewind(usize),
+    Rewind,
+    Back(usize),
     PrintState,
     PrintStack,
     PrintStackItem(usize),
@@ -36,7 +36,7 @@ impl DebugCommand {
             "n" | "next" => Self::parse_next(tokens.by_ref())?,
             "c" | "continue" => Self::Continue,
             "b" | "back" => Self::parse_back(tokens.by_ref())?,
-            "r" | "rewind" => Self::RewindAll,
+            "r" | "rewind" => Self::Rewind,
             "p" | "print" => Self::parse_print(tokens.by_ref())?,
             "l" | "clock" => Self::Clock,
             "h" | "?" | "help" => Self::Help,
@@ -89,9 +89,9 @@ impl DebugCommand {
                     n, err
                 )
             })?,
-            None => return Ok(Self::Rewind(1)),
+            None => return Ok(Self::Back(1)),
         };
-        Ok(Self::Rewind(num_cycles))
+        Ok(Self::Back(num_cycles))
     }
 
     /// parse print command - p [m|s] [addr]

--- a/miden/tests/integration/exec_iters.rs
+++ b/miden/tests/integration/exec_iters.rs
@@ -1,6 +1,6 @@
 use super::build_debug_test;
 use processor::{AsmOpInfo, VmState};
-use vm_core::{utils::ToElements, Felt, FieldElement, Operation};
+use vm_core::{utils::ToElements, AssemblyOp, Felt, FieldElement, Operation};
 
 // EXEC ITER TESTS
 // =================================================================
@@ -39,7 +39,10 @@ fn test_exec_iter() {
             clk: 2,
             ctx: 0,
             op: Some(Operation::Pad),
-            asmop: Some(AsmOpInfo::new("mem_storew.1".to_string(), 3, 1)),
+            asmop: Some(AsmOpInfo::new(
+                AssemblyOp::new("#main".to_string(), 3, "mem_storew.1".to_string(), false),
+                1,
+            )),
             stack: [0, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1].to_elements(),
             fmp,
             memory: Vec::new(),
@@ -48,7 +51,10 @@ fn test_exec_iter() {
             clk: 3,
             ctx: 0,
             op: Some(Operation::Incr),
-            asmop: Some(AsmOpInfo::new("mem_storew.1".to_string(), 3, 2)),
+            asmop: Some(AsmOpInfo::new(
+                AssemblyOp::new("#main".to_string(), 3, "mem_storew.1".to_string(), false),
+                2,
+            )),
             stack: [1, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2].to_elements(),
             fmp,
             memory: Vec::new(),
@@ -57,7 +63,10 @@ fn test_exec_iter() {
             clk: 4,
             ctx: 0,
             op: Some(Operation::MStoreW),
-            asmop: Some(AsmOpInfo::new("mem_storew.1".to_string(), 3, 3)),
+            asmop: Some(AsmOpInfo::new(
+                AssemblyOp::new("#main".to_string(), 3, "mem_storew.1".to_string(), false),
+                3,
+            )),
             stack: [16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1].to_elements(),
             fmp,
             memory: mem.clone(),
@@ -66,7 +75,10 @@ fn test_exec_iter() {
             clk: 5,
             ctx: 0,
             op: Some(Operation::Drop),
-            asmop: Some(AsmOpInfo::new("dropw".to_string(), 4, 1)),
+            asmop: Some(AsmOpInfo::new(
+                AssemblyOp::new("#main".to_string(), 4, "dropw".to_string(), false),
+                1,
+            )),
             stack: [15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0].to_elements(),
             fmp,
             memory: mem.clone(),
@@ -75,7 +87,10 @@ fn test_exec_iter() {
             clk: 6,
             ctx: 0,
             op: Some(Operation::Drop),
-            asmop: Some(AsmOpInfo::new("dropw".to_string(), 4, 2)),
+            asmop: Some(AsmOpInfo::new(
+                AssemblyOp::new("#main".to_string(), 4, "dropw".to_string(), false),
+                2,
+            )),
             stack: [14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0].to_elements(),
             fmp,
             memory: mem.clone(),
@@ -84,7 +99,10 @@ fn test_exec_iter() {
             clk: 7,
             ctx: 0,
             op: Some(Operation::Drop),
-            asmop: Some(AsmOpInfo::new("dropw".to_string(), 4, 3)),
+            asmop: Some(AsmOpInfo::new(
+                AssemblyOp::new("#main".to_string(), 4, "dropw".to_string(), false),
+                3,
+            )),
             stack: [13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0].to_elements(),
             fmp,
             memory: mem.clone(),
@@ -93,7 +111,10 @@ fn test_exec_iter() {
             clk: 8,
             ctx: 0,
             op: Some(Operation::Drop),
-            asmop: Some(AsmOpInfo::new("dropw".to_string(), 4, 4)),
+            asmop: Some(AsmOpInfo::new(
+                AssemblyOp::new("#main".to_string(), 4, "dropw".to_string(), false),
+                4,
+            )),
             stack: [12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0].to_elements(),
             fmp,
             memory: mem.clone(),
@@ -102,7 +123,10 @@ fn test_exec_iter() {
             clk: 9,
             ctx: 0,
             op: Some(Operation::Push(Felt::new(17))),
-            asmop: Some(AsmOpInfo::new("push.17".to_string(), 1, 1)),
+            asmop: Some(AsmOpInfo::new(
+                AssemblyOp::new("#main".to_string(), 1, "push.17".to_string(), false),
+                1,
+            )),
             stack: [17, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0].to_elements(),
             fmp,
             memory: mem.clone(),
@@ -138,7 +162,10 @@ fn test_exec_iter() {
             clk: 13,
             ctx: 0,
             op: Some(Operation::Pad),
-            asmop: Some(AsmOpInfo::new("loc_store.0".to_string(), 4, 1)),
+            asmop: Some(AsmOpInfo::new(
+                AssemblyOp::new("foo".to_string(), 4, "loc_store.0".to_string(), false),
+                1,
+            )),
             stack: [0, 17, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0].to_elements(),
             fmp: next_fmp,
             memory: mem.clone(),
@@ -147,7 +174,10 @@ fn test_exec_iter() {
             clk: 14,
             ctx: 0,
             op: Some(Operation::FmpAdd),
-            asmop: Some(AsmOpInfo::new("loc_store.0".to_string(), 4, 2)),
+            asmop: Some(AsmOpInfo::new(
+                AssemblyOp::new("foo".to_string(), 4, "loc_store.0".to_string(), false),
+                2,
+            )),
             stack: [2u64.pow(30) + 1, 17, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0]
                 .to_elements(),
             fmp: next_fmp,
@@ -157,7 +187,10 @@ fn test_exec_iter() {
             clk: 15,
             ctx: 0,
             op: Some(Operation::MStore),
-            asmop: Some(AsmOpInfo::new("loc_store.0".to_string(), 4, 3)),
+            asmop: Some(AsmOpInfo::new(
+                AssemblyOp::new("foo".to_string(), 4, "loc_store.0".to_string(), false),
+                3,
+            )),
             stack: [17, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0].to_elements(),
             fmp: next_fmp,
             memory: vec![
@@ -169,7 +202,10 @@ fn test_exec_iter() {
             clk: 16,
             ctx: 0,
             op: Some(Operation::Drop),
-            asmop: Some(AsmOpInfo::new("loc_store.0".to_string(), 4, 4)),
+            asmop: Some(AsmOpInfo::new(
+                AssemblyOp::new("foo".to_string(), 4, "loc_store.0".to_string(), false),
+                4,
+            )),
             stack: [12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0].to_elements(),
             fmp: next_fmp,
             memory: vec![

--- a/miden/tests/integration/operations/decorators/asmop.rs
+++ b/miden/tests/integration/operations/decorators/asmop.rs
@@ -1,6 +1,6 @@
 use crate::build_debug_test;
 use processor::{AsmOpInfo, VmStateIterator};
-use vm_core::{Felt, Operation};
+use vm_core::{AssemblyOp, Felt, Operation};
 
 #[test]
 fn asmop_one_span_block_test() {
@@ -20,22 +20,34 @@ fn asmop_one_span_block_test() {
         },
         VmStatePartial {
             clk: 2,
-            asmop: Some(AsmOpInfo::new("push.1".to_string(), 2, 1)),
+            asmop: Some(AsmOpInfo::new(
+                AssemblyOp::new("#main".to_string(), 2, "push.1".to_string(), false),
+                1,
+            )),
             op: Some(Operation::Pad),
         },
         VmStatePartial {
             clk: 3,
-            asmop: Some(AsmOpInfo::new("push.1".to_string(), 2, 2)),
+            asmop: Some(AsmOpInfo::new(
+                AssemblyOp::new("#main".to_string(), 2, "push.1".to_string(), false),
+                2,
+            )),
             op: Some(Operation::Incr),
         },
         VmStatePartial {
             clk: 4,
-            asmop: Some(AsmOpInfo::new("push.2".to_string(), 1, 1)),
+            asmop: Some(AsmOpInfo::new(
+                AssemblyOp::new("#main".to_string(), 1, "push.2".to_string(), false),
+                1,
+            )),
             op: Some(Operation::Push(Felt::new(2))),
         },
         VmStatePartial {
             clk: 5,
-            asmop: Some(AsmOpInfo::new("add".to_string(), 1, 1)),
+            asmop: Some(AsmOpInfo::new(
+                AssemblyOp::new("#main".to_string(), 1, "add".to_string(), false),
+                1,
+            )),
             op: Some(Operation::Add),
         },
         VmStatePartial {
@@ -66,22 +78,34 @@ fn asmop_with_one_procedure() {
         },
         VmStatePartial {
             clk: 2,
-            asmop: Some(AsmOpInfo::new("push.1".to_string(), 2, 1)),
+            asmop: Some(AsmOpInfo::new(
+                AssemblyOp::new("foo".to_string(), 2, "push.1".to_string(), false),
+                1,
+            )),
             op: Some(Operation::Pad),
         },
         VmStatePartial {
             clk: 3,
-            asmop: Some(AsmOpInfo::new("push.1".to_string(), 2, 2)),
+            asmop: Some(AsmOpInfo::new(
+                AssemblyOp::new("foo".to_string(), 2, "push.1".to_string(), false),
+                2,
+            )),
             op: Some(Operation::Incr),
         },
         VmStatePartial {
             clk: 4,
-            asmop: Some(AsmOpInfo::new("push.2".to_string(), 1, 1)),
+            asmop: Some(AsmOpInfo::new(
+                AssemblyOp::new("foo".to_string(), 1, "push.2".to_string(), false),
+                1,
+            )),
             op: Some(Operation::Push(Felt::new(2))),
         },
         VmStatePartial {
             clk: 5,
-            asmop: Some(AsmOpInfo::new("add".to_string(), 1, 1)),
+            asmop: Some(AsmOpInfo::new(
+                AssemblyOp::new("foo".to_string(), 1, "add".to_string(), false),
+                1,
+            )),
             op: Some(Operation::Add),
         },
         VmStatePartial {
@@ -116,62 +140,98 @@ fn asmop_repeat_test() {
         },
         VmStatePartial {
             clk: 2,
-            asmop: Some(AsmOpInfo::new("push.1".to_string(), 2, 1)),
+            asmop: Some(AsmOpInfo::new(
+                AssemblyOp::new("#main".to_string(), 2, "push.1".to_string(), false),
+                1,
+            )),
             op: Some(Operation::Pad),
         },
         VmStatePartial {
             clk: 3,
-            asmop: Some(AsmOpInfo::new("push.1".to_string(), 2, 2)),
+            asmop: Some(AsmOpInfo::new(
+                AssemblyOp::new("#main".to_string(), 2, "push.1".to_string(), false),
+                2,
+            )),
             op: Some(Operation::Incr),
         },
         VmStatePartial {
             clk: 4,
-            asmop: Some(AsmOpInfo::new("push.2".to_string(), 1, 1)),
+            asmop: Some(AsmOpInfo::new(
+                AssemblyOp::new("#main".to_string(), 1, "push.2".to_string(), false),
+                1,
+            )),
             op: Some(Operation::Push(Felt::new(2))),
         },
         VmStatePartial {
             clk: 5,
-            asmop: Some(AsmOpInfo::new("add".to_string(), 1, 1)),
+            asmop: Some(AsmOpInfo::new(
+                AssemblyOp::new("#main".to_string(), 1, "add".to_string(), false),
+                1,
+            )),
             op: Some(Operation::Add),
         },
         VmStatePartial {
             clk: 6,
-            asmop: Some(AsmOpInfo::new("push.1".to_string(), 2, 1)),
+            asmop: Some(AsmOpInfo::new(
+                AssemblyOp::new("#main".to_string(), 2, "push.1".to_string(), false),
+                1,
+            )),
             op: Some(Operation::Pad),
         },
         VmStatePartial {
             clk: 7,
-            asmop: Some(AsmOpInfo::new("push.1".to_string(), 2, 2)),
+            asmop: Some(AsmOpInfo::new(
+                AssemblyOp::new("#main".to_string(), 2, "push.1".to_string(), false),
+                2,
+            )),
             op: Some(Operation::Incr),
         },
         VmStatePartial {
             clk: 8,
-            asmop: Some(AsmOpInfo::new("push.2".to_string(), 1, 1)),
+            asmop: Some(AsmOpInfo::new(
+                AssemblyOp::new("#main".to_string(), 1, "push.2".to_string(), false),
+                1,
+            )),
             op: Some(Operation::Push(Felt::new(2))),
         },
         VmStatePartial {
             clk: 9,
-            asmop: Some(AsmOpInfo::new("add".to_string(), 1, 1)),
+            asmop: Some(AsmOpInfo::new(
+                AssemblyOp::new("#main".to_string(), 1, "add".to_string(), false),
+                1,
+            )),
             op: Some(Operation::Add),
         },
         VmStatePartial {
             clk: 10,
-            asmop: Some(AsmOpInfo::new("push.1".to_string(), 2, 1)),
+            asmop: Some(AsmOpInfo::new(
+                AssemblyOp::new("#main".to_string(), 2, "push.1".to_string(), false),
+                1,
+            )),
             op: Some(Operation::Pad),
         },
         VmStatePartial {
             clk: 11,
-            asmop: Some(AsmOpInfo::new("push.1".to_string(), 2, 2)),
+            asmop: Some(AsmOpInfo::new(
+                AssemblyOp::new("#main".to_string(), 2, "push.1".to_string(), false),
+                2,
+            )),
             op: Some(Operation::Incr),
         },
         VmStatePartial {
             clk: 12,
-            asmop: Some(AsmOpInfo::new("push.2".to_string(), 1, 1)),
+            asmop: Some(AsmOpInfo::new(
+                AssemblyOp::new("#main".to_string(), 1, "push.2".to_string(), false),
+                1,
+            )),
             op: Some(Operation::Push(Felt::new(2))),
         },
         VmStatePartial {
             clk: 13,
-            asmop: Some(AsmOpInfo::new("add".to_string(), 1, 1)),
+            asmop: Some(AsmOpInfo::new(
+                AssemblyOp::new("#main".to_string(), 1, "add".to_string(), false),
+                1,
+            )),
             op: Some(Operation::Add),
         },
         VmStatePartial {
@@ -231,7 +291,10 @@ fn asmop_conditional_execution_test() {
         },
         VmStatePartial {
             clk: 3,
-            asmop: Some(AsmOpInfo::new("eq".to_string(), 1, 1)),
+            asmop: Some(AsmOpInfo::new(
+                AssemblyOp::new("#main".to_string(), 1, "eq".to_string(), false),
+                1,
+            )),
             op: Some(Operation::Eq),
         },
         VmStatePartial {
@@ -251,22 +314,34 @@ fn asmop_conditional_execution_test() {
         },
         VmStatePartial {
             clk: 7,
-            asmop: Some(AsmOpInfo::new("push.1".to_string(), 2, 1)),
+            asmop: Some(AsmOpInfo::new(
+                AssemblyOp::new("#main".to_string(), 2, "push.1".to_string(), false),
+                1,
+            )),
             op: Some(Operation::Pad),
         },
         VmStatePartial {
             clk: 8,
-            asmop: Some(AsmOpInfo::new("push.1".to_string(), 2, 2)),
+            asmop: Some(AsmOpInfo::new(
+                AssemblyOp::new("#main".to_string(), 2, "push.1".to_string(), false),
+                2,
+            )),
             op: Some(Operation::Incr),
         },
         VmStatePartial {
             clk: 9,
-            asmop: Some(AsmOpInfo::new("push.2".to_string(), 1, 1)),
+            asmop: Some(AsmOpInfo::new(
+                AssemblyOp::new("#main".to_string(), 1, "push.2".to_string(), false),
+                1,
+            )),
             op: Some(Operation::Push(Felt::new(2))),
         },
         VmStatePartial {
             clk: 10,
-            asmop: Some(AsmOpInfo::new("add".to_string(), 1, 1)),
+            asmop: Some(AsmOpInfo::new(
+                AssemblyOp::new("#main".to_string(), 1, "add".to_string(), false),
+                1,
+            )),
             op: Some(Operation::Add),
         },
         VmStatePartial {
@@ -309,7 +384,10 @@ fn asmop_conditional_execution_test() {
         },
         VmStatePartial {
             clk: 3,
-            asmop: Some(AsmOpInfo::new("eq".to_string(), 1, 1)),
+            asmop: Some(AsmOpInfo::new(
+                AssemblyOp::new("#main".to_string(), 1, "eq".to_string(), false),
+                1,
+            )),
             op: Some(Operation::Eq),
         },
         VmStatePartial {
@@ -329,17 +407,26 @@ fn asmop_conditional_execution_test() {
         },
         VmStatePartial {
             clk: 7,
-            asmop: Some(AsmOpInfo::new("push.3".to_string(), 1, 1)),
+            asmop: Some(AsmOpInfo::new(
+                AssemblyOp::new("#main".to_string(), 1, "push.3".to_string(), false),
+                1,
+            )),
             op: Some(Operation::Push(Felt::new(3))),
         },
         VmStatePartial {
             clk: 8,
-            asmop: Some(AsmOpInfo::new("push.4".to_string(), 1, 1)),
+            asmop: Some(AsmOpInfo::new(
+                AssemblyOp::new("#main".to_string(), 1, "push.4".to_string(), false),
+                1,
+            )),
             op: Some(Operation::Push(Felt::new(4))),
         },
         VmStatePartial {
             clk: 9,
-            asmop: Some(AsmOpInfo::new("add".to_string(), 1, 1)),
+            asmop: Some(AsmOpInfo::new(
+                AssemblyOp::new("#main".to_string(), 1, "add".to_string(), false),
+                1,
+            )),
             op: Some(Operation::Add),
         },
         VmStatePartial {

--- a/processor/src/debug.rs
+++ b/processor/src/debug.rs
@@ -3,7 +3,10 @@ use crate::{
     System, Vec,
 };
 use core::fmt;
-use vm_core::{utils::string::String, Operation, StackOutputs, Word};
+use vm_core::{
+    utils::string::{String, ToString},
+    AssemblyOp, Operation, StackOutputs, Word,
+};
 
 /// VmState holds a current process state information at a specific clock cycle.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -24,8 +27,17 @@ impl fmt::Display for VmState {
             self.memory.iter().map(|x| (x.0, word_to_ints(&x.1))).collect();
         write!(
             f,
-            "clk={}, op={:?}, asmop={:?}, fmp={}, stack={stack:?}, memory={memory:?}",
-            self.clk, self.op, self.asmop, self.fmp
+            "clk={}{}{}, fmp={}, stack={stack:?}, memory={memory:?}",
+            self.clk,
+            match self.op {
+                Some(op) => format!(", op={op}"),
+                None => "".to_string(),
+            },
+            match &self.asmop {
+                Some(op) => format!(", {op}"),
+                None => "".to_string(),
+            },
+            self.fmp
         )
     }
 }
@@ -75,19 +87,21 @@ impl VmStateIterator {
 
         // keeps track of the next assembly op in the list. It's the same as the current asmop
         // when the current asmop is last in the list
-        let next_asmop = if self.asmop_idx < assembly_ops.len() {
+        let next_asmop = if self.forward && self.asmop_idx < assembly_ops.len() {
             &assembly_ops[self.asmop_idx]
         } else {
-            &assembly_ops[self.asmop_idx - 1]
+            &assembly_ops[self.asmop_idx.saturating_sub(1)]
         };
 
         // keeps track of the current assembly op in the list. It's the same as the next asmop
         // when the clock cycle is less than the clock cycle of the first asmop.
         let (curr_asmop, cycle_idx) = if self.asmop_idx > 0 {
+            let a = self.clk;
+            let b = assembly_ops[self.asmop_idx - 1].0 as u32;
             (
                 &assembly_ops[self.asmop_idx - 1],
                 // difference between current clock cycle and start clock cycle of the current asmop
-                (self.clk - assembly_ops[self.asmop_idx - 1].0 as u32) as u8,
+                (a.max(b) - a.min(b)) as u8,
             )
         } else {
             (next_asmop, 0) //dummy value, never used.
@@ -96,29 +110,63 @@ impl VmStateIterator {
         // if this is the first op in the sequence corresponding to the next asmop, returns a new
         // instance of [AsmOp] instantiated with next asmop, num_cycles and cycle_idx of 1.
         if next_asmop.0 as u32 == self.clk - 1 {
-            let asmop = Some(AsmOpInfo::new(
-                next_asmop.1.op().clone(),
-                next_asmop.1.num_cycles(),
-                1, // cycle_idx starts at 1 instead of 0 to remove ambiguity
-            ));
-            (asmop, true)
+            // cycle_idx starts at 1 instead of 0 to remove ambiguity
+            let cycle_idx = 1;
+            let asmop = AsmOpInfo::new(next_asmop.1.clone(), cycle_idx);
+            (Some(asmop), true)
         }
         // if this is not the first asmop in the list and if this op is part of current asmop,
         // returns a new instance of [AsmOp] instantiated with current asmop, num_cycles and
         // cycle_idx of current op.
         else if self.asmop_idx > 0 && cycle_idx <= curr_asmop.1.num_cycles() {
-            let asmop = Some(AsmOpInfo::new(
-                curr_asmop.1.op().clone(),
-                curr_asmop.1.num_cycles(),
-                cycle_idx, /* diff between curr clock cycle and start clock cycle of the current asmop */
-            ));
-            (asmop, false)
+            // diff between curr clock cycle and start clock cycle of the current asmop
+            let asmop = AsmOpInfo::new(curr_asmop.1.clone(), cycle_idx);
+            (Some(asmop), false)
         }
         // if the next asmop is the first in the list and is at a greater than current clock cycle
         // or if the current op is not a part of any asmop, return None.
         else {
             (None, false)
         }
+    }
+
+    pub fn back(&mut self) -> Option<VmState> {
+        if self.clk == 0 {
+            return None;
+        }
+
+        // if we are changing directions we must decrement the clk counter.
+        if self.forward {
+            self.clk = self.clk.saturating_sub(1);
+            self.forward = false;
+        }
+
+        let ctx = self.system.get_ctx_at(self.clk);
+
+        let op = if self.clk == 0 {
+            None
+        } else {
+            Some(self.decoder.debug_info().operations()[self.clk as usize - 1])
+        };
+
+        let (asmop, is_start) = self.get_asmop();
+        if is_start {
+            self.asmop_idx -= 1;
+        }
+
+        let result = Some(VmState {
+            clk: self.clk,
+            ctx,
+            op,
+            asmop,
+            fmp: self.system.get_fmp_at(self.clk),
+            stack: self.stack.get_state_at(self.clk),
+            memory: self.chiplets.get_mem_state_at(ctx, self.clk),
+        });
+
+        self.clk -= 1;
+
+        result
     }
 }
 
@@ -171,45 +219,6 @@ impl Iterator for VmStateIterator {
     }
 }
 
-impl DoubleEndedIterator for VmStateIterator {
-    fn next_back(&mut self) -> Option<Self::Item> {
-        if self.clk == 0 {
-            return None;
-        }
-
-        self.clk -= 1;
-
-        // if we are changing directions we must decrement the clk counter.
-        if self.forward && self.clk > 0 {
-            self.clk -= 1;
-            self.forward = false;
-        }
-
-        let ctx = self.system.get_ctx_at(self.clk);
-
-        let op = if self.clk == 0 {
-            None
-        } else {
-            Some(self.decoder.debug_info().operations()[self.clk as usize - 1])
-        };
-
-        let (asmop, is_start) = self.get_asmop();
-        if is_start {
-            self.asmop_idx -= 1;
-        }
-
-        Some(Ok(VmState {
-            clk: self.clk,
-            ctx,
-            op,
-            asmop,
-            fmp: self.system.get_fmp_at(self.clk),
-            stack: self.stack.get_state_at(self.clk),
-            memory: self.chiplets.get_mem_state_at(ctx, self.clk),
-        }))
-    }
-}
-
 // HELPER FUNCTIONS
 // ================================================================================================
 fn word_to_ints(word: &Word) -> [u64; 4] {
@@ -220,8 +229,7 @@ fn word_to_ints(word: &Word) -> [u64; 4] {
 /// AsmOp decorator. This index starts from 1 instead of 0.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct AsmOpInfo {
-    op: String,
-    num_cycles: u8,
+    asmop: AssemblyOp,
     cycle_idx: u8,
 }
 
@@ -232,38 +240,50 @@ impl AsmOpInfo {
     /// Returns [AsmOpInfo] instantiated with the specified assembly instruction string, number of
     /// cycles it takes to execute the assembly instruction and op index in sequence of operations
     /// corresponding to the current assembly instruction. The first index is 1 instead of 0.
-    pub fn new(op: String, num_cycles: u8, cycle_idx: u8) -> Self {
-        Self {
-            op,
-            num_cycles,
-            cycle_idx,
-        }
+    pub fn new(asmop: AssemblyOp, cycle_idx: u8) -> Self {
+        Self { asmop, cycle_idx }
+    }
+
+    /// Returns the context name for this operation.
+    pub fn context_name(&self) -> &str {
+        self.asmop.context_name()
     }
 
     /// Returns the assembly instruction corresponding to this state.
-    pub fn op(&self) -> &String {
-        &self.op
+    pub fn op(&self) -> &str {
+        self.asmop.op()
     }
 
     /// Returns the gerneralized form of assembly instruction corresponding to this state.
     pub fn op_generalized(&self) -> String {
-        let op_vec: Vec<&str> = self.op.split('.').collect();
+        let op_vec: Vec<&str> = self.op().split('.').collect();
         let keep_params = matches!(op_vec[0], "movdn" | "movup");
         if !keep_params && op_vec.last().unwrap().parse::<usize>().is_ok() {
             op_vec.split_last().unwrap().1.join(".")
         } else {
-            self.op.clone()
+            self.op().to_string()
         }
     }
 
     /// Returns the number of VM cycles taken to execute the assembly instruction.
     pub fn num_cycles(&self) -> u8 {
-        self.num_cycles
+        self.asmop.num_cycles()
     }
 
     /// Returns the operation index of the operation at the specified clock cycle in the sequence
     /// of operations corresponding to the current assembly instruction.
     pub fn cycle_idx(&self) -> u8 {
         self.cycle_idx
+    }
+
+    /// Returns `true` if the debug should break for this line.
+    pub const fn should_break(&self) -> bool {
+        self.asmop.should_break()
+    }
+}
+
+impl fmt::Display for AsmOpInfo {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}, cycles={}", self.asmop, self.cycle_idx)
     }
 }

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -12,7 +12,8 @@ pub use vm_core::{
     },
     errors::InputError,
     utils::DeserializationError,
-    Kernel, Operation, Program, ProgramInfo, QuadExtension, StackInputs, StackOutputs, Word,
+    AssemblyOp, Kernel, Operation, Program, ProgramInfo, QuadExtension, StackInputs, StackOutputs,
+    Word,
 };
 use vm_core::{
     code_blocks::{


### PR DESCRIPTION
This commit introduces `breakpoint`, a transparent instruction that will cause a debug execution to break when reached.

This instruction will not be serialized into libraries, and will not have an opcode or be part of the code block tree.

For debug executions, it will produce a `NOOP`, so the internal clock of the VM will be affected.

The decision of not including this as part of the code block is to avoid further consuming variants of opcodes as they are already scarce.

related issue: #580