### PR TITLE
refactor: advice provider merkle to return `Option`

### DIFF
--- a/processor/src/advice/mod.rs
+++ b/processor/src/advice/mod.rs
@@ -1,6 +1,6 @@
 use super::{ExecutionError, Felt, InputError, Word};
 use vm_core::{
-    crypto::merkle::{MerklePath, MerkleStore, NodeIndex},
+    crypto::merkle::{MerkleError, MerklePath, MerkleStore, NodeIndex},
     utils::{
         collections::{BTreeMap, Vec},
         IntoBytes,
@@ -105,8 +105,12 @@ pub trait AdviceProvider {
     /// - The specified depth is either zero or greater than the depth of the Merkle tree
     ///   identified by the specified root.
     /// - Value of the node at the specified depth and index is not known to this advice provider.
-    fn get_tree_node(&self, root: Word, depth: &Felt, index: &Felt)
-        -> Result<Word, ExecutionError>;
+    fn get_tree_node(
+        &self,
+        root: Word,
+        depth: &Felt,
+        index: &Felt,
+    ) -> Result<Option<Word>, ExecutionError>;
 
     /// Returns a path to a node at the specified depth and index in a Merkle tree with the
     /// specified root.
@@ -122,7 +126,7 @@ pub trait AdviceProvider {
         root: Word,
         depth: &Felt,
         index: &Felt,
-    ) -> Result<MerklePath, ExecutionError>;
+    ) -> Result<Option<MerklePath>, ExecutionError>;
 
     /// Updates a node at the specified depth and index in a Merkle tree with the specified root;
     /// returns the Merkle path from the updated node to the new root.
@@ -198,7 +202,7 @@ where
         root: Word,
         depth: &Felt,
         index: &Felt,
-    ) -> Result<Word, ExecutionError> {
+    ) -> Result<Option<Word>, ExecutionError> {
         T::get_tree_node(self, root, depth, index)
     }
 
@@ -207,7 +211,7 @@ where
         root: Word,
         depth: &Felt,
         index: &Felt,
-    ) -> Result<MerklePath, ExecutionError> {
+    ) -> Result<Option<MerklePath>, ExecutionError> {
         T::get_merkle_path(self, root, depth, index)
     }
 

--- a/processor/src/decorators/mod.rs
+++ b/processor/src/decorators/mod.rs
@@ -72,7 +72,13 @@ where
         let root = [self.stack.get(5), self.stack.get(4), self.stack.get(3), self.stack.get(2)];
 
         // look up the node in the advice provider
-        let node = self.advice_provider.get_tree_node(root, &depth, &index)?;
+        let node = self.advice_provider.get_tree_node(root, &depth, &index)?.ok_or(
+            ExecutionError::AdviceNodeNotFound {
+                root,
+                depth,
+                value: index,
+            },
+        )?;
 
         // push the node onto the advice stack with the first element pushed last so that it can
         // be popped first (i.e. stack behavior for word)

--- a/processor/src/errors.rs
+++ b/processor/src/errors.rs
@@ -17,7 +17,15 @@ use std::error::Error;
 pub enum ExecutionError {
     AdviceKeyNotFound(Word),
     AdviceStackReadFailed(u32),
-    InvalidNodeIndex { depth: Felt, value: Felt },
+    AdviceNodeNotFound {
+        root: Word,
+        depth: Felt,
+        value: Felt,
+    },
+    InvalidNodeIndex {
+        depth: Felt,
+        value: Felt,
+    },
     MerkleUpdateInPlace,
     MerkleStoreLookupFailed(MerkleError),
     MerkleStoreUpdateFailed(MerkleError),
@@ -50,6 +58,13 @@ impl Display for ExecutionError {
             AdviceKeyNotFound(key) => {
                 let hex = to_hex(Felt::elements_as_bytes(key))?;
                 write!(fmt, "Can't push values onto the advice stack: value for key {hex} not present in the advice map.")
+            }
+            AdviceNodeNotFound { root, depth, value } => {
+                let hex = to_hex(&Digest::from(*root).as_bytes())?;
+                write!(
+                    fmt,
+                    "An advice node was not found for root {hex}, depth {depth}, and index {value}"
+                )
             }
             InvalidNodeIndex { depth, value } => write!(
                 fmt,

--- a/processor/src/operations/crypto_ops.rs
+++ b/processor/src/operations/crypto_ops.rs
@@ -75,7 +75,13 @@ where
 
         // get a Merkle path from the advice provider for the specified root and node index.
         // the path is expected to be of the specified depth.
-        let path = self.advice_provider.get_merkle_path(provided_root, &depth, &index)?;
+        let path = self.advice_provider.get_merkle_path(provided_root, &depth, &index)?.ok_or(
+            ExecutionError::AdviceNodeNotFound {
+                root: provided_root,
+                depth,
+                value: index,
+            },
+        )?;
 
         // use hasher to compute the Merkle root of the path
         let (addr, computed_root) = self.chiplets.build_merkle_root(node, &path, index);

--- a/stdlib/docs/mmr_collections.md
+++ b/stdlib/docs/mmr_collections.md
@@ -1,7 +1,0 @@
-
-## std::collections::mmr
-| Procedure | Description |
-| ----------- | ------------- |
-| ilog2_checked | Computes the `ilog2(number)` and `2^(ilog2(number))`.<br /><br />number must be non-zero, otherwise this will error<br /><br />Stack transition:<br /><br />Input: [number, ...]<br /><br />Output: [ilog2, power_of_two, ...]<br /><br />Cycles:  12 + 9 * leading_zeros |
-| get | Loads the leaf at the absolute `pos` in the MMR.<br /><br />This MMR implementation supports only u32 positions.<br /><br />Stack transition:<br /><br />Input: [pos, mmr_ptr, ...]<br /><br />Output: [N, ...] where `N` is the leaf and `R` is the MMR peak that owns the leaf.<br /><br />Cycles: 65 + 9 * tree_position (where `tree_position` is 0-indexed bit position from most to least significant) |
-| unpack | Load the MMR peak data based on its hash.<br /><br />Input: [HASH, mmr_ptr, ...]<br /><br />Output: [...]<br /><br />Where:<br /><br />- HASH: is the MMR peak hash, the hash is expected to be padded to an even<br /><br />length and to have a minimum size of 16 elements<br /><br />- mmt_ptr: the memory location where the MMR data will be written to,<br /><br />starting with the MMR forest (its total leaves count) followed by its peaks<br /><br />Cycles: 156 + 9 * extra_peak_pair cycles<br /><br />where `extra_peak` is the number of peak pairs in addition to the first<br /><br />16, i.e. `round_up((num_of_peaks - 16) / 2)` |


### PR DESCRIPTION
Currently, the advice provider functions to query a Merkle store returns a value wrapped by a `Result`. It means a "node not found" will be treated as storage error.

However, this is not accurate; an absent node is not a storage failure, and it might convey meaning under certain contexts.

One such example is the Sparse Merkle tree: an absent node means a leaf is inserted on a tier smaller than the max bottom. This is a valid state, and currently it is impossible to be represented by the advice provider.

The current implementation is a reflection of how `miden-crypto` is implemented. This PR intercepts the [MerkleError::NodeNotInStore] error and returns `None`. However, ideally, [MerkleStore] should return `None` for such cases.