### PR TITLE
chore: format ext2fri and sha256 docstrings using current guidelines

### DIFF
--- a/stdlib/asm/crypto/fri/ext2fri.masm
+++ b/stdlib/asm/crypto/fri/ext2fri.masm
@@ -10,13 +10,8 @@
 #! which is used for piping interpolated polynomial coefficients into memory, which will be later
 #! used for computing α.
 #!
-#! Expected stack state:
-#!
-#! [q_ptr, p_ptr, ...]
-#!
-#! Final stack state:
-#!
-#! [τ1, τ0, q_ptr, ...] | τ = (τ0, τ1)
+#! Input: [q_ptr, p_ptr, ...]
+#! Output: [τ1, τ0, q_ptr, ...]
 #!
 #! τ = rpo::hash_elements(q || p)[..2]
 #!
@@ -74,13 +69,8 @@ end
 #! which is used for piping interpolated polynomial coefficients into memory, which will be later
 #! used for computing α.
 #!
-#! Expected stack state:
-#!
-#! [q_ptr, p_ptr, ...]
-#!
-#! Final stack state:
-#!
-#! [τ1, τ0, q_ptr, ...] | τ = (τ0, τ1)
+#! Input: [q_ptr, p_ptr, ...]
+#! Output: [τ1, τ0, q_ptr, ...]
 #!
 #! τ = rpo::hash_elements(q || p)[..2]
 #!
@@ -124,23 +114,17 @@ proc.compute_tau_32
     drop
 end
 
-#! Given ω, accumulator ν and τ on the top of the stack, this routine first computes ⍳, then it
-#! loads four elements from memory address (q_ptr + 1) i.e. a0, a1, a2, a3 and finally accumulates
-#! it into ν, while consuming <a1, a0>, only when j is even | j ∈ [0..64)
+#! Given ω, accumulator ν and τ on the top of the stack, this routine first computes ⍳ = ω / (τ - ω),
+#! then it loads four elements from memory address (q_ptr + 1) i.e. a0, a1, a2, a3 and finally
+#! accumulates it into ν, while consuming <a1, a0>, only when j is even | j ∈ [0..64)
 #!
-#! Expected stack state:
+#! Input: [ω, ν1, ν0, τ1, τ0, q_ptr - 1, ...]
+#! Output: [a3, a2, ν1', ν0', τ1, τ0, q_ptr, ...]
 #!
-#! [ω, ν1, ν0, τ1, τ0, q_ptr - 1, ...]
-#!
-#! One computes ⍳ = ω / (τ - ω)
-#! <a0, a1, a2, a3> loaded from (q_ptr + 1) s.t. a1, a0 are consumed into ν
-#!
-#! Final stack state:
-#!
-#! [a3, a2, ν1', ν0', τ1, τ0, q_ptr, ...]
-#!
-#! Remaining part of word i.e. a3, a2 will be consumed during immediate next iteration
-#! of computing β which involves invocation of accumulate_for_odd_index.
+#! Where:
+#!    <a0, a1, a2, a3> loaded from (q_ptr + 1) s.t. a1, a0 are consumed into ν, and
+#!    remaining part of word i.e. a3, a2 will be consumed during immediate next iteration
+#!    of computing β which involves invocation of accumulate_for_odd_index.
 proc.accumulate_for_even_index
     # compute ⍳ = ω / (τ - ω)
     dup.4
@@ -187,21 +171,16 @@ proc.accumulate_for_even_index
     # into ν, in next iteration, when j is odd.
 end
 
-#! Given ω, accumulator ν and τ on stack top, this routine first computes ⍳ , and then accumulates
-#! ⍳ into ν, while consuming <a2, a3>, only when j is odd | j ∈ [0..64), following formula for
-#! computing β.
+#! Given ω, accumulator ν and τ on stack top, this routine first computes ⍳ = ω / (τ - ω), and
+#! then accumulates ⍳ into ν, while consuming <a2, a3>, only when j is odd | j ∈ [0..64), following
+#! formula for computing β.
 #!
-#! Expected stack state:
+#! Input: [ω, a3, a2, ν1, ν0, τ1, τ0, q_ptr, ...]
+#! Output: [ν1', ν0', τ1, τ0, q_ptr, ...]
 #!
