### PR TITLE
Fix typos in docs

### DIFF
--- a/docs/src/design/decoder/constraints.md
+++ b/docs/src/design/decoder/constraints.md
@@ -245,8 +245,8 @@ Adding and removing entries to/from the block hash table is accomplished as foll
 To simplify constraint descriptions, we define values representing left and right children of a block as follows:
 
 $$
-ch_1 = \alpha_0 + \alpha_1 \cdot a' + \sum_{i=0}^3(a_{i+2} \cdot h_i) \text{ | degree} = 1 \\
-ch_2 = \alpha_0 + \alpha_1 \cdot a' + \sum_{i=0}^3(a_{i+2} \cdot h_{i+4}) \text{ | degree} = 1
+ch_1 = \alpha_0 + \alpha_1 \cdot a' + \sum_{i=0}^3(\alpha_{i+2} \cdot h_i) \text{ | degree} = 1 \\
+ch_2 = \alpha_0 + \alpha_1 \cdot a' + \sum_{i=0}^3(\alpha_{i+2} \cdot h_{i+4}) \text{ | degree} = 1
 $$
 
 Graphically, this looks like so:
@@ -266,7 +266,7 @@ Using the above variables, we define row values to be added to and removed from 
 When `JOIN` operation is executed, hashes of both child nodes are added to the block hash table. We add $\alpha_6$ term to the first child value to differentiate it from the second child (i.e., this sets `is_first_child` to $1$):
 
 $$
-v_{join} = f_{join} \cdot (ch_1 + \alpha^6) \cdot ch_2  \text{ | degree} = 8
+v_{join} = f_{join} \cdot (ch_1 + \alpha_6) \cdot ch_2  \text{ | degree} = 8
 $$
 
 When `SPLIT` operation is executed and the top of the stack is $1$, hash of the *true* branch is added to the block hash table, but when the top of the stack is $0$, hash of the *false* branch is added to the block hash table:
@@ -310,12 +310,12 @@ In addition to the above transition constraint, we also need to set the followin
 Span block constraints ensure proper decoding of span blocks. In addition to the block stack table constraints and block hash table constraints described previously, decoding of span blocks requires constraints described below.
 
 ### In-span column constraints
-The `in_span` column (denoted as $sp$) is used to identify rows which execute non-control flow operations. The values in this column are set as follows:
+The `is_span` column (denoted as $sp$) is used to identify rows which execute non-control flow operations. The values in this column are set as follows:
 
-* Executing a `SPAN` operation sets the value of `in_span` column to $1$.
+* Executing a `SPAN` operation sets the value of `is_span` column to $1$.
 * The value remains $1$ until the `END` operation is executed.
-* If `RESPAN` operation is executed between `SPAN` and `END` operations, in the row at which `RESPAN` operation is executed `in_span` is set to $0$. It is then reset to $1$ in the following row.
-* In all other cases, value in the `in_span` column should be $0$.
+* If `RESPAN` operation is executed between `SPAN` and `END` operations, in the row at which `RESPAN` operation is executed `is_span` is set to $0$. It is then reset to $1$ in the following row.
+* In all other cases, value in the `is_span` column should be $0$.
 
 The picture below illustrates the above rules.
 
@@ -544,7 +544,7 @@ Where $i \in 1..7$. Thus, $v_1$ defines row value for group in $h_1$, $v_2$ defi
 We compute the value of the row to be removed from the op group table as follows:
 
 $$
-u = \alpha_0 + \alpha_1 \cdot a + \alpha^2 \cdot gc + \alpha_3 \cdot ((h_0' \cdot 2^7 + op') \cdot (1 - f_{push}) + s_0' \cdot f_{push}) \text{ | degree} = 5
+u = \alpha_0 + \alpha_1 \cdot a + \alpha_2 \cdot gc + \alpha_3 \cdot ((h_0' \cdot 2^7 + op') \cdot (1 - f_{push}) + s_0' \cdot f_{push}) \text{ | degree} = 5
 $$
 
 In the above, the value of the group is computed as $(h_0' \cdot 2^7 + op') \cdot (1 - f_{push}) + s_0' \cdot f_{push}$. This basically says that when we execute a `PUSH` operation we need to remove the immediate value from the table. This value is at the top of the stack (column $s_0$) in the next row. However, when we are not executing a `PUSH` operation, the value to be removed is an op group value which is a combination of values in $h_0$ and `op_bits` columns (also in the next row). Note also that value for batch address comes from the current value in the block address column ($a$), and the group position comes from the current value of the group count column ($gc$).

--- a/docs/src/design/decoder/constraints.md
+++ b/docs/src/design/decoder/constraints.md
@@ -86,7 +86,7 @@ Values in `op_bits` columns must be binary (i.e., either $1$ or $0$):
 b_i^2 - b_i = 0 \text{ for } i \in 0..6 \text{ | degree} = 2
 $$
 
-When the value in `is_span` column is set to $1$, control flow operations cannot be executed on the VM, but when `is_span` flag is $0$, only control flow operations can be executed on the VM:
+When the value in `in_span` column is set to $1$, control flow operations cannot be executed on the VM, but when `in_span` flag is $0$, only control flow operations can be executed on the VM:
 
 > $$
 1 - sp - f_{ctrl} = 0 \text{ | degree} = 4
@@ -310,12 +310,12 @@ In addition to the above transition constraint, we also need to set the followin
 Span block constraints ensure proper decoding of span blocks. In addition to the block stack table constraints and block hash table constraints described previously, decoding of span blocks requires constraints described below.
 
 ### In-span column constraints
-The `is_span` column (denoted as $sp$) is used to identify rows which execute non-control flow operations. The values in this column are set as follows:
+The `in_span` column (denoted as $sp$) is used to identify rows which execute non-control flow operations. The values in this column are set as follows:
 
-* Executing a `SPAN` operation sets the value of `is_span` column to $1$.
+* Executing a `SPAN` operation sets the value of `in_span` column to $1$.
 * The value remains $1$ until the `END` operation is executed.
-* If `RESPAN` operation is executed between `SPAN` and `END` operations, in the row at which `RESPAN` operation is executed `is_span` is set to $0$. It is then reset to $1$ in the following row.
-* In all other cases, value in the `is_span` column should be $0$.
+* If `RESPAN` operation is executed between `SPAN` and `END` operations, in the row at which `RESPAN` operation is executed `in_span` is set to $0$. It is then reset to $1$ in the following row.
+* In all other cases, value in the `in_span` column should be $0$.
 
 The picture below illustrates the above rules.
 

--- a/docs/src/design/decoder/main.md
+++ b/docs/src/design/decoder/main.md
@@ -287,9 +287,9 @@ In the above diagram, `blk` is the ID of the *split* block which is about to be 
 When the VM executes a `SPLIT` operation, it does the following:
 
 1. Adds a tuple `(blk, prnt, 0)` to the block stack table.
-2. Pops the stack and:
-   a. If the popped value is $1$, adds a tuple `(blk, true_branch_hash, 0, 0)` to the block hash table.
-   b. If the popped value is $0$, adds a tuple `(blk, false_branch_hash, 0, 0)` to the block hash table.
+2. Pops the stack and:\
+   a. If the popped value is $1$, adds a tuple `(blk, true_branch_hash, 0, 0)` to the block hash table.\
+   b. If the popped value is $0$, adds a tuple `(blk, false_branch_hash, 0, 0)` to the block hash table.\
    c. If the popped value is neither $1$ nor $0$, the execution fails.
 3. Initiates a 2-to-1 hash computation in the hash chiplet (as described [here](#simple-2-to-1-hash)) using `blk` as row address in the auxiliary hashing table and $h_0, ..., h_7$ as input values.
 
@@ -303,9 +303,9 @@ In the above diagram, `blk` is the ID of the *loop* block which is about to be e
 
 When the VM executes a `LOOP` operation, it does the following:
 
-1. Pops the stack and:
-   a. If the popped value is $1$ adds a tuple `(blk, prnt, 1)` to the block stack table (the `1` indicates that the loop's body is expected to be executed). Then, adds a tuple `(blk, loop_body_hash, 0, 1)` to the block hash table.
-   b. If the popped value is $0$, adds `(blk, prnt, 0)` to the block stack table. In this case, nothing is added to the block hash table.
+1. Pops the stack and:\
+   a. If the popped value is $1$ adds a tuple `(blk, prnt, 1)` to the block stack table (the `1` indicates that the loop's body is expected to be executed). Then, adds a tuple `(blk, loop_body_hash, 0, 1)` to the block hash table.\
+   b. If the popped value is $0$, adds `(blk, prnt, 0)` to the block stack table. In this case, nothing is added to the block hash table.\
    c. If the popped value is neither $1$ nor $0$, the execution fails.
 2. Initiates a 2-to-1 hash computation in the hash chiplet (as described [here](#simple-2-to-1-hash)) using `blk` as row address in the auxiliary hashing table and $h_0, ..., h_3$ as input values.
 

--- a/docs/src/design/stack/crypto_ops.md
+++ b/docs/src/design/stack/crypto_ops.md
@@ -15,11 +15,11 @@ In the above, $r$ (located in the helper register $h_0$) is the row address from
 For the `HPERM` operation, we define input and output values as follows:
 
 $$
-v_{input} = \alpha_0 + \alpha_1 \cdot op_{linhash} + \alpha_2 \cdot h_0 + \sum_{j=0}^{11} (\alpha_{j+4} \cdot s_{11-i})
+v_{input} = \alpha_0 + \alpha_1 \cdot op_{linhash} + \alpha_2 \cdot h_0 + \sum_{j=0}^{11} (\alpha_{j+4} \cdot s_{11-j})
 $$
 
 $$
-v_{output} = \alpha_0 + \alpha_1 \cdot op_{retstate} + \alpha_2 \cdot (h_0 + 7) + \sum_{j=0}^{11} (\alpha_{i+4} \cdot s_{11-i}')
+v_{output} = \alpha_0 + \alpha_1 \cdot op_{retstate} + \alpha_2 \cdot (h_0 + 7) + \sum_{j=0}^{11} (\alpha_{j+4} \cdot s_{11-j}')
 $$
 
 In the above, $op_{linhash}$ and $op_{retstate}$ are the unique [operation labels](../chiplets/main.md#operation-labels) for initiating a linear hash and reading the full state of the hasher respectively. Also note that the term for $\alpha_3$ is missing from the above expressions because for Rescue Prime Optimized permutation computation the index column is expected to be set to $0$.

--- a/docs/src/design/stack/op_constraints.md
+++ b/docs/src/design/stack/op_constraints.md
@@ -138,7 +138,7 @@ This group contains $16$ operations which shift the stack to the right (i.e., pu
 | `DUP11`      | $58$         | `011_1010`      | [Stack ops](./stack_ops.md)   | $7$         |
 | `DUP13`      | $59$         | `011_1011`      | [Stack ops](./stack_ops.md)   | $7$         |
 | `DUP15`      | $60$         | `011_1100`      | [Stack ops](./stack_ops.md)   | $7$         |
-| `ADVPOP`     | $61$         | `011_1101`      | [Stack ops](./io_ops.md)      | $7$         |
+| `ADVPOP`     | $61$         | `011_1101`      | [I/O ops](./io_ops.md)        | $7$         |
 | `SDEPTH`     | $62$         | `011_1110`      | [I/O ops](./io_ops.md)        | $7$         |
 | `CLK`        | $63$         | `011_1111`      | [System ops](./system_ops.md) | $7$         |
 

--- a/docs/src/design/stack/stack_ops.md
+++ b/docs/src/design/stack/stack_ops.md
@@ -165,7 +165,7 @@ $$
 where $n$ is the depth to which the top stack element is moved.
 
 The effect of this operation on the rest of the stack is:
-* **Right shift** for elements between $0$ and $n-1$.
+* **Left shift** for elements between $1$ and $n$.
 * **No change** starting from position $n+1$.
 
 ## CSWAP
@@ -216,7 +216,7 @@ s_i' - s_0 \cdot s_{i+5} - (1-s_0) \cdot s_{i+1} = 0 \text{ for } i \in \{0..3\}
 $$
 
 >$$
-s_{i+4}' - s_0 \cdot s_{i+1} + (1-s_0) \cdot s_{i+5} = 0 \text{ for } i \in \{0..3\} \text{ | degree} = 2
+s_{i+4}' - s_0 \cdot s_{i+1} - (1-s_0) \cdot s_{i+5} = 0 \text{ for } i \in \{0..3\} \text{ | degree} = 2
 $$
 
 We also need to enforce that the value in $s_0$ is binary. This can be done with the following constraint:

--- a/docs/src/design/stack/u32_ops.md
+++ b/docs/src/design/stack/u32_ops.md
@@ -7,7 +7,7 @@ Most operations described below require some number of 16-bit range checks (i.e.
 To perform these range checks, the prover puts the values to be range-checked into helper registers $h_0, ..., h_3$, and then divides the range checker bus column $b_{range}$ by a randomized product of these values. This operation is enforced via the following constraint:
 
 >$$
-b_{range}' \cdot (\alpha_0 + h_0) \cdot (\alpha_1 + h_1) \cdot (\alpha_2 + h_2) \cdot (\alpha_3 + h_3) = b_{range} \text{ | degree} = 5
+b_{range}' \cdot (\alpha_0 + h_0) \cdot (\alpha_0 + h_1) \cdot (\alpha_0 + h_2) \cdot (\alpha_0 + h_3) = b_{range} \text{ | degree} = 5
 $$
 
 The above is just a partial constraint as it does not show the range checker's part of the constraint, which multiplies the required values into the bus column. It also omits the [selector flag](./op_constraints.md#operation-flags) which is used to turn this constraint on only when executing relevant operations.

--- a/docs/src/design/stack/u32_ops.md
+++ b/docs/src/design/stack/u32_ops.md
@@ -7,7 +7,7 @@ Most operations described below require some number of 16-bit range checks (i.e.
 To perform these range checks, the prover puts the values to be range-checked into helper registers $h_0, ..., h_3$, and then divides the range checker bus column $b_{range}$ by a randomized product of these values. This operation is enforced via the following constraint:
 
 >$$
-b_{range}' \cdot (\alpha_0 + h_0) \cdot (\alpha_0 + h_1) \cdot (\alpha_0 + h_2) \cdot (\alpha_0 + h_3) = b_{range} \text{ | degree} = 5
+b_{range}' \cdot (\alpha_0 + h_0) \cdot (\alpha_1 + h_1) \cdot (\alpha_2 + h_2) \cdot (\alpha_3 + h_3) = b_{range} \text{ | degree} = 5
 $$
 
 The above is just a partial constraint as it does not show the range checker's part of the constraint, which multiplies the required values into the bus column. It also omits the [selector flag](./op_constraints.md#operation-flags) which is used to turn this constraint on only when executing relevant operations.


### PR DESCRIPTION
This PR fixes small typos in Miden VM documentation.
