### PR TITLE
Remove Dependency of Miden REPL on `internals` feature of `miden-processor`

### DIFF
--- a/miden/Cargo.toml
+++ b/miden/Cargo.toml
@@ -39,7 +39,7 @@ path = "tests/integration/main.rs"
 [features]
 concurrent = ["prover/concurrent", "std"]
 default = ["std"]
-executable = ["env_logger", "hex/std", "processor/internals", "std", "serde/std", "serde_derive", "serde_json/std", "structopt", "rustyline"]
+executable = ["env_logger", "hex/std", "std", "serde/std", "serde_derive", "serde_json/std", "structopt", "rustyline"]
 std = ["assembly/std", "log/std", "processor/std", "prover/std", "verifier/std"]
 
 [dependencies]

--- a/miden/src/repl/mod.rs
+++ b/miden/src/repl/mod.rs
@@ -270,7 +270,10 @@ fn execute(program: String) -> Result<(Vec<(u64, Word)>, Vec<Felt>), ProgramErro
     let advice_provider = MemAdviceProvider::default();
 
     let state_iter = processor::execute_iter(&program, stack_inputs, advice_provider);
-    let (system, _, stack, chiplets) = state_iter.into_parts();
+    let (system, _, stack, chiplets, err) = state_iter.into_parts();
+    if let Some(err) = err {
+        return Err(ProgramError::ExecutionError(err));
+    }
 
     // loads the memory at the latest clock cycle.
     let mem_state = chiplets.get_mem_state_at(0, system.clk());

--- a/miden/src/repl/mod.rs
+++ b/miden/src/repl/mod.rs
@@ -3,7 +3,6 @@ use miden::{
     math::{Felt, StarkField},
     MemAdviceProvider, StackInputs, Word,
 };
-use processor::Process;
 use rustyline::{error::ReadlineError, Editor};
 
 /// This work is in continuation to the amazing work done by team `Scribe`
@@ -270,18 +269,15 @@ fn execute(program: String) -> Result<(Vec<(u64, Word)>, Vec<Felt>), ProgramErro
     let stack_inputs = StackInputs::default();
     let advice_provider = MemAdviceProvider::default();
 
-    let mut process = Process::new_debug(program.kernel().clone(), stack_inputs, advice_provider);
-    let _program_outputs = process.execute(&program).map_err(ProgramError::ExecutionError);
-
-    let (sys, _, stack, _, chiplets, _) = process.into_parts();
+    let state_iter = processor::execute_iter(&program, stack_inputs, advice_provider);
+    let (system, _, stack, chiplets) = state_iter.into_parts();
 
     // loads the memory at the latest clock cycle.
-    let mem = chiplets.get_mem_state_at(0, sys.clk());
-
+    let mem_state = chiplets.get_mem_state_at(0, system.clk());
     // loads the stack along with the overflow values at the latest clock cycle.
-    let stack_state = stack.get_state_at(sys.clk());
+    let stack_state = stack.get_state_at(system.clk());
 
-    Ok((mem, stack_state))
+    Ok((mem_state, stack_state))
 }
 
 /// Parses the address in integer form from "!mem[addr]" command, otherwise throws an error.

--- a/processor/src/debug.rs
+++ b/processor/src/debug.rs
@@ -169,8 +169,8 @@ impl VmStateIterator {
         result
     }
 
-    pub fn into_parts(self) -> (System, Decoder, Stack, Chiplets) {
-        (self.system, self.decoder, self.stack, self.chiplets)
+    pub fn into_parts(self) -> (System, Decoder, Stack, Chiplets, Option<ExecutionError>) {
+        (self.system, self.decoder, self.stack, self.chiplets, self.error)
     }
 }
 

--- a/processor/src/debug.rs
+++ b/processor/src/debug.rs
@@ -168,6 +168,10 @@ impl VmStateIterator {
 
         result
     }
+
+    pub fn into_parts(self) -> (System, Decoder, Stack, Chiplets) {
+        (self.system, self.decoder, self.stack, self.chiplets)
+    }
 }
 
 impl Iterator for VmStateIterator {


### PR DESCRIPTION
This PR addresses the issue described in https://github.com/0xPolygonMiden/miden-vm/issues/719