-#! [ω, a3, a2, ν1, ν0, τ1, τ0, q_ptr, ...]
-#!
-#! One computes ⍳ = ω / (τ - ω)
-#! <a2, a3> which was loaded (during the previous iteration i.e. when j was even) from q_ptr
-#! is consumed into ν.
-#!
-#! Final stack state:
-#!
-#! [ν1', ν0', τ1, τ0, q_ptr, ...]
+#! Where:
+#!   <a2, a3> which was loaded (during the previous iteration i.e. when j was even) from q_ptr
+#!   is consumed into ν.
 proc.accumulate_for_odd_index
     # compute ⍳ = ω / (τ - ω)
     dup.6
@@ -230,13 +209,8 @@ end
 
 #! Given τ and starting memory address to q (FRI codeword of size 64), this routine computes β.
 #!
-#! Expected stack state
-#!
-#! [τ1, τ0, q_ptr, ...]
-#!
-#! Final stack state
-#!
-#! [β1, β0, τ1, τ0, q_ptr, ...]
+#! Input: [τ1, τ0, q_ptr, ...]
+#! Output: [β1, β0, τ1, τ0, q_ptr, ...]
 proc.compute_beta_64
     # decrement starting address by 1, because we first increment and then load onto the stack
     movup.2
@@ -522,13 +496,8 @@ end
 
 #! Given τ and starting memory address to q (FRI codeword of size 32), this routine computes β.
 #!
-#! Expected stack state
-#!
-#! [τ1, τ0, q_ptr, ...]
-#!
-#! Final stack state
-#!
-#! [β1, β0, τ1, τ0, q_ptr, ...]
+#! Input: [τ1, τ0, q_ptr, ...]
+#! Output: [β1, β0, τ1, τ0, q_ptr, ...]
 proc.compute_beta_32
     # decrement starting address by 1, because we first increment and then load onto the stack
     movup.2
@@ -687,13 +656,8 @@ end
 #! Given τ and end memory address of interpolated polynomial p (with degree at max 7, over
 #! quadratic extension field of Fq) on the top of the stack, this routine computes α.
 #!
-#! Expected stack state:
-#!
-#! [_, _, τ1, τ0, p_ptr, ...]
-#!
-#! Final stack state:
-#!
-#! [α1, α0, _, _, ...]
+#! Input: [_, _, τ1, τ0, p_ptr, ...]
+#! Output: [α1, α0, _, _, ...]
 #!
 #! Note, p_ptr is absolute memory address of polynomial p (which was interpolated using advice
 #! provider) s.t. next 3 decreasing (by 1) memory addresses hold remaining 6 coefficients of p.
@@ -772,13 +736,8 @@ end
 #! Given τ and end memory address of interpolated polynomial p (with degree at max 3, over
 #! quadratic extension field of Fq) on the top of the stack, this routine computes α.
 #!
-#! Expected stack state:
-#!
-#! [_, _, τ1, τ0, p_ptr, ...]
-#!
-#! Final stack state:
-#!
-#! [α1, α0, _, _, ...]
+#! Input: [_, _, τ1, τ0, p_ptr, ...]
+#! Output: [α1, α0, _, _, ...]
 #!
 #! Note, p_ptr is absolute memory address of polynomial p (which was interpolated using advice
 #! provider) s.t. this and next (decreased by 1) memory address holds total 4 coefficients of p.
@@ -817,9 +776,8 @@ end
 #! Given memory address of the remainder codeword with 64 evaluations, this routine attempts to
 #! probabilistically verify that the codeword contains evaluations of a degree 7 polynomial.
 #!
-#! Expected stack state:
-#!
-#! [q_ptr, ...]
+#! Input: [q_ptr, ...]
+#! Output: [...]
 #!
 #! A few assumptions about q_ptr:
 #! - q_ptr is an absolute memory address of the beginning of remainder codeword.
@@ -830,8 +788,6 @@ end
 #! - Next 31 memory addresses should be holding remaining 62 evaluations. That is, if q_ptr holds
 #!   (a0_0, a0_1, a1_0, a1_1), then q_ptr + 1, must hold (a2_0, a2_1, a3_0, a3_1), and q_ptr + 31
 #!   should be holding (a62_0, a62_1, a63_0, a63_1).
