### PR TITLE
feat: expose stack trace_state() via internals flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,4 +2,4 @@ exec:
 	cargo build --release --features concurrent,executable
 
 test:
-	RUSTFLAGS="-C debug-assertions -C overflow-checks -C debuginfo=2" cargo test --release --features internals
+	RUSTFLAGS="-C debug-assertions -C overflow-checks -C debuginfo=2" cargo test --release

--- a/miden/Cargo.toml
+++ b/miden/Cargo.toml
@@ -35,13 +35,11 @@ harness = false
 [[test]]
 name = "miden"
 path = "tests/integration/main.rs"
-required-features = ["internals"]
 
 [features]
 concurrent = ["prover/concurrent", "std"]
 default = ["std"]
-executable = ["env_logger", "hex/std", "internals", "std", "serde/std", "serde_derive", "serde_json/std", "structopt", "rustyline"]
-internals = ["processor/internals"]
+executable = ["env_logger", "hex/std", "processor/internals", "std", "serde/std", "serde_derive", "serde_json/std", "structopt", "rustyline"]
 std = ["assembly/std", "log/std", "processor/std", "prover/std", "verifier/std"]
 
 [dependencies]
@@ -66,6 +64,7 @@ criterion = "0.4"
 escargot = "0.5.7"
 num-bigint = "0.4"
 predicates = "2.1.5"
+processor = { package = "miden-processor", path = "../processor", version = "0.5", features = ["internals"], default-features = false }
 proptest = "1.0.0"
 rand-utils = { package = "winter-rand-utils", version = "0.5" }
 sha2 = "0.10"

--- a/processor/src/stack/mod.rs
+++ b/processor/src/stack/mod.rs
@@ -311,7 +311,7 @@ impl Stack {
 
     /// Returns state of stack item columns at the current clock cycle. This does not include stack
     /// values in the overflow table.
-    #[cfg(test)]
+    #[cfg(any(test, feature = "internals"))]
     pub fn trace_state(&self) -> [Felt; STACK_TOP_SIZE] {
         self.trace.get_stack_state_at(self.clk)
     }

--- a/processor/src/stack/trace.rs
+++ b/processor/src/stack/trace.rs
@@ -201,7 +201,7 @@ impl StackTrace {
     // --------------------------------------------------------------------------------------------
 
     /// Returns the stack trace state at the specified clock cycle.
-    #[cfg(test)]
+    #[cfg(any(test, feature = "internals"))]
     pub fn get_stack_state_at(&self, clk: u32) -> [Felt; STACK_TOP_SIZE] {
         let mut result = [ZERO; STACK_TOP_SIZE];
         for (result, column) in result.iter_mut().zip(self.stack.iter()) {


### PR DESCRIPTION
This PR exposes `stack.trace_state()` via the internals flag.  This is required for testing of the note setup script in which we need to assert the note inputs are placed on the stack following the completion of the procedure. 

 It also enables the `internals` flag by default for the `processor` crate in `miden` tests via specifying the feature in the dev dependency. 