### PR TITLE
Fibonacci example fix

### DIFF
--- a/docs/src/intro/usage.md
+++ b/docs/src/intro/usage.md
@@ -76,7 +76,7 @@ As described [here](https://0xpolygonmiden.github.io/miden-vm/intro/overview.htm
 After a program finishes executing, the elements that remain on the stack become the outputs of the program, along with the overflow addresses (`overflow_addrs`) that are required to reconstruct the [stack overflow table](../design/stack/main.md#overflow-table).
 
 ## Fibonacci example
-In the `miden/examples/fib` directory, we provide a very simple Fibonacci calculator example. This example computes the 1000th term of the Fibonacci sequence. You can execute this example on Miden VM like so:
+In the `miden/examples/fib` directory, we provide a very simple Fibonacci calculator example. This example computes the 1001st term of the Fibonacci sequence. You can execute this example on Miden VM like so:
 ```
 ./target/optimized/miden run -a miden/examples/fib/fib.masm -n 1
 ```

--- a/miden/examples/fib/fib.inputs
+++ b/miden/examples/fib/fib.inputs
@@ -1,3 +1,3 @@
 {
-    "operand_stack": ["1", "1"]
+    "operand_stack": ["1"]
 }

--- a/miden/examples/fib/fib.masm
+++ b/miden/examples/fib/fib.masm
@@ -1,5 +1,5 @@
 begin
-    repeat.1000
+    repeat.999
         swap dup.1 add
     end
 end

--- a/miden/examples/fib/fib.masm
+++ b/miden/examples/fib/fib.masm
@@ -1,5 +1,6 @@
 begin
-    repeat.999
+    # This code computes 1001st Fibonacci number
+    repeat.1000
         swap dup.1 add
     end
 end


### PR DESCRIPTION
Current version of Fibonacci example computes not 1000th, but 1002nd Fibonacci number. This PR fixes this by putting only `[1]` to the input and changing number of cycles to 999.
