### PR TITLE
CLI advice map + merkle structures

### DIFF
--- a/miden/src/cli/data.rs
+++ b/miden/src/cli/data.rs
@@ -1,11 +1,14 @@
 use assembly::{Library, MaslLibrary};
 use miden::{
+    crypto::MerkleStore,
+    math::Felt,
     utils::{Deserializable, SliceReader},
     AdviceInputs, Assembler, Digest, ExecutionProof, MemAdviceProvider, Program, StackInputs,
-    StackOutputs,
+    StackOutputs, Word,
 };
 use serde_derive::{Deserialize, Serialize};
 use std::{
+    collections::HashMap,
     fs,
     io::Write,
     path::{Path, PathBuf},
@@ -29,15 +32,46 @@ impl Debug {
     }
 }
 
+// MERKLE DATA
+// ================================================================================================
+
+/// Struct used to deserialize merkle data from input file. Merkle data can be represented as a
+/// merkle tree or a sparse merkle tree.
+#[derive(Deserialize, Debug)]
+pub enum MerkleData {
+    /// String representation of a merkle tree.  The merkle tree is represented as a vector of
+    /// 32 byte hex strings where each string represents a leaf in the tree.
+    #[serde(rename = "merkle_tree")]
+    MerkleTree(Vec<String>),
+    /// String representation of a sparse merkle tree. The sparse merkle tree is represented as a
+    /// vector of tuples where each tuple consists of a u64 node index and a 32 byte hex string
+    /// representing the value of the node.
+    #[serde(rename = "sparse_merkle_tree")]
+    SparseMerkleTree(Vec<(u64, String)>),
+}
+
 // INPUT FILE
 // ================================================================================================
 
 // TODO consider using final types instead of string representations.
-/// Input file struct
+/// Input file struct that is used to deserialize input data from file. It consists of four
+/// components:
+/// - operand_stack
+/// - advice_stack
+/// - advice_map
+/// - merkle_store
 #[derive(Deserialize, Debug)]
 pub struct InputFile {
+    /// String representation of the initial operand stack, composed of chained field elements.
     pub operand_stack: Vec<String>,
+    /// Opitonal string representation of the initial advice stack, composed of chained field
+    /// elements.
     pub advice_stack: Option<Vec<String>>,
+    /// Optional map of 32 byte hex strings to vectors of u64s representing the initial advice map.
+    pub advice_map: Option<HashMap<String, Vec<u64>>>,
+    /// Optional vector of merkle data which will be loaded into the initial merkle store. Merkle
+    /// data is represented as 32 byte hex strings and node indexes are represented as u64s.
+    pub merkle_store: Option<Vec<MerkleData>>,
 }
 
 /// Helper methods to interact with the input file
@@ -49,6 +83,8 @@ impl InputFile {
             return Ok(Self {
                 operand_stack: Vec::new(),
                 advice_stack: Some(Vec::new()),
+                advice_map: Some(HashMap::new()),
+                merkle_store: None,
             });
         }
 
@@ -72,18 +108,137 @@ impl InputFile {
         Ok(inputs)
     }
 