-#!
-#! At the end of execution q_ptr is popped off the stack.
 #!
 #! If remainder verification fails, execution of the program stops.
 export.verify_remainder_64.4
@@ -877,9 +833,8 @@ end
 #! Given memory address of the remainder codeword with 32 evaluations, this routine attempts to
 #! probabilistically verify that the codeword contains evaluations of a degree 3 polynomial.
 #!
-#! Expected stack state:
-#!
-#! [q_ptr, ...]
+#! Input: [q_ptr, ...]
+#! Output: [...]
 #!
 #! A few assumptions about q_ptr:
 #! - q_ptr is an absolute memory address of the beginning of remainder codeword.
@@ -890,8 +845,6 @@ end
 #! - Next 15 memory addresses should be holding remaining 30 evaluations. That is, if q_ptr holds
 #!   (a0_0, a0_1, a1_0, a1_1), then q_ptr + 1, must hold (a2_0, a2_1, a3_0, a3_1), and q_ptr + 15
 #!   should be holding (a30_0, a30_1, a31_0, a31_1).
-#!
-#! At the end of execution q_ptr is popped off the stack.
 #!
 #! If remainder verification fails, execution of the program stops.
 export.verify_remainder_32.2

--- a/stdlib/asm/crypto/hashes/sha256.masm
+++ b/stdlib/asm/crypto/hashes/sha256.masm
@@ -1,6 +1,9 @@
-#! Given [x, ...] on stack top, this routine computes [y, ...]
-#! such that y = σ_0(x), as defined in SHA specification
+#! Computes SHA2 small sigma 0.
 #!
+#! Input: [x, ...]
+#! Output: [y, ...]
+#!
+#! Where y = σ_0(x), as defined in SHA specification
 #! See https://github.com/itzmeanjan/merklize-sha/blob/8a2c006/include/sha2.hpp#L73-L79
 proc.small_sigma_0
     dup
@@ -19,9 +22,12 @@ proc.small_sigma_0
     u32checked_xor
 end
 
-#! Given [x, ...] on stack top, this routine computes [y, ...]
-#! such that y = σ_1(x), as defined in SHA specification
+#! Computes SHA2 small sigma 1.
 #!
+#! Input: [x, ...]
+#! Output: [y, ...]
+#!
+#! Where y = σ_1(x), as defined in SHA specification
 #! See https://github.com/itzmeanjan/merklize-sha/blob/8a2c006/include/sha2.hpp#L81-L87
 proc.small_sigma_1
     dup
@@ -40,9 +46,12 @@ proc.small_sigma_1
     u32checked_xor
 end
 
-#! Given [x, ...] on stack top, this routine computes [y, ...]
-#! such that y = Σ_0(x), as defined in SHA specification
+#! Computes SHA2 big sigma 0.
 #!
+#! Input: [x, ...]
+#! Output: [y, ...]
+#!
+#! Where y = Σ_0(x), as defined in SHA specification
 #! See https://github.com/itzmeanjan/merklize-sha/blob/8a2c006/include/sha2.hpp#L57-L63
 proc.cap_sigma_0
     dup
@@ -61,9 +70,12 @@ proc.cap_sigma_0
     u32checked_xor
 end
 
-#! Given [x, ...] on stack top, this routine computes [y, ...]
-#! such that y = Σ_1(x), as defined in SHA specification
+#! Computes SHA2 big sigma 1.
 #!
+#! Input: [x, ...]
+#! Output: [y, ...]
+#!
+#! Where y = Σ_1(x), as defined in SHA specification
 #! See https://github.com/itzmeanjan/merklize-sha/blob/8a2c006/include/sha2.hpp#L65-L71
 proc.cap_sigma_1
     dup
@@ -82,9 +94,12 @@ proc.cap_sigma_1
     u32checked_xor
 end
 
-#! Given [x, y, z, ...] on stack top, this routine computes [o, ...]
-#! such that o = ch(x, y, z), as defined in SHA specification
+#! Computes SHA2 ch.
 #!
+#! Input: [x, y, z, ...]
+#! Output: [o, ...]
+#!
+#! Where o = ch(x, y, z), as defined in SHA specification
 #! See https://github.com/itzmeanjan/merklize-sha/blob/8a2c006/include/sha2.hpp#L37-L45
 proc.ch
     swap
@@ -100,9 +115,12 @@ proc.ch
     u32checked_xor
 end
 
