### PR TITLE
chore: update cargo toml and makefile parameters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       matrix:
         toolchain: [stable, nightly]
         os: [ubuntu]
-        args: [--release, --doc]
+        args: [--profile test-release, --profile test-release --doc]
     steps:
       - uses: actions/checkout@main
       - name: Install rust

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,10 +10,13 @@ members = [
   "verifier"
 ]
 
-[profile.release]
+[profile.optimized]
+inherits = "release"
 codegen-units = 1
 lto = true
 
-[profile.bench]
-codegen-units = 1
-lto = true
+[profile.test-release]
+inherits = "release"
+debug = true
+debug-assertions = true
+overflow-checks = true

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,13 @@
+FEATURES_INTERNALS=--features internals
+FEATURES_CONCURRENT_EXEC=--features concurrent,executable
+PROFILE_OPTIMIZED=--profile optimized
+PROFILE_TEST=--profile test-release
+
+bench:
+	cargo bench $(PROFILE_OPTIMIZED)
+
 exec:
-	cargo build --release --features concurrent,executable
+	cargo build $(PROFILE_OPTIMIZED) $(FEATURES_CONCURRENT_EXEC)
 
 test:
-	RUSTFLAGS="-C debug-assertions -C overflow-checks -C debuginfo=2" cargo test --release
+	cargo test $(PROFILE_TEST) $(FEATURES_INTERNALS)

--- a/docs/src/intro/usage.md
+++ b/docs/src/intro/usage.md
@@ -11,17 +11,22 @@ The above functionality is also exposed via the single [miden](https://crates.io
 ## CLI interface
 
 ### Compiling Miden VM
-To compile Miden VM into a binary, you can run the following command:
+To compile Miden VM into a binary, we have a [Makefile](https://www.gnu.org/software/make/manual/make.html) with the following tasks:
 ```
-cargo build --release --features executable
+make exec
 ```
-This will place `miden` executable in the `./target/release` directory.
-
-By default, the executable will be compiled in the single-threaded mode. If you would like to enable multi-threaded proof generation, you can compile Miden VM using the following command:
+This will place an optimized, multi-threaded `miden` executable in the `./target/release` directory. It is equivalent to executing:
 ```
-cargo build --release --features "executable concurrent"
+cargo build --profile optimized --features concurrent,executable
 ```
-
+If you would like to enable single-threaded mode, you can compile Miden Vm using the following command:
+```
+cargo build --profile optimized --features executable
+```
+For a faster build, you can compile with less optimizations, replacing `--profile optimized` by `--release`. Example:
+```
+cargo build --release --features concurrent,executable
+```
 ### Controlling parallelism
 Internally, Miden VM uses [rayon](https://github.com/rayon-rs/rayon) for parallel computations. To control the number of threads used to generate a STARK proof, you can use `RAYON_NUM_THREADS` environment variable.
 


### PR DESCRIPTION
This commit removes the mandatory optimization from cargo toml and creates makefile tasks to replace them.

They will allow the user to choose when he wants a full optimization, or a partial. The full optimization is useful for release artifacts, and partial is useful for development tasks such as tests.

closes #768 