### PR TITLE
rustfmt: set edition to 2021

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,4 @@
+edition = "2021"
 array_width = 80
 attr_fn_like_width = 80
 chain_width = 80


### PR DESCRIPTION
## Describe your changes

rustfmt will remove leading `::` used to disambiguate `use` imports in edition 2018+. This sets the edition so the tool will no longer remove it.

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
