### PR TITLE
feat: add stdlib smt collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,11 @@
 ## 0.6.0 (TBD)
 
 #### Assembly
-- Added new instruction: `mtree_verify`.
+- Added new instructions: `mtree_verify`, `adv.smtget`.
 - [BREAKING] Refactored `adv.mem` decorator to use parameters from operand stack instead of immediate values.
+
+#### Stdlib
+- Added new module: `collections::smt` with `smt::get`.
 
 ## 0.5.0 (2023-03-29)
 

--- a/assembly/src/assembler/instruction/mod.rs
+++ b/assembly/src/assembler/instruction/mod.rs
@@ -290,6 +290,7 @@ impl Assembler {
             Instruction::AdvMem => adv_ops::adv_mem(span),
             Instruction::AdvExt2Inv => span.add_decorator(Decorator::Advice(Ext2Inv)),
             Instruction::AdvExt2INTT => span.add_decorator(Decorator::Advice(Ext2INTT)),
+            Instruction::AdvSmtGet => span.add_decorator(Decorator::Advice(SmtGet)),
 
             // ----- cryptographic instructions ---------------------------------------------------
             Instruction::Hash => crypto_ops::hash(span),

--- a/assembly/src/parsers/adv_ops.rs
+++ b/assembly/src/parsers/adv_ops.rs
@@ -7,7 +7,8 @@ use super::{
 // INSTRUCTION PARSERS
 // ================================================================================================
 
-/// Returns `AdvU64Div`, `AdvKeyval`, or `AdvMem`  instruction node.
+/// Returns `AdvU64Div`, `AdvKeyval`, `AdvMem`, `AdvExt2Inv`, `AdvExt2INTT`, or `AdvSmtGet`
+/// instruction node.
 ///
 /// # Errors
 /// Returns an error if:
@@ -48,6 +49,12 @@ pub fn parse_adv_inject(op: &Token) -> Result<Node, ParsingError> {
                 return Err(ParsingError::extra_param(op));
             }
             Ok(Instruction(AdvExt2INTT))
+        }
+        "smtget" => {
+            if op.num_parts() > 2 {
+                return Err(ParsingError::extra_param(op));
+            }
+            Ok(Instruction(AdvSmtGet))
         }
         _ => Err(ParsingError::invalid_op(op)),
     }

