### PR TITLE
Add constant support for memory operations

### DIFF
--- a/assembly/src/errors.rs
+++ b/assembly/src/errors.rs
@@ -215,6 +215,16 @@ impl ParsingError {
         }
     }
 
+    pub fn const_conversion_failed(token: &Token, type_name: &str) -> Self {
+        ParsingError {
+            message: format!(
+                "failed to convert u64 constant used in `{token}` to required type {type_name}"
+            ),
+            step: token.pos(),
+            op: token.to_string(),
+        }
+    }
+
     // INVALID / MALFORMED INSTRUCTIONS
     // --------------------------------------------------------------------------------------------
 

--- a/assembly/src/parsers/context.rs
+++ b/assembly/src/parsers/context.rs
@@ -468,21 +468,21 @@ impl ParserContext {
             "push" => io_ops::parse_push(op, &self.local_constants),
 
             "sdepth" => simple_instruction(op, Sdepth),
-            "locaddr" => io_ops::parse_locaddr(op),
+            "locaddr" => io_ops::parse_locaddr(op, &self.local_constants),
             "caller" => simple_instruction(op, Caller), // TODO: error if not in SYSCALL (issue #551)
             "clk" => simple_instruction(op, Clk),
 
-            "mem_load" => io_ops::parse_mem_load(op),
-            "loc_load" => io_ops::parse_loc_load(op),
+            "mem_load" => io_ops::parse_mem_load(op, &self.local_constants),
+            "loc_load" => io_ops::parse_loc_load(op, &self.local_constants),
 
-            "mem_loadw" => io_ops::parse_mem_loadw(op),
-            "loc_loadw" => io_ops::parse_loc_loadw(op),
+            "mem_loadw" => io_ops::parse_mem_loadw(op, &self.local_constants),
+            "loc_loadw" => io_ops::parse_loc_loadw(op, &self.local_constants),
 
-            "mem_store" => io_ops::parse_mem_store(op),
-            "loc_store" => io_ops::parse_loc_store(op),
+            "mem_store" => io_ops::parse_mem_store(op, &self.local_constants),
+            "loc_store" => io_ops::parse_loc_store(op, &self.local_constants),
 
-            "mem_storew" => io_ops::parse_mem_storew(op),
-            "loc_storew" => io_ops::parse_loc_storew(op),
+            "mem_storew" => io_ops::parse_mem_storew(op, &self.local_constants),
+            "loc_storew" => io_ops::parse_loc_storew(op, &self.local_constants),
 
             "mem_stream" => simple_instruction(op, MemStream),
             "adv_pipe" => simple_instruction(op, AdvPipe),

--- a/docs/src/user_docs/assembly/code_organization.md
+++ b/docs/src/user_docs/assembly/code_organization.md
@@ -93,7 +93,7 @@ In the above example we import `std::math::u64` module from the [standard librar
 The set of modules which can be imported by a program can be specified via a Module Provider when instantiating the [Miden Assembler](https://crates.io/crates/miden-assembly) used to compile the program.
 
 ### Constants
-Miden assembly supports constant declarations. These constants are scoped to the module they are defined in and can be used as immediate parameters for Miden assembly instructions. Currently only `push` instruction supports this.
+Miden assembly supports constant declarations. These constants are scoped to the module they are defined in and can be used as immediate parameters for Miden assembly instructions. Constants are supported as immediate values for the following instructions: `push.CONSTANT1.CONSTANT2`, `locaddr.CONSTANT`, `loc_load.CONSTANT`, `loc_loadw.CONSTANT`, `loc_store.CONSTANT`, `loc_storew.CONSTANT`, `mem_load.CONSTANT`, `mem_loadw.CONSTANT`, `mem_store.CONSTANT`, `mem_storew.CONSTANT`.
 
 Constants must be declared right after module imports and before any procedures or program bodies. A constant's name must start with an upper-case letter and can contain any combination of numbers, upper-case ASCII letters, and underscores (`_`). The number of characters in a constant name cannot exceed 100.
 


### PR DESCRIPTION
This PR introduces constant support for the following operations:

* `locaddr.CONSTANT`
* `loc_load.CONSTANT`
* `loc_loadw.CONSTANT`
* `loc_store.CONSTANT`
* `loc_storew.CONSTANT`
* `mem_load.CONSTANT`
* `mem_loadw.CONSTANT`
* `mem_store.CONSTANT`
* `mem_storew.CONSTANT`
