### PR TITLE
fix: fix no_std support

### DIFF
--- a/core/src/random.rs
+++ b/core/src/random.rs
@@ -1,5 +1,6 @@
 use super::{
     crypto::hash::{Rpo256, RpoDigest},
+    utils::collections::Vec,
     Felt, FieldElement,
 };
 


### PR DESCRIPTION
This PR fixes `no_std` support by importing `no_std` compatible `Vec` object.