--- a/assembly/src/parsers/nodes.rs
+++ b/assembly/src/parsers/nodes.rs
@@ -261,6 +261,7 @@ pub enum Instruction {
     AdvMem,
     AdvExt2Inv,
     AdvExt2INTT,
+    AdvSmtGet,
 
     // ----- cryptographic operations -------------------------------------------------------------
     Hash,
@@ -537,6 +538,7 @@ impl fmt::Display for Instruction {
             Self::AdvMem => write!(f, "adv.mem"),
             Self::AdvExt2Inv => write!(f, "adv.ext2inv"),
             Self::AdvExt2INTT => write!(f, "adv.ext2intt"),
+            Self::AdvSmtGet => write!(f, "adv.smtget"),
 
             // ----- cryptographic operations -----------------------------------------------------
             Self::Hash => write!(f, "hash"),

--- a/assembly/src/parsers/serde/deserialization.rs
+++ b/assembly/src/parsers/serde/deserialization.rs
@@ -331,6 +331,7 @@ impl Deserializable for Instruction {
             OpCode::AdvLoadW => Ok(Instruction::AdvLoadW),
             OpCode::AdvExt2Inv => Ok(Instruction::AdvExt2Inv),
             OpCode::AdvExt2INTT => Ok(Instruction::AdvExt2INTT),
+            OpCode::AdvSmtGet => Ok(Instruction::AdvSmtGet),
 
             // ----- cryptographic operations -----------------------------------------------------
             OpCode::Hash => Ok(Instruction::Hash),

--- a/assembly/src/parsers/serde/mod.rs
+++ b/assembly/src/parsers/serde/mod.rs
@@ -257,23 +257,24 @@ pub enum OpCode {
     AdvMem = 227,
     AdvExt2Inv = 228,
     AdvExt2INTT = 229,
+    AdvSmtGet = 230,
 
     // ----- cryptographic operations -------------------------------------------------------------
-    Hash = 230,
-    HMerge = 231,
-    HPerm = 232,
-    MTreeGet = 233,
-    MTreeSet = 234,
-    MTreeMerge = 235,
-    MTreeVerify = 236,
-    FriExt2Fold4 = 237,
+    Hash = 231,
+    HMerge = 232,
+    HPerm = 233,
+    MTreeGet = 234,
+    MTreeSet = 235,
+    MTreeMerge = 236,
+    MTreeVerify = 237,
+    FriExt2Fold4 = 238,
 
     // ----- exec / call --------------------------------------------------------------------------
-    ExecLocal = 238,
-    ExecImported = 239,
-    CallLocal = 240,
-    CallImported = 241,
-    SysCall = 242,
+    ExecLocal = 239,
+    ExecImported = 240,
+    CallLocal = 241,
+    CallImported = 242,
+    SysCall = 243,
 
     // ----- control flow -------------------------------------------------------------------------
     IfElse = 253,

--- a/assembly/src/parsers/serde/serialization.rs
+++ b/assembly/src/parsers/serde/serialization.rs
@@ -442,6 +442,7 @@ impl Serializable for Instruction {
             Self::AdvLoadW => OpCode::AdvLoadW.write_into(target),
             Self::AdvExt2Inv => OpCode::AdvExt2Inv.write_into(target),
             Self::AdvExt2INTT => OpCode::AdvExt2INTT.write_into(target),
+            Self::AdvSmtGet => OpCode::AdvSmtGet.write_into(target),
 
             // ----- cryptographic operations -----------------------------------------------------
             Self::Hash => OpCode::Hash.write_into(target),

--- a/assembly/src/parsers/tests.rs
+++ b/assembly/src/parsers/tests.rs
@@ -184,11 +184,12 @@ fn test_ast_parsing_adv_ops() {
 
 #[test]
 fn test_ast_parsing_adv_injection() {
-    let source = "begin adv.u64div adv.keyval adv.mem end";
+    let source = "begin adv.u64div adv.keyval adv.mem adv.smtget end";
     let nodes: Vec<Node> = vec![
         Node::Instruction(Instruction::AdvU64Div),
         Node::Instruction(Instruction::AdvKeyval),
         Node::Instruction(Instruction::AdvMem),
+        Node::Instruction(Instruction::AdvSmtGet),
     ];
 
     assert_program_output(source, BTreeMap::new(), nodes);

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -14,7 +14,8 @@ pub use ::crypto::{Word, ONE, WORD_SIZE, ZERO};
 pub mod crypto {
     pub mod merkle {
         pub use ::crypto::merkle::{
-            MerkleError, MerklePath, MerklePathSet, MerkleStore, MerkleTree, NodeIndex, SimpleSmt,
+            EmptySubtreeRoots, MerkleError, MerklePath, MerklePathSet, MerkleStore, MerkleTree,
+            NodeIndex, SimpleSmt,
         };
     }
 

--- a/core/src/operations/decorators/advice.rs
+++ b/core/src/operations/decorators/advice.rs
@@ -50,6 +50,24 @@ pub enum AdviceInjector {
     /// routine interpolates ( using inverse NTT ) the evaluations into a polynomial in
     /// coefficient form and pushes the result into the advice stack.
     Ext2INTT,
+
+    /// Pushes the value and depth flags of a leaf indexed by `key` on a Sparse Merkle tree with
+    /// the provided `root`.
+    ///
+    /// The Sparse Merkle tree is tiered, meaning it will have leaf depths in `{16, 32, 48, 64}`.
+    /// The depth flags define the tier on which the leaf is located.
+    ///
+    /// The operand stack is expected to be arranged as follows (from the top):
+    /// - key, 4 elements.
+    /// - root of the Sparse Merkle tree, 4 elements.
+    ///
+    /// After a successful operation, the advice stack will look as follows:
+    /// - boolean flag set to `1` if the depth is `16` or `48`.
+    /// - boolean flag set to `1` if the depth is `16` or `32`.
+    /// - remaining key word; will be zeroed if the tree don't contain a mapped value for the key.
+    /// - value word; will be zeroed if the tree don't contain a mapped value for the key.
+    /// - boolean flag set to `1` if a remaining key is not zero.
+    SmtGet,
 }
 
 impl fmt::Display for AdviceInjector {
@@ -62,6 +80,7 @@ impl fmt::Display for AdviceInjector {
             Self::Memory => write!(f, "mem"),
             Self::Ext2Inv => write!(f, "ext2_inv"),
             Self::Ext2INTT => write!(f, "ext2_intt"),
+            Self::SmtGet => write!(f, "smt_get"),
         }
     }
 }

--- a/processor/Cargo.toml
+++ b/processor/Cargo.toml
@@ -30,5 +30,6 @@ winter-prover = { package = "winter-prover", version = "0.6", default-features =
 logtest = { version = "2.0", default-features = false  }
 miden-assembly = { package = "miden-assembly", path = "../assembly", version = "0.6", default-features = false }
 rand-utils = { package = "winter-rand-utils", version = "0.6" }
+test-utils = { package = "miden-test-utils", path = "../test-utils", version = "0.1" }
 winter-fri = { package = "winter-fri", version = "0.6" }
 winter-utils = { package = "winter-utils", version = "0.6" }

--- a/processor/src/advice/mem_provider.rs
+++ b/processor/src/advice/mem_provider.rs
@@ -1,6 +1,6 @@
 use super::{
     AdviceInputs, AdviceProvider, AdviceSource, BTreeMap, ExecutionError, Felt, IntoBytes,
-    MerklePath, MerkleStore, NodeIndex, Vec, Word,
+    MerklePath, MerkleStore, NodeIndex, StarkField, Vec, Word,
 };
 
 // MEMORY ADVICE PROVIDER
@@ -117,6 +117,19 @@ impl AdviceProvider for MemAdviceProvider {
         self.store
             .get_path(root, index)
             .map(|value| value.path)
+            .map_err(ExecutionError::MerkleStoreLookupFailed)
+    }
+
+    fn get_leaf_depth(
+        &self,
+        root: Word,
+        tree_depth: &Felt,
+        index: &Felt,
+    ) -> Result<u8, ExecutionError> {
+        let tree_depth = u8::try_from(tree_depth.as_int())
+            .map_err(|_| ExecutionError::InvalidTreeDepth { depth: *tree_depth })?;
+        self.store
+            .get_leaf_depth(root, tree_depth, index.as_int())
             .map_err(ExecutionError::MerkleStoreLookupFailed)
     }
 

--- a/processor/src/advice/mod.rs
+++ b/processor/src/advice/mod.rs
@@ -1,4 +1,4 @@
-use super::{ExecutionError, Felt, InputError, Word};
+use super::{ExecutionError, Felt, InputError, StarkField, Word};
 use vm_core::{
     crypto::merkle::{MerklePath, MerkleStore, NodeIndex},
     utils::{
@@ -124,6 +124,21 @@ pub trait AdviceProvider {
         index: &Felt,
     ) -> Result<MerklePath, ExecutionError>;
 
+    /// Reconstructs a path from the root until a leaf or empty node and returns its depth.
+    ///
+    /// For more information, check [MerkleStore::get_leaf_depth].
+    ///
+    /// # Errors
+    /// Will return an error if:
+    /// - The provided `tree_depth` doesn't fit `u8`.
+    /// - The conditions of [MerkleStore::get_leaf_depth] aren't met.
+    fn get_leaf_depth(
+        &self,
+        root: Word,
+        tree_depth: &Felt,
+        index: &Felt,
+    ) -> Result<u8, ExecutionError>;
+
     /// Updates a node at the specified depth and index in a Merkle tree with the specified root;
     /// returns the Merkle path from the updated node to the new root.
     ///
@@ -209,6 +224,15 @@ where
         index: &Felt,
     ) -> Result<MerklePath, ExecutionError> {
         T::get_merkle_path(self, root, depth, index)
+    }
+
+    fn get_leaf_depth(
+        &self,
+        root: Word,
+        tree_depth: &Felt,
+        index: &Felt,
+    ) -> Result<u8, ExecutionError> {
+        T::get_leaf_depth(self, root, tree_depth, index)
     }
 
     fn update_merkle_node(

--- a/processor/src/decorators/tests.rs
+++ b/processor/src/decorators/tests.rs
@@ -1,0 +1,203 @@
+use super::{
+    super::{AdviceInputs, Felt, FieldElement, Kernel, Operation, StarkField},
+    Process, ZERO,
+};
+use crate::{MemAdviceProvider, StackInputs, Word};
+use test_utils::{crypto::get_smt_remaining_key, rand::seeded_word};
+use vm_core::{
+    crypto::{
+        hash::Rpo256,
+        merkle::{EmptySubtreeRoots, MerkleStore, MerkleTree, NodeIndex},
+    },
+    utils::IntoBytes,
+    AdviceInjector, Decorator, ONE,
+};
+
+#[test]
+fn inject_merkle_node() {
+    let leaves = [init_leaf(1), init_leaf(2), init_leaf(3), init_leaf(4)];
+    let tree = MerkleTree::new(leaves.to_vec()).unwrap();
+    let store = MerkleStore::default().with_merkle_tree(leaves).unwrap();
+    let stack_inputs = [
+        tree.root()[0].as_int(),
+        tree.root()[1].as_int(),
+        tree.root()[2].as_int(),
+        tree.root()[3].as_int(),
+        1,
+        tree.depth() as u64,
+    ];
+
+    let stack_inputs = StackInputs::try_from_values(stack_inputs).unwrap();
+    let advice_inputs = AdviceInputs::default().with_merkle_store(store);
+    let advice_provider = MemAdviceProvider::from(advice_inputs);
+    let mut process = Process::new(Kernel::default(), stack_inputs, advice_provider);
+    process.execute_op(Operation::Noop).unwrap();
+
+    // push the node onto the advice stack
+    process
+        .execute_decorator(&Decorator::Advice(AdviceInjector::MerkleNode))
+        .unwrap();
+
+    // pop the node from the advice stack and push it onto the operand stack
+    process.execute_op(Operation::AdvPop).unwrap();
+    process.execute_op(Operation::AdvPop).unwrap();
+    process.execute_op(Operation::AdvPop).unwrap();
+    process.execute_op(Operation::AdvPop).unwrap();
+
+    let expected_stack = build_expected(&[
+        leaves[1][3],
+        leaves[1][2],
+        leaves[1][1],
+        leaves[1][0],
+        Felt::new(2),
+        Felt::new(1),
+        tree.root()[3],
+        tree.root()[2],
+        tree.root()[1],
+        tree.root()[0],
+    ]);
+    assert_eq!(expected_stack, process.stack.trace_state());
+}
+
+#[test]
+fn inject_smtget() {
+    // setup the test
+    let empty = EmptySubtreeRoots::empty_hashes(64);
+    let initial_root = Word::from(empty[0]);
+    let mut seed = 0xfb;
+    let key = seeded_word(&mut seed);
+    let value = seeded_word(&mut seed);
+
+    // check leaves on empty trees
+    for depth in [16, 32, 48] {
+        // compute the remaining key
+        let remaining = get_smt_remaining_key(key, depth);
+
+        // compute node value
+        let depth_element = Felt::from(depth);
+        let store = MerkleStore::new();
+        let node = Rpo256::merge_in_domain(&[remaining.into(), value.into()], depth_element).into();
+
+        // expect absent value with constant depth 16
+        let expected = [ZERO, ZERO, ZERO, ZERO, ZERO, ZERO, ZERO, ZERO, ZERO, ONE, ONE];
+        assert_case_smtget(depth, key, value, node, initial_root, store, &expected);
+    }
+
+    // check leaves inserted on all tiers
+    for depth in [16, 32, 48] {
+        // compute the remaining key
+        let remaining = get_smt_remaining_key(key, depth);
+
+        // set depth flags
+        let is_16_or_32 = (depth == 16 || depth == 32).then_some(ONE).unwrap_or(ZERO);
+        let is_16_or_48 = (depth == 16 || depth == 48).then_some(ONE).unwrap_or(ZERO);
+
+        // compute node value
+        let index = key[3].as_int() >> 64 - depth;
+        let index = NodeIndex::new(depth, index).unwrap();
+        let depth_element = Felt::from(depth);
+        let node = Rpo256::merge_in_domain(&[remaining.into(), value.into()], depth_element).into();
+
+        // set tier node value and expect the value from the injector
+        let mut store = MerkleStore::new();
+        let root = store.set_node(initial_root, index, node).unwrap().root;
+        let expected = [
+            ONE,
+            value[3],
+            value[2],
+            value[1],
+            value[0],
+            remaining[3],
+            remaining[2],
+            remaining[1],
+            remaining[0],
+            is_16_or_32,
+            is_16_or_48,
+        ];
+        assert_case_smtget(depth, key, value, node, root, store, &expected);
+    }
+
+    // check absent siblings of non-empty trees
+    for depth in [16, 32, 48] {
+        // set depth flags
+        let is_16_or_32 = (depth == 16 || depth == 32).then_some(ONE).unwrap_or(ZERO);
+        let is_16_or_48 = (depth == 16 || depth == 48).then_some(ONE).unwrap_or(ZERO);
+
+        // compute the index of the absent node
+        let index = key[3].as_int() >> 64 - depth;
+        let index = NodeIndex::new(depth, index).unwrap();
+
+        // compute the sibling index of the target with its remaining key and node
+        let sibling = index.sibling();
+        let mut sibling_key = key;
+        sibling_key[3] = Felt::new(sibling.value() >> depth.min(63));
+        let sibling_node =
+            Rpo256::merge_in_domain(&[sibling_key.into(), value.into()], Felt::new(depth as u64))
+                .into();
+
+        // run the text, expecting absent target node
+        let mut store = MerkleStore::new();
+        let root = store.set_node(initial_root, sibling, sibling_node).unwrap().root;
+        let expected =
+            [ZERO, ZERO, ZERO, ZERO, ZERO, ZERO, ZERO, ZERO, ZERO, is_16_or_32, is_16_or_48];
+        assert_case_smtget(depth, key, value, sibling_node, root, store, &expected);
+    }
+}
+
+// HELPER FUNCTIONS
+// --------------------------------------------------------------------------------------------
+
+fn init_leaf(value: u64) -> Word {
+    [Felt::new(value), Felt::ZERO, Felt::ZERO, Felt::ZERO]
+}
+
+fn build_expected(values: &[Felt]) -> [Felt; 16] {
+    let mut expected = [Felt::ZERO; 16];
+    for (&value, result) in values.iter().zip(expected.iter_mut()) {
+        *result = value
+    }
+    expected
+}
+
+fn assert_case_smtget(
+    depth: u8,
+    key: Word,
+    value: Word,
+    node: Word,
+    root: Word,
+    store: MerkleStore,
+    expected_stack: &[Felt],
+) {
+    // build the process
+    let stack_inputs = StackInputs::try_from_values([
+        root[0].as_int(),
+        root[1].as_int(),
+        root[2].as_int(),
+        root[3].as_int(),
+        key[0].as_int(),
+        key[1].as_int(),
+        key[2].as_int(),
+        key[3].as_int(),
+    ])
+    .unwrap();
+    let remaining = get_smt_remaining_key(key, depth);
+    let mapped = remaining.into_iter().chain(value.into_iter()).collect();
+    let advice_inputs = AdviceInputs::default()
+        .with_merkle_store(store)
+        .with_map([(node.into_bytes(), mapped)]);
+    let advice_provider = MemAdviceProvider::from(advice_inputs);
+    let mut process = Process::new(Kernel::default(), stack_inputs, advice_provider);
+
+    // call the injector and clear the stack
+    process.execute_op(Operation::Noop).unwrap();
+    process.execute_decorator(&Decorator::Advice(AdviceInjector::SmtGet)).unwrap();
+    for _ in 0..8 {
+        process.execute_op(Operation::Drop).unwrap();
+    }
+
+    // expect the stack output
+    for _ in 0..expected_stack.len() {
+        process.execute_op(Operation::AdvPop).unwrap();
+    }
+    assert_eq!(build_expected(expected_stack), process.stack.trace_state());
+}

--- a/processor/src/errors.rs
+++ b/processor/src/errors.rs
@@ -18,6 +18,7 @@ pub enum ExecutionError {
     AdviceKeyNotFound(Word),
     AdviceStackReadFailed(u32),
     InvalidNodeIndex { depth: Felt, value: Felt },
+    InvalidTreeDepth { depth: Felt },
     MerkleUpdateInPlace,
     MerkleStoreLookupFailed(MerkleError),
     MerkleStoreUpdateFailed(MerkleError),
@@ -54,6 +55,9 @@ impl Display for ExecutionError {
                 fmt,
                 "The provided index {value} is out of bounds for a node at depth {depth}"
             ),
+            InvalidTreeDepth { depth } => {
+                write!(fmt, "The provided {depth} is out of bounds and cannot be represented as an unsigned 8-bits integer")
+            }
             MerkleUpdateInPlace => write!(fmt, "Update in place is not supported"),
             MerkleStoreLookupFailed(reason) => {
                 write!(fmt, "Advice provider Merkle store backend lookup failed: {reason}")

--- a/stdlib/asm/collections/smt.masm
+++ b/stdlib/asm/collections/smt.masm
@@ -1,0 +1,309 @@
+# Constant value for empty sub-tree root at depth 16
+const.EMPTY_16_0=17483286922353768131
+const.EMPTY_16_1=353378057542380712
+const.EMPTY_16_2=1935183237414585408
+const.EMPTY_16_3=4820339620987989650
+
+# Constant value for empty sub-tree root at depth 32
+const.EMPTY_32_0=11677748883385181208
+const.EMPTY_32_1=15891398395707500576
+const.EMPTY_32_2=3790704659934033620
+const.EMPTY_32_3=2126099371106695189
+
+# Constant value for empty sub-tree root at depth 48
+const.EMPTY_48_0=10650694022550988030
+const.EMPTY_48_1=5634734408638476525
+const.EMPTY_48_2=9233115969432897632
+const.EMPTY_48_3=1437907447409278328
+
+#! Produces a remaining path key and index for depth 16
+#!
+#! Input:  [v, ...]
+#! Output: [(v << 16) >> 16, v >> 48, ...]
+#!
+#! Cycles: 7
+proc.split_16
+    u32split
+    u32unchecked_divmod.65536
+    mul.4294967296
+    movup.2
+    add
+end
+
+#! Produces a remaining path key and index for depth 48
+#!
+#! Input:  [v, ...]
+#! Output: [v >> 16, (v << 48) >> 48, ...]
+#!
+#! Cycles: 9
+proc.split_48
+    u32split
+    swap
+    u32unchecked_divmod.65536
+    swap
+    movup.2
+    mul.65536
+    add
+end
+
+#! Get the leaf value for depth 16
+#!
+#! Input:  [K, R, ...]
+#! Output: [V, R, ...]
+#!
+#! Cycles: 86
+proc.get16.2
+    # compute the remaining path (9 cycles)
+    exec.split_16 swap movdn.4
+    # => [K', i, R, ...]
+
+    # save [0, 0, 0, 0] into loc[0] (7 cycles)
+    padw loc_storew.0
+
+    # load Ka from advice provider and compare it to K' (16 cycles)
+    # Ka is expected to be the remaining key for the node stored at
+    # depth; it could be either equal to K', or could be something
+    # different
+    adv_loadw eqw
+    # => [Ka ?= K', Ka, K', i, R, ...]
+
+    # move the comparison result out of the way (1 cycle)
+    movdn.8
+    # => [Ka, K', Ka ?= K', i, R, ...]
+
+    # load the value from adv provider and prepare hash (6 cycles)
+    push.0.16.0.0 swapw.2 adv_loadw
+    # => [V, Ka, D, Ka ?= K', i, R, ...]
+
+    # save the value into loc[1] (4 cycles)
+    loc_storew.1
+    # => [V, Ka, D, Ka ?= K', i, R, ...]
+
+    # compute hash(K', V, domain=16) (10 cycles)
+    hperm dropw swapw dropw
+    # => [N, Ka ?= K', i, R, ...]
+
+    # push the root of the empty subtree (5 cycles)
+    push.EMPTY_16_0.EMPTY_16_1.EMPTY_16_2.EMPTY_16_3 swapw
+    # => [N, E, Ka ?= K', i, R, ...]
+
+    # read the flag if the node is empty subtree (5 cycles)
+    adv_push.1 movdn.8 dup.8
+    # => [not_empty?, N, E, not_empty?, Ka ?= K', i, R, ...]
+
+    # conditionally select node (5 cycles)
+    cdropw
+    # => [N', not_empty?, Ka ?= K', i, R, ...]
+
+    # compute the flag indicating if value is not zero (3 cycles)
+    movup.5 movup.5 and
+    # => [take_val?, N', i, R, ...]
+
+    # move take_val out of the way (4 cycles)
+    movdn.9
+    # => [N', i, R, take_val?, ...]
+
+    # verify Merkle path from N' to R (3 cycles)
+    push.16 movdn.4 mtree_verify
+    # => [N', 16, i, R, take_val?, ...]
+
+    # reorganize stack (4 cycles)
+    movup.4 drop movup.4 drop movup.8
+    # => [take_val?, N', R, ...]
+
+    # compute the address of the return value based on `take_val`
+    # and return it, being either zero or V (3 cycles)
+    locaddr.0 add
+    # => [addr, N', R, ...]
+
+    # load the selected value and return (1 cycle)
+    mem_loadw
+    # => [V, R, ...]
+end
+
+#! Get the leaf value for depth 32
+#!
+#! Input:  [K, R, ...]
+#! Output: [V, R, ...]
+#!
+#! Cycles: 79
+proc.get32.2
+    # compute the remaining path (2 cycles)
+    u32split movdn.4
+    # => [K', i, R, ...]
+
+    # save [0, 0, 0, 0] into loc[0] (7 cycles)
+    padw loc_storew.0
+
+    # load Ka from advice provider and compare it to K' (16 cycles)
+    # Ka is expected to be the remaining key for the node stored at
+    # depth; it could be either equal to K', or could be something
+    # different
+    adv_loadw eqw
+    # => [Ka ?= K', Ka, K', i, R, ...]
+
+    # move the comparison result out of the way (1 cycle)
+    movdn.8
+    # => [Ka, K', Ka ?= K', i, R, ...]
+
+    # load the value from adv provider and prepare hash (6 cycles)
+    push.0.32.0.0 swapw.2 adv_loadw
+    # => [V, Ka, D, Ka ?= K', i, R, ...]
+
+    # save the value into loc[1] (4 cycles)
+    loc_storew.1
+    # => [V, Ka, D, Ka ?= K', i, R, ...]
+
+    # compute hash(K', V, domain=32) (10 cycles)
+    hperm dropw swapw dropw
+    # => [N, Ka ?= K', i, R, ...]
+
+    # push the root of the empty subtree (5 cycles)
+    push.EMPTY_32_0.EMPTY_32_1.EMPTY_32_2.EMPTY_32_3 swapw
+    # => [N, E, Ka ?= K', i, R, ...]
+
+    # read the flag if the node is empty subtree (5 cycles)
+    adv_push.1 movdn.8 dup.8
+    # => [not_empty?, N, E, not_empty?, Ka ?= K', i, R, ...]
+
+    # conditionally select node (5 cycles)
+    cdropw
+    # => [N', not_empty?, Ka ?= K', i, R, ...]
+
+    # compute the flag indicating if value is not zero (3 cycles)
+    movup.5 movup.5 and
+    # => [take_val?, N', i, R, ...]
+
+    # move take_val out of the way (4 cycles)
+    movdn.9
+    # => [N', i, R, take_val?, ...]
+
+    # verify Merkle path from N' to R (3 cycles)
+    push.32 movdn.4 mtree_verify
+    # => [N', 32, i, R, take_val?, ...]
+
+    # reorganize stack (4 cycles)
+    movup.4 drop movup.4 drop movup.8
+    # => [take_val?, N', R, ...]
+
+    # compute the address of the return value based on `take_val`
+    # and return it, being either zero or V (3 cycles)
+    locaddr.0 add
+    # => [addr, N', R, ...]
+
+    # load the selected value and return (1 cycle)
+    mem_loadw
+    # => [V, R, ...]
+end
+
+#! Get the leaf value for depth 48
+#!
+#! Input:  [K, R, ...]
+#! Output: [V, R, ...]
+#!
+#! Cycles: 87
+proc.get48.2
+    # compute the remaining path (10 cycles)
+    exec.split_48 movdn.4
+    # => [K', i, R, ...]
+
+    # save [0, 0, 0, 0] into loc[0] (7 cycles)
+    padw loc_storew.0
+
+    # load Ka from advice provider and compare it to K' (16 cycles)
+    # Ka is expected to be the remaining key for the node stored at
+    # depth; it could be either equal to K', or could be something
+    # different
+    adv_loadw eqw
+    # => [Ka ?= K', Ka, K', i, R, ...]
+
+    # move the comparison result out of the way (1 cycle)
+    movdn.8
+    # => [Ka, K', Ka ?= K', i, R, ...]
+
+    # load the value from adv provider and prepare hash (6 cycles)
+    push.0.48.0.0 swapw.2 adv_loadw
+    # => [V, Ka, D, Ka ?= K', i, R, ...]
+
+    # save the value into loc[1] (4 cycles)
+    loc_storew.1
+    # => [V, Ka, D, Ka ?= K', i, R, ...]
+
+    # compute hash(K', V, domain=48) (10 cycles)
+    hperm dropw swapw dropw
+    # => [N, Ka ?= K', i, R, ...]
+
+    # push the root of the empty subtree (5 cycles)
+    push.EMPTY_48_0.EMPTY_48_1.EMPTY_48_2.EMPTY_48_3 swapw
+    # => [N, E, Ka ?= K', i, R, ...]
+
+    # read the flag if the node is empty subtree (5 cycles)
+    adv_push.1 movdn.8 dup.8
+    # => [not_empty?, N, E, not_empty?, Ka ?= K', i, R, ...]
+
+    # conditionally select node (5 cycles)
+    cdropw
+    # => [N', not_empty?, Ka ?= K', i, R, ...]
+
+    # compute the flag indicating if value is not zero (3 cycles)
+    movup.5 movup.5 and
+    # => [take_val?, N', i, R, ...]
+
+    # move take_val out of the way (4 cycles)
+    movdn.9
+    # => [N', i, R, take_val?, ...]
+
+    # verify Merkle path from N' to R (3 cycles)
+    push.48 movdn.4 mtree_verify
+    # => [N', 48, i, R, take_val?, ...]
+
+    # reorganize stack (4 cycles)
+    movup.4 drop movup.4 drop movup.8
+    # => [take_val?, N', R, ...]
+
+    # compute the address of the return value based on `take_val`
+    # and return it, being either zero or V (3 cycles)
+    locaddr.0 add
+    # => [addr, N', R, ...]
+
+    # load the selected value and return (1 cycle)
+    mem_loadw
+    # => [V, R, ...]
+end
+
+#! Returns the value stored under the specified key in a Sparse Merkle tree with the specified root.
+#!
+#! If the value for a given key has not been set, the returned `V` will consist of all zeroes.
+#!
+#! Input:  [K, R, ...]
+#! Output: [V, R, ...]
+#!
+#! Depth 16: 92 cycles
+#! Depth 32: 95 cycles
+#! Depth 48: 93 cycles
+export.get
+    # invoke adv and fetch target depth flags
+    adv.smtget adv_push.2
+    # => [d ∈ {16, 32}, d ∈ {16, 48}, K, R, ...]
+
+    # call the inner procedure depending on the depth
+    if.true
+        if.true
+            # depth 16
+            exec.get16
+        else
+            # depth 32
+            exec.get32
+        end
+    else
+        if.true
+            # depth 48
+            exec.get48
+        else
+            # depth 64
+            # currently not implemented
+            push.0 assert
+        end
+    end
+    # => [V, R, ...]
+end

--- a/stdlib/docs/smt_collections.md
+++ b/stdlib/docs/smt_collections.md
@@ -1,0 +1,5 @@
+
+## std::collections::smt
+| Procedure | Description |
+| ----------- | ------------- |
+| get | Returns the value stored under the specified key in a Sparse Merkle tree with the specified root.<br /><br />If the value for a given key has not been set, the returned `V` will consist of all zeroes.<br /><br />Input:  [K, R, ...]<br /><br />Output: [V, R, ...]<br /><br />Depth 16: 92 cycles<br /><br />Depth 32: 95 cycles<br /><br />Depth 48: 93 cycles |

--- a/stdlib/tests/collections/mod.rs
+++ b/stdlib/tests/collections/mod.rs
@@ -1,1 +1,2 @@
 mod mmr;
+mod smt;

--- a/stdlib/tests/collections/smt.rs
+++ b/stdlib/tests/collections/smt.rs
@@ -1,0 +1,382 @@
+use crate::build_test;
+use test_utils::{
+    crypto::{get_smt_remaining_key, EmptySubtreeRoots, MerkleStore, NodeIndex, Rpo256},
+    rand::{seeded_element, seeded_word},
+    Felt, IntoBytes, StarkField, Word,
+};
+
+#[test]
+fn smtget_single_leaf_depth_16() {
+    // setup the base values
+    let mut seed = 1 << 40;
+    let (root, mut store) = setup();
+
+    // append a leaf
+    let path = seeded_element(&mut seed).as_int();
+    let leaf = SmtLeaf::new(&mut seed, path, 16);
+    let root = leaf.insert(&mut store, root);
+
+    // run the test
+    let advice_map = build_advice_map([leaf]);
+    assert_smt_get_opens_correctly(leaf.key, leaf.value, root, store, &advice_map);
+}
+
+#[test]
+fn smtget_absent_leaf_depth_16() {
+    // setup the base values
+    let mut seed = 1 << 40;
+    let (root, mut store) = setup();
+
+    // generate two paths that diverges at depth 16
+    let a = 0b00000000_00000000_11111111_11111111_11111111_11111111_11111111_11111111_u64;
+    let b = 0b10000000_00000000_11111111_11111111_11111111_11111111_11111111_11111111_u64;
+
+    // generate two leaves from the paths
+    let a = SmtLeaf::new(&mut seed, a, 16);
+    let b = SmtLeaf::new(&mut seed, b, 16);
+
+    // append only `b` to the store
+    let root = b.insert(&mut store, root);
+
+    // sanity check if `b` is properly returned
+    let advice_map = build_advice_map([b]);
+    assert_smt_get_opens_correctly(b.key, b.value, root, store.clone(), &advice_map);
+
+    // `a` should return zeroes as it was not inserted
+    assert_smt_get_opens_correctly(a.key, Word::default(), root, store.clone(), &advice_map);
+}
+
+#[test]
+fn smtget_absent_leaf_with_conflicting_path_at_depth_16() {
+    // setup the base values
+    let mut seed = 1 << 40;
+    let (root, mut store) = setup();
+
+    // generate two paths that diverges after depth 16
+    let a = 0b00000000_00000000_01111111_11111111_11111111_11111111_11111111_11111111_u64;
+    let b = 0b00000000_00000000_11111111_11111111_11111111_11111111_11111111_11111111_u64;
+
+    // generate two leaves from the paths
+    let a = SmtLeaf::new(&mut seed, a, 16);
+    let b = SmtLeaf::new(&mut seed, b, 16);
+
+    // append only `b` to the store
+    let root = b.insert(&mut store, root);
+
+    // sanity check if `b` is properly returned
+    let advice_map = build_advice_map([b]);
+    assert_smt_get_opens_correctly(b.key, b.value, root, store.clone(), &advice_map);
+
+    // `a` should return zeroes as it was not inserted
+    assert_smt_get_opens_correctly(a.key, Word::default(), root, store.clone(), &advice_map);
+}
+
+#[test]
+fn smtget_single_leaf_depth_32() {
+    // setup the base values
+    let mut seed = 1 << 40;
+    let (root, mut store) = setup();
+
+    // append a leaf
+    let path = seeded_element(&mut seed).as_int();
+    let leaf = SmtLeaf::new(&mut seed, path, 32);
+    let root = leaf.insert(&mut store, root);
+
+    // run the test
+    let advice_map = build_advice_map([leaf]);
+    assert_smt_get_opens_correctly(leaf.key, leaf.value, root, store, &advice_map);
+}
+
+#[test]
+fn smtget_absent_leaf_depth_32() {
+    // setup the base values
+    let mut seed = 1 << 40;
+    let (root, mut store) = setup();
+
+    // generate two paths that diverges at depth 32
+    let a = 0b00000000_00000000_00000000_00000000_11111111_11111111_11111111_11111111_u64;
+    let b = 0b00000000_00000000_10000000_00000000_11111111_11111111_11111111_11111111_u64;
+
+    // generate two leaves from the paths
+    let a = SmtLeaf::new(&mut seed, a, 32);
+    let b = SmtLeaf::new(&mut seed, b, 32);
+
+    // append only `b` to the store
+    let root = b.insert(&mut store, root);
+
+    // sanity check if `b` is properly returned
+    let advice_map = build_advice_map([b]);
+    assert_smt_get_opens_correctly(b.key, b.value, root, store.clone(), &advice_map);
+
+    // `a` should return zeroes as it was not inserted
+    assert_smt_get_opens_correctly(a.key, Word::default(), root, store.clone(), &advice_map);
+}
+
+#[test]
+fn smtget_absent_leaf_with_conflicting_path_at_depth_32() {
+    // setup the base values
+    let mut seed = 1 << 40;
+    let (root, mut store) = setup();
+
+    // generate two paths that diverges after depth 32
+    let a = 0b00000000_00000000_00000000_00000000_01111111_11111111_11111111_11111111_u64;
+    let b = 0b00000000_00000000_00000000_00000000_11111111_11111111_11111111_11111111_u64;
+
+    // generate two leaves from the paths
+    let a = SmtLeaf::new(&mut seed, a, 32);
+    let b = SmtLeaf::new(&mut seed, b, 32);
+
+    // append only `b` to the store
+    let root = b.insert(&mut store, root);
+
+    // sanity check if `b` is properly returned
+    let advice_map = build_advice_map([b]);
+    assert_smt_get_opens_correctly(b.key, b.value, root, store.clone(), &advice_map);
+
+    // `a` should return zeroes as it was not inserted
+    assert_smt_get_opens_correctly(a.key, Word::default(), root, store.clone(), &advice_map);
+}
+
+#[test]
+fn smtget_single_leaf_depth_48() {
+    // setup the base values
+    let mut seed = 1 << 40;
+    let (root, mut store) = setup();
+
+    // append a leaf
+    let path = seeded_element(&mut seed).as_int();
+    let leaf = SmtLeaf::new(&mut seed, path, 48);
+    let root = leaf.insert(&mut store, root);
+
+    // run the test
+    let advice_map = build_advice_map([leaf]);
+    assert_smt_get_opens_correctly(leaf.key, leaf.value, root, store, &advice_map);
+}
+
+#[test]
+fn smtget_absent_leaf_depth_48() {
+    // setup the base values
+    let mut seed = 1 << 40;
+    let (root, mut store) = setup();
+
+    // generate two paths that diverges at depth 48
+    let a = 0b00000000_00000000_00000000_00000000_00000000_00000000_11111111_11111111_u64;
+    let b = 0b00000000_00000000_00000000_00000000_10000000_00000000_11111111_11111111_u64;
+
+    // generate two leaves from the paths
+    let a = SmtLeaf::new(&mut seed, a, 48);
+    let b = SmtLeaf::new(&mut seed, b, 48);
+
+    // append only `b` to the store
+    let root = b.insert(&mut store, root);
+
+    // sanity check if `b` is properly returned
+    let advice_map = build_advice_map([b]);
+    assert_smt_get_opens_correctly(b.key, b.value, root, store.clone(), &advice_map);
+
+    // `a` should return zeroes as it was not inserted
+    assert_smt_get_opens_correctly(a.key, Word::default(), root, store.clone(), &advice_map);
+}
+
+#[test]
+fn smtget_absent_leaf_with_conflicting_path_at_depth_48() {
+    // setup the base values
+    let mut seed = 1 << 40;
+    let (root, mut store) = setup();
+
+    // generate two paths that diverges after depth 48
+    let a = 0b00000000_00000000_00000000_00000000_00000000_00000000_01111111_11111111_u64;
+    let b = 0b00000000_00000000_00000000_00000000_00000000_00000000_11111111_11111111_u64;
+
+    // generate two leaves from the paths
+    let a = SmtLeaf::new(&mut seed, a, 48);
+    let b = SmtLeaf::new(&mut seed, b, 48);
+
+    // append only `b` to the store
+    let root = b.insert(&mut store, root);
+
+    // sanity check if `b` is properly returned
+    let advice_map = build_advice_map([b]);
+    assert_smt_get_opens_correctly(b.key, b.value, root, store.clone(), &advice_map);
+
+    // `a` should return zeroes as it was not inserted
+    assert_smt_get_opens_correctly(a.key, Word::default(), root, store.clone(), &advice_map);
+}
+
+#[test]
+fn smtget_opens_correctly_from_tree_with_multiple_leaves() {
+    // setup the base values
+    let mut seed = 1 << 40;
+    let (root, mut store) = setup();
+
+    // define some paths
+    let a_3 = 0b00000000_00000000_11111111_11111111_11111111_11111111_11111111_11111111_u64;
+    let b_3 = 0b10000000_00000000_01111111_11111111_11111111_11111111_11111111_11111111_u64;
+    let c_3 = 0b10000000_00000000_11111111_11111111_11111111_11111111_11111111_11111111_u64;
+    let d_3 = 0b11000000_00000000_00000000_00000000_01111111_11111111_11111111_11111111_u64;
+    let e_3 = 0b11000000_00000000_00000000_00000000_11111111_11111111_11111111_11111111_u64;
+
+    // `a` has no conflicts on depth `16` (first tier)
+    let a = SmtLeaf::new(&mut seed, a_3, 16);
+
+    // `b` conflicts with `c` up to `16`; the target tier is `32`
+    let b = SmtLeaf::new(&mut seed, b_3, 32);
+    let c = SmtLeaf::new(&mut seed, c_3, 32);
+
+    // `d` conflicts with `e` up to `32`; the target tier is `48`
+    let d = SmtLeaf::new(&mut seed, d_3, 48);
+    let e = SmtLeaf::new(&mut seed, e_3, 48);
+
+    // append all leaves to the storage
+    let root = a.insert(&mut store, root);
+    let root = b.insert(&mut store, root);
+    let root = c.insert(&mut store, root);
+    let root = d.insert(&mut store, root);
+    let root = e.insert(&mut store, root);
+
+    // assert all nodes are returned
+    let advice_map = build_advice_map([a, b, c, d, e]);
+    assert_smt_get_opens_correctly(a.key, a.value, root, store.clone(), &advice_map);
+    assert_smt_get_opens_correctly(b.key, b.value, root, store.clone(), &advice_map);
+    assert_smt_get_opens_correctly(c.key, c.value, root, store.clone(), &advice_map);
+    assert_smt_get_opens_correctly(d.key, d.value, root, store.clone(), &advice_map);
+    assert_smt_get_opens_correctly(e.key, e.value, root, store.clone(), &advice_map);
+
+    // assert similar siblings returns zeroes
+    let x = 0b00000000_00000000_10111111_11111111_11111111_11111111_11111111_11111111_u64;
+    let y = 0b10000000_00000000_10111111_11111111_11111111_11111111_11111111_11111111_u64;
+    let z = 0b11000000_00000000_00000000_00000000_10111111_11111111_11111111_11111111_u64;
+
+    // `x` is the same path of `a` for the included part of `a` (i.e. until depth `16)
+    let mut key = a.key;
+    key[3] = Felt::new(x);
+    assert_smt_get_opens_correctly(key, Word::default(), root, store.clone(), &advice_map);
+
+    // `y` is the same path of `c` until depth `32`
+    let mut key = c.key;
+    key[3] = Felt::new(y);
+    assert_smt_get_opens_correctly(key, Word::default(), root, store.clone(), &advice_map);
+
+    // `z` is the same path of `e` until depth `48`
+    let mut key = e.key;
+    key[3] = Felt::new(z);
+    assert_smt_get_opens_correctly(key, Word::default(), root, store.clone(), &advice_map);
+}
+
+// TEST HELPERS
+// ================================================================================================
+
+/// Common initial test setup
+///
+/// Returns the set of empty digests for SMT, the initial root, and an empty MerkleStore
+fn setup() -> (Word, MerkleStore) {
+    let empty = EmptySubtreeRoots::empty_hashes(64);
+    let root = Word::from(empty[0]);
+    let store = MerkleStore::new();
+    (root, store)
+}
+
+/// Asserts key/value opens to root, provided the advice map and store
+fn assert_smt_get_opens_correctly(
+    key: Word,
+    value: Word,
+    root: Word,
+    store: MerkleStore,
+    advice_map: &[([u8; 32], Vec<Felt>)],
+) {
+    let source = r#"
+        use.std::collections::smt
+
+        begin
+            exec.smt::get
+        end
+    "#;
+    let initial_stack = [
+        root[0].as_int(),
+        root[1].as_int(),
+        root[2].as_int(),
+        root[3].as_int(),
+        key[0].as_int(),
+        key[1].as_int(),
+        key[2].as_int(),
+        key[3].as_int(),
+    ];
+    let expected_output = [
+        value[3].as_int(),
+        value[2].as_int(),
+        value[1].as_int(),
+        value[0].as_int(),
+        root[3].as_int(),
+        root[2].as_int(),
+        root[1].as_int(),
+        root[0].as_int(),
+    ];
+    let advice_stack = [];
+    build_test!(source, &initial_stack, &advice_stack, store, advice_map.iter().cloned())
+        .expect_stack(&expected_output);
+}
+
+/// Builds the advice map from the given leaves
+fn build_advice_map<I>(leaves: I) -> Vec<([u8; 32], Vec<Felt>)>
+where
+    I: IntoIterator<Item = SmtLeaf>,
+{
+    leaves
+        .into_iter()
+        .map(|leaf| {
+            let node = leaf.node.into_bytes();
+            let mapped = leaf.remaining_key.into_iter().chain(leaf.value.into_iter()).collect();
+            (node, mapped)
+        })
+        .collect()
+}
+
+/// A representation of the post-insertion state of a leaf
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct SmtLeaf {
+    /// Key
+    pub key: Word,
+    /// Remaining key for the depth
+    pub remaining_key: Word,
+    /// Generated value
+    pub value: Word,
+    /// Index in which the node was inserted
+    pub index: NodeIndex,
+    /// Computed node value
+    pub node: Word,
+}
+
+impl SmtLeaf {
+    /// Creates a new leaf, generating a random key/value from the seed and replacing the last limb
+    /// of the key by `path`.
+    ///
+    /// The node value and remaining key will be defined by `depth`.
+    pub fn new(seed: &mut u64, path: u64, depth: u8) -> Self {
+        // generate a random pair
+        let mut key = seeded_word(seed);
+        let value = seeded_word(seed);
+
+        // override the limb that defines the SMT path
+        key[3] = Felt::new(path);
+
+        // compute the target index, remaining key, and node value
+        let index = NodeIndex::new(depth, path >> (64 - depth)).unwrap();
+        let remaining_key = get_smt_remaining_key(key, depth);
+        let depth = Felt::from(depth);
+        let node = Rpo256::merge_in_domain(&[remaining_key.into(), value.into()], depth).into();
+
+        // return the values
+        SmtLeaf {
+            key,
+            remaining_key,
+            value,
+            index,
+            node,
+        }
+    }
+
+    /// Insert the leaf onto the [MerkleStore], returning the new root value.
+    pub fn insert(&self, store: &mut MerkleStore, root: Word) -> Word {
+        store.set_node(root, self.index, self.node).unwrap().root
+    }
+}

--- a/test-utils/src/crypto.rs
+++ b/test-utils/src/crypto.rs
@@ -1,11 +1,14 @@
-use super::{Felt, FieldElement, Vec, Word};
+use super::{Felt, FieldElement, StarkField, Vec, Word};
 
 // RE-EXPORTS
 // ================================================================================================
 
 pub use vm_core::crypto::{
-    hash::Rpo256,
-    merkle::{MerkleError, MerklePath, MerklePathSet, MerkleStore, MerkleTree, NodeIndex},
+    hash::{Rpo256, RpoDigest},
+    merkle::{
+        EmptySubtreeRoots, MerkleError, MerklePath, MerklePathSet, MerkleStore, MerkleTree,
+        NodeIndex,
+    },
 };
 
 pub use winter_prover::crypto::{BatchMerkleProof, ElementHasher, Hasher};
@@ -25,4 +28,14 @@ pub fn init_merkle_leaves(values: &[u64]) -> Vec<Word> {
 
 pub fn init_merkle_leaf(value: u64) -> Word {
     [Felt::new(value), Felt::ZERO, Felt::ZERO, Felt::ZERO]
+}
+
+/// Returns a remaining path key for a Sparse Merkle tree
+pub fn get_smt_remaining_key(mut key: Word, depth: u8) -> Word {
+    key[3] = Felt::new(match depth {
+        16 | 32 | 48 => (key[3].as_int() << depth) >> depth,
+        64 => 0,
+        _ => unreachable!(),
+    });
+    key
 }

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -25,7 +25,6 @@ pub use prover::{MemAdviceProvider, ProofOptions};
 pub use test_case::test_case;
 pub use verifier::ProgramInfo;
 pub use vm_core::{
-    crypto::hash::RpoDigest,
     stack::STACK_TOP_SIZE,
     utils::{collections, group_slice_elements, group_vector_elements, IntoBytes, ToElements},
     Felt, FieldElement, Program, StarkField, Word, ONE, WORD_SIZE, ZERO,
@@ -41,14 +40,14 @@ pub mod serde {
 
 pub mod crypto;
 
+#[cfg(not(target_family = "wasm"))]
+pub mod rand;
+
 mod test_builders;
 pub use test_builders::*;
 
 #[cfg(not(target_family = "wasm"))]
 pub use proptest;
-
-#[cfg(not(target_family = "wasm"))]
-pub use rand_utils as rand;
 
 // TYPE ALIASES
 // ================================================================================================

--- a/test-utils/src/rand.rs
+++ b/test-utils/src/rand.rs
@@ -1,0 +1,35 @@
+use super::{Felt, Word};
+
+pub use rand_utils::*;
+
+// SEEDED GENERATORS
+// ================================================================================================
+
+/// Mutates a seed and generates a word deterministically
+pub fn seeded_word(seed: &mut u64) -> Word {
+    let seed = generate_bytes_seed(seed);
+    prng_array(seed)
+}
+
+/// Mutates a seed and generates an element deterministically
+pub fn seeded_element(seed: &mut u64) -> Felt {
+    let seed = generate_bytes_seed(seed);
+    let num = prng_array::<u64, 1>(seed)[0];
+    Felt::new(num)
+}
+
+// HELPERS
+// ================================================================================================
+
+/// Generate a bytes seed that can be used as input for rand_utils.
+///
+/// Increments the argument.
+fn generate_bytes_seed(seed: &mut u64) -> [u8; 32] {
+    // increment the seed
+    *seed = seed.wrapping_add(1);
+
+    // generate a bytes seed
+    let mut bytes = [0u8; 32];
+    bytes[..8].copy_from_slice(&seed.to_le_bytes());
+    bytes
+}


### PR DESCRIPTION
This commit introduces a `collections` module for the `stdlib`. It contains, initially, functions to support Sparse Merkle Tree functionality.

It also adds a `mtree_smt_index` operation that will fetch a depth/index pair from the advice provider and push onto the operand stack.