-#! Given [x, y, z, ...] on stack top, this routine computes [o, ...]
-#! such that o = maj(x, y, z), as defined in SHA specification
+#! Computes SHA2 maj.
 #!
+#! Input: [x, y, z, ...]
+#! Output: [o, ...]
+#!
+#! Where o = maj(x, y, z), as defined in SHA specification
 #! See https://github.com/itzmeanjan/merklize-sha/blob/8a2c006/include/sha2.hpp#L47-L55
 proc.maj
     dup.1
@@ -121,21 +139,23 @@ proc.maj
     u32checked_xor
 end
 
-#! Given [a, b, c, d, ...] on stack top, this routine reverses order of first
-#! four elements on stack top such that final stack state looks like [d, c, b, a, ...]
+#! Reverses order of first four elements on stack
+#!
+#! Input: [a, b, c, d, ...]
+#! Output: [d, c, b, a, ...]
+#! Cycles: 3
 proc.rev_element_order
     swap
     movup.2
     movup.3
 end
 
-#! Given [a, b, c, d, ...] on stack top, this routine computes next message schedule word
-#! using following formula
+#! Computes next message schedule word
 #!
-#! t0 = small_sigma_1(a) + b
-#! t1 = small_sigma_0(c) + d
-#! return t0 + t1
+#! Input: [a, b, c, d, ...]
+#! Output: [r, ...]
 #!
+#! Where:
 #! If to be computed message schedule word has index i ∈ [16, 64), then
 #! a, b, c, d will have following indices in message schedule
 #!
@@ -143,6 +163,10 @@ end
 #! b = msg[i - 7]
 #! c = msg[i - 15]
 #! d = msg[i - 16]
+#!
+#! t0 = small_sigma_1(a) + b
+#! t1 = small_sigma_0(c) + d
+#! r = t0 + t1
 proc.compute_message_schedule_word
     exec.small_sigma_1
     movup.2
@@ -153,18 +177,14 @@ proc.compute_message_schedule_word
     u32wrapping_add
 end
 
-#! Given eight working variables of SHA256 ( i.e. hash state ), a 32 -bit round constant &
-#! 32 -bit message word on stack top, this routine consumes constant & message word into
-#! hash state.
+#! Consumes constant and message word into hash state according to SHA256 specification.
 #!
-#! Expected stack state looks like
+#! Input: [a, b, c, d, e, f, g, h, CONST_i, WORD_i]
+#! Output: [a', b', c', d', e', f', g', h']
 #!
-#! [a, b, c, d, e, f, g, h, CONST_i, WORD_i] | i ∈ [0, 64)
-#!
-#! After finishing execution, stack looks like
-#!
-#! [a', b', c', d', e', f', g', h']
-#!
+#! Where:
+#! - i ∈ [0, 64)
+#! - a through h are working variables of SHA256 ( i.e. hash state )
 #! See https://github.com/itzmeanjan/merklize-sha/blob/8a2c006/include/sha2_256.hpp#L165-L175
 proc.consume_message_word
     dup.6
@@ -203,20 +223,14 @@ proc.consume_message_word
     u32wrapping_add
 end
 
-#! Given 32 -bytes hash state ( in terms of 8 SHA256 words ) and 64 -bytes input
-#! message ( in terms of 16 SHA256 words ) on stack top, this routine computes
-#! whole message schedule of 64 message words and consumes them into hash state.
+#! Computes whole message schedule of 64 message words and consumes them into hash state.
 #!
-#! Expected stack state:
+#! Input: [state0, state1, state2, state3, state4, state5, state6, state7, msg0, msg1, msg2, msg3, msg4, msg5, msg6, msg7, msg8, msg9, msg10, msg11, msg12, msg13, msg14, msg15]
+#! Output: [state0', state1', state2', state3', state4', state5', state6', state7']
 #!
