### PR TITLE
Merkle path set

### DIFF
--- a/miden/src/cli/data.rs
+++ b/miden/src/cli/data.rs
@@ -1,6 +1,6 @@
 use assembly::{Library, MaslLibrary};
 use miden::{
-    crypto::MerkleStore,
+    crypto::{MerklePath, MerklePathSet, MerkleStore},
     math::Felt,
     utils::{Deserializable, SliceReader},
     AdviceInputs, Assembler, Digest, ExecutionProof, MemAdviceProvider, Program, StackInputs,
@@ -48,6 +48,12 @@ pub enum MerkleData {
     /// representing the value of the node.
     #[serde(rename = "sparse_merkle_tree")]
     SparseMerkleTree(Vec<(u64, String)>),
+    /// String representation of a Merkle path set. A Merkle path set is represented as a vector of
+    /// tuples where each tuple consists of a u64 node index, a 32 byte hex string representing the
+    /// value of the node, and a vector of 32 byte hex strings representing the Merkle path to the
+    /// node.
+    #[serde(rename = "merkle_path_set")]
+    MerklePathSet(Vec<(u64, String, Vec<String>)>),
 }
 
 // INPUT FILE
@@ -201,6 +207,12 @@ impl InputFile {
                         format!("failed to add sparse merkle tree to merkle store - {e}")
                     })?;
                 }
+                MerkleData::MerklePathSet(data) => {
+                    let path_set = Self::parse_merkle_path_set(data)?;
+                    merkle_store.add_merkle_path_set(&path_set).map_err(|e| {
+                        format!("failed to add merkle path set to merkle store - {e}")
+                    })?;
+                }
             }
         }
 
@@ -225,6 +237,38 @@ impl InputFile {
                 Ok((*index, leaf))
             })
             .collect()
+    }
+
+    /// Parse and return merkle path set.
+    fn parse_merkle_path_set(
+        path_set: &[(u64, String, Vec<String>)],
+    ) -> Result<MerklePathSet, String> {
+        // parse merkle paths
+        let mut paths = Vec::with_capacity(path_set.len());
+        for (index, root, path) in path_set {
+            let root = Self::parse_word(root)?;
+            let path = path
+                .iter()
+                .map(|v| {
+                    let node: Word = Self::parse_word(v)?;
+                    Ok(node)
+                })
+                .collect::<Result<Vec<_>, String>>()?;
+            let path = MerklePath::new(path);
+            paths.push((*index, root, path));
+        }
+
+        // create merkle path set
+        let path_container = paths.get(0).ok_or(format!("failed to get path from path set"))?;
+        let path_depth: u8 = path_container
+            .2
+            .len()
+            .try_into()
+            .map_err(|e| format!("failed to convert merkle path set depth to u8 - {e}"))?;
+        let merkle_path_set = MerklePathSet::new(path_depth)
+            .with_paths(paths)
+            .map_err(|e| format!("failed to add paths to merkle path set - {e}"))?;
+        Ok(merkle_path_set)
     }
 
     /// Parse a `Word` from a hex string.

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -64,7 +64,7 @@ pub mod math {
 pub mod crypto {
     pub use vm_core::crypto::{
         hash::{Blake3_192, Blake3_256, ElementHasher, Hasher, Rpo256},
-        merkle::{MerkleError, MerkleStore, MerkleTree, SimpleSmt},
+        merkle::{MerkleError, MerklePath, MerklePathSet, MerkleStore, MerkleTree, SimpleSmt},
         random::{RandomCoin, RpoRandomCoin, WinterRandomCoin},
     };
 }


### PR DESCRIPTION
This PR introduces support for merkle path set data structures via CLI.  Data definition description:
String representation of a Merkle path set. A Merkle path set is represented as a vector of tuples where each tuple consists of a u64 node index, a 32 byte hex string representing the value of the node, and a vector of 32 byte hex strings representing the Merkle path to the node.