### PR TITLE
Reduce Procedure Id Length to 20 -bytes

### DIFF
--- a/assembly/src/parsers/nodes.rs
+++ b/assembly/src/parsers/nodes.rs
@@ -595,8 +595,8 @@ fn test_instruction_display() {
     );
     assert_eq!("push.3.4.8.9", instruction);
 
-    let hash = [7; 24];
+    let hash = [7; 20];
     let proc_id = ProcedureId::from(hash);
     let instruction = format!("{}", Instruction::ExecImported(proc_id));
-    assert_eq!("exec.0x070707070707070707070707070707070707070707070707", instruction);
+    assert_eq!("exec.0x0707070707070707070707070707070707070707", instruction);
 }

--- a/assembly/src/procedures/mod.rs
+++ b/assembly/src/procedures/mod.rs
@@ -1,5 +1,5 @@
 use super::{
-    crypto::hash::Blake3_192, AbsolutePath, BTreeSet, ByteReader, ByteWriter, CodeBlock,
+    crypto::hash::Blake3_160, AbsolutePath, BTreeSet, ByteReader, ByteWriter, CodeBlock,
     Deserializable, DeserializationError, LabelError, Serializable, String, ToString,
     MODULE_PATH_DELIM, PROCEDURE_LABEL_PARSER,
 };
@@ -192,7 +192,7 @@ pub struct ProcedureId(pub [u8; Self::SIZE]);
 
 impl ProcedureId {
     /// Truncated length of the id
-    pub const SIZE: usize = 24;
+    pub const SIZE: usize = 20;
 
     /// Creates a new procedure id from its path, composed by module path + name identifier.
     ///
@@ -202,7 +202,7 @@ impl ProcedureId {
         L: AsRef<str>,
     {
         let mut digest = [0u8; Self::SIZE];
-        let hash = Blake3_192::hash(path.as_ref().as_bytes());
+        let hash = Blake3_160::hash(path.as_ref().as_bytes());
         digest.copy_from_slice(&(*hash)[..Self::SIZE]);
         Self(digest)
     }


### PR DESCRIPTION
This small PR address the issue described in https://github.com/0xPolygonMiden/miden-vm/issues/711. Instead of using BLAKE3_192 variant for computing 24 -bytes procedure id from procedure path name, we're using BLAKE3_160 variant now. 