-#! [state0, state1, state2, state3, state4, state5, state6, state7, msg0, msg1, msg2, msg3, msg4, msg5, msg6, msg7, msg8, msg9, msg10, msg11, msg12, msg13, msg14, msg15]
-#!
-#! Final stack state after completion of execution
-#!
-#! [state0', state1', state2', state3', state4', state5', state6', state7']
-#!
-#! Note, each SHA256 word is 32 -bit wide
-#!
+#! Where:
+#! - state0 through state7 are the hash state (in terms of 8 SHA256 words)
+#! - msg0 through msg15 are the 64 -bytes input message (in terms of 16 SHA256 words)
 #! See https://github.com/itzmeanjan/merklize-sha/blob/8a2c006/include/sha2.hpp#L89-L113
 #! & https://github.com/itzmeanjan/merklize-sha/blob/8a2c006/include/sha2_256.hpp#L148-L187 ( loop body execution when i = 0 )
 proc.prepare_message_schedule_and_consume.2
@@ -1079,22 +1093,15 @@ proc.prepare_message_schedule_and_consume.2
     movdn.7
 end
 
-#! Given 32 -bytes hash state ( in terms of 8 SHA256 words ) and precomputed message
-#! schedule of padding bytes ( in terms of 64 message words ), this routine consumes
-#! that into hash state, leaving final hash state, which is 32 -bytes SHA256 digest.
+#! Consumes precomputed message schedule of padding bytes into hash state, returns final hash state.
+#!
+#! Input: [state0, state1, state2, state3, state4, state5, state6, state7, ...]
+#! Output: [state0', state1', state2', state3', state4', state5', state6', state7']
 #!
 #! Note, in SHA256 2-to-1 hashing, 64 -bytes are padded, which is processed as second message
 #! block ( each SHA256 message block is 64 -bytes wide ). That message block is used for generating
 #! message schedule of 64 SHA256 words. That's exactly what can be precomputed & is consumed here
 #! ( in this routine ) into provided hash state.
-#!
-#! Expected stack state:
-#!
-#! [state0, state1, state2, state3, state4, state5, state6, state7, ...]
-#!
-#! Final stack state after completion of execution
-#!
-#! [state0', state1', state2', state3', state4', state5', state6', state7']
 #!
 #! Note, each SHA256 word is 32 -bit wide
 #!
@@ -1529,17 +1536,14 @@ end
 
 #! Given 64 -bytes input, this routine computes 32 -bytes SHA256 digest
 #!
-#! Expected stack state:
+#! Input: [m0, m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15, ...]
+#! Output: [dig0, dig1, dig2, dig3, dig4, dig5, dig6, dig7, ...]
 #!
-#! [m0, m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15, ...] | m[0,16) = 32 -bit word
+#! Where: m[0,16) = 32 -bit word
 #!
 #! Note, each SHA256 word is 32 -bit wide, so that's how input is expected.
 #! As you've 64 -bytes, consider packing 4 consecutive bytes into single word,
 #! maintaining big endian byte order.
-#!
-#! Final stack state:
-#!
-#! [dig0, dig1, dig2, dig3, dig4, dig5, dig6, dig7, ...]
 #!
 #! SHA256 digest is represented in terms of eight 32 -bit words ( big endian byte order ).
 export.hash_2to1
@@ -1554,15 +1558,14 @@ end
 #!
 #! Expected stack state:
 #!
-#! [m0, m1, m2, m3, m4, m5, m6, m7, ...] | m[0,8) = 32 -bit word
+#! Input: [m0, m1, m2, m3, m4, m5, m6, m7, ...]
+#! Output: [dig0, dig1, dig2, dig3, dig4, dig5, dig6, dig7, ...]
+#!
+#! Where: m[0,8) = 32 -bit word
 #!
 #! Note, each SHA256 word is 32 -bit wide, so that's how input is expected.
 #! As you've 32 -bytes, consider packing 4 consecutive bytes into single word,
 #! maintaining big endian byte order.
-#!
-#! Final stack state:
-#!
-#! [dig0, dig1, dig2, dig3, dig4, dig5, dig6, dig7, ...]
 #!
 #! SHA256 digest is represented in terms of eight 32 -bit words ( big endian byte order ).
 export.hash_1to1


### PR DESCRIPTION
## Describe your changes

This is a first iteration on the existing masm code to move the formatting according to https://github.com/0xPolygonMiden/miden-vm/discussions/698 . Hopefully I didn't introduce any errors :)

On this round I just added the Input/Output, only counted cycles for a very simple method, after I started this I realized the whole codebase will take a lot of time, so I decided to open this small PR first, with just a few of the changes to get it started, the other changes / files will come on follow ups.

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