+    /// Parse advice provider data from the input file.
     pub fn parse_advice_provider(&self) -> Result<MemAdviceProvider, String> {
+        let mut advice_inputs = AdviceInputs::default();
+
         let stack = self
-            .advice_stack
+            .parse_advice_stack()
+            .map_err(|e| format!("failed to parse advice provider: {e}"))?;
+        advice_inputs = advice_inputs.with_stack_values(stack).map_err(|e| e.to_string())?;
+
+        if let Some(map) = self
+            .parse_advice_map()
+            .map_err(|e| format!("failed to parse advice provider: {e}"))?
+        {
+            advice_inputs = advice_inputs.with_map(map);
+        }
+
+        if let Some(merkle_store) = self
+            .parse_merkle_store()
+            .map_err(|e| format!("failed to parse advice provider: {e}"))?
+        {
+            advice_inputs = advice_inputs.with_merkle_store(merkle_store);
+        }
+
+        Ok(MemAdviceProvider::from(advice_inputs))
+    }
+
+    /// Parse advice stack data from the input file.
+    fn parse_advice_stack(&self) -> Result<Vec<u64>, String> {
+        self.advice_stack
             .as_ref()
             .map(Vec::as_slice)
             .unwrap_or(&[])
             .iter()
-            .map(|v| v.parse::<u64>().map_err(|e| e.to_string()))
-            .collect::<Result<Vec<_>, _>>()?;
-        let advice_inputs =
-            AdviceInputs::default().with_stack_values(stack).map_err(|e| e.to_string())?;
-        Ok(MemAdviceProvider::from(advice_inputs))
+            .map(|v| {
+                v.parse::<u64>()
+                    .map_err(|e| format!("failed to parse advice stack value `{v}` - {e}"))
+            })
+            .collect::<Result<Vec<_>, _>>()
+    }
+
+    /// Parse advice map data from the input file.
+    fn parse_advice_map(&self) -> Result<Option<HashMap<[u8; 32], Vec<Felt>>>, String> {
+        let advice_map = match &self.advice_map {
+            Some(advice_map) => advice_map,
+            None => return Ok(None),
+        };
+
+        let map = advice_map
+            .iter()
+            .map(|(k, v)| {
+                // decode hex key
+                let mut key = [0u8; 32];
+                hex::decode_to_slice(k, &mut key)
+                    .map_err(|e| format!("failed to decode advice map key `{k}` - {e}"))?;
+
+                // convert values to Felt
+                let values = v
+                    .iter()
+                    .map(|v| {
+                        Felt::try_from(*v).map_err(|e| {
+                            format!("failed to convert advice map value `{v}` to Felt - {e}")
+                        })
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
+                Ok((key, values))
+            })
+            .collect::<Result<HashMap<[u8; 32], Vec<Felt>>, String>>()?;
+
+        Ok(Some(map))
+    }
+
+    /// Parse merkle store data from the input file.
+    fn parse_merkle_store(&self) -> Result<Option<MerkleStore>, String> {
+        let merkle_data = match &self.merkle_store {
+            Some(merkle_data) => merkle_data,
+            None => return Ok(None),
+        };
+
+        let mut merkle_store = MerkleStore::default();
+        for data in merkle_data {
+            match data {
+                MerkleData::MerkleTree(data) => {
+                    let leaves = Self::parse_merkle_tree(data)?;
+                    merkle_store
+                        .add_merkle_tree(leaves)
+                        .map_err(|e| format!("failed to add merkle tree to merkle store - {e}"))?;
+                }
+                MerkleData::SparseMerkleTree(data) => {
+                    let entries = Self::parse_sparse_merkle_tree(data)?;
+                    merkle_store.add_sparse_merkle_tree(entries).map_err(|e| {
+                        format!("failed to add sparse merkle tree to merkle store - {e}")
+                    })?;
+                }
+            }
+        }
+
+        Ok(Some(merkle_store))
+    }
+
+    /// Parse and return merkle tree leaves.
+    fn parse_merkle_tree(tree: &[String]) -> Result<Vec<Word>, String> {
+        tree.iter()
+            .map(|v| {
+                let leaf = Self::parse_word(v)?;
+                Ok(leaf)
+            })
+            .collect()
+    }
+
+    /// Parse and return sparse merkle tree entries.
+    fn parse_sparse_merkle_tree(tree: &[(u64, String)]) -> Result<Vec<(u64, Word)>, String> {
+        tree.iter()
+            .map(|(index, v)| {
+                let leaf = Self::parse_word(v)?;
+                Ok((*index, leaf))
+            })
+            .collect()
+    }
+
+    /// Parse a `Word` from a hex string.
+    pub fn parse_word(word_hex: &str) -> Result<Word, String> {
+        let mut word_data = [0u8; 32];
+        hex::decode_to_slice(word_hex, &mut word_data)
+            .map_err(|e| format!("failed to decode `Word` from hex {word_hex} - {e}"))?;
+        let mut word = Word::default();
+        for (i, value) in word_data.chunks(8).enumerate() {
+            word[i] = Felt::try_from(value).map_err(|e| {
+                format!("failed to convert `Word` data {word_hex} (element {i}) to Felt - {e}")
+            })?;
+        }
+        Ok(word)
     }
 
     /// Parse and return the stack inputs for the program.


### PR DESCRIPTION
This PR introduces the ability to define advice map entries and merkle store data structures via the cli inputs file.

- Advice map keys are defined as a 32 byte hex string.
- Merkle tree leafs are defined as 32 byte hex strings. 
- Current support for `MerkleTree` and `SparseMerkleTree` data structures.

Please see this [miden example PR](https://github.com/0xPolygonMiden/examples/pull/120/files) for an example of this functionality and data definition. 

