### PR TITLE
code: use add_* span variants were possible

### DIFF
--- a/assembly/src/assembler/instruction/adv_ops.rs
+++ b/assembly/src/assembler/instruction/adv_ops.rs
@@ -14,8 +14,7 @@ use vm_core::{code_blocks::CodeBlock, Operation::*};
 /// than 16.
 pub fn adv_push(span: &mut SpanBuilder, n: u8) -> Result<Option<CodeBlock>, AssemblyError> {
     validate_param(n, 1..=ADVICE_READ_LIMIT)?;
-    span.push_op_many(AdvPop, n as usize);
-    Ok(None)
+    span.add_op_many(AdvPop, n as usize)
 }
 
 // ADVICE INJECTORS

--- a/assembly/src/assembler/instruction/env_ops.rs
+++ b/assembly/src/assembler/instruction/env_ops.rs
@@ -1,6 +1,6 @@
 use super::{
-    mem_ops::local_to_absolute_addr, push_felt, AssemblyContext, AssemblyError, CodeBlock, Felt,
-    Operation::*, SpanBuilder,
+    mem_ops::local_to_absolute_addr, AssemblyContext, AssemblyError, CodeBlock, Felt, Operation::*,
+    SpanBuilder,
 };
 
 // CONSTANT INPUTS
@@ -15,8 +15,7 @@ pub fn push_one<T>(imm: T, span: &mut SpanBuilder) -> Result<Option<CodeBlock>, 
 where
     T: Into<Felt>,
 {
-    push_felt(span, imm.into());
-    Ok(None)
+    span.add_felt(imm.into())
 }
 
 /// Appends `PUSH` operations to the span block to push two or more provided constant values onto
@@ -29,7 +28,7 @@ pub fn push_many<T>(imms: &[T], span: &mut SpanBuilder) -> Result<Option<CodeBlo
 where
     T: Into<Felt> + Copy,
 {
-    imms.iter().for_each(|imm| push_felt(span, (*imm).into()));
+    imms.iter().for_each(|imm| span.push_felt((*imm).into()));
     Ok(None)
 }
 

--- a/assembly/src/assembler/instruction/field_ops.rs
+++ b/assembly/src/assembler/instruction/field_ops.rs
@@ -110,7 +110,7 @@ pub fn append_pow2_op(span: &mut SpanBuilder) {
     // drop the top two elements bit and exp value of the latest bit.
     span.push_ops([Drop, Drop]);
     // taking `b` to the top and asserting if it's equal to ZERO after all the right shifts.
-    span.push_ops([Swap, Eqz, Assert]);
+    span.push_ops([Swap, Eqz, Assert])
 }
 
 // EXPONENTIATION OPERATION
@@ -139,8 +139,7 @@ pub fn exp(span: &mut SpanBuilder, num_pow_bits: u8) -> Result<Option<CodeBlock>
     span.push_ops([Drop, Drop]);
 
     // taking `b` to the top and asserting if it's equal to ZERO after all the right shifts.
-    span.push_ops([Swap, Eqz, Assert]);
-    Ok(None)
+    span.add_ops([Swap, Eqz, Assert])
 }
 
 /// Appends a sequence of operations to compute b^pow where b is the value at the top of the stack.
@@ -284,9 +283,7 @@ pub fn lt(span: &mut SpanBuilder) -> Result<Option<CodeBlock>, AssemblyError> {
 
     // combine low-bit and high-bit results
     // 2 cycles
-    set_result(span);
-
-    Ok(None)
+    set_result(span)
 }
 
 /// Appends a sequence of operations to pop the top 2 elements off the stack and do a "less
@@ -310,9 +307,7 @@ pub fn lte(span: &mut SpanBuilder) -> Result<Option<CodeBlock>, AssemblyError> {
 
     // combine low-bit and high-bit results
     // 2 cycles
-    set_result(span);
-
-    Ok(None)
+    set_result(span)
 }
 
 /// Appends a sequence of operations to pop the top 2 elements off the stack and do a "greater
@@ -336,9 +331,7 @@ pub fn gt(span: &mut SpanBuilder) -> Result<Option<CodeBlock>, AssemblyError> {
 
     // combine low-bit and high-bit results
     // 2 cycles
-    set_result(span);
-
-    Ok(None)
+    set_result(span)
 }
 
 /// Appends a sequence of operations to pop the top 2 elements off the stack and do a "greater
@@ -362,9 +355,7 @@ pub fn gte(span: &mut SpanBuilder) -> Result<Option<CodeBlock>, AssemblyError> {
 
     // combine low-bit and high-bit results
     // 2 cycles
-    set_result(span);
-
-    Ok(None)
+    set_result(span)
 }
 
 /// Checks if the top element in the stack is an odd number or not.
@@ -475,12 +466,12 @@ fn check_lt(span: &mut SpanBuilder) {
 /// - high-bit comparison flag: 1 if the lt/gt condition being checked was true; 0 otherwise
 ///
 /// This function takes 2 cycles.
-fn set_result(span: &mut SpanBuilder) {
+fn set_result(span: &mut SpanBuilder) -> Result<Option<CodeBlock>, AssemblyError> {
     // check if high bits are equal AND low bit comparison condition was true
     span.push_op(And);
 
     // Set the result flag if the above check passed OR the high-bit comparison was true
-    span.push_op(Or);
+    span.add_op(Or)
 }
 
 /// Appends operations to the span block to emulate a "less than or equal" conditional and check

--- a/assembly/src/assembler/instruction/mod.rs
+++ b/assembly/src/assembler/instruction/mod.rs
@@ -331,42 +331,6 @@ impl Assembler {
 // HELPER FUNCTIONS
 // ================================================================================================
 
-/// This is a helper function that appends a PUSH operation to the span block which puts the
-/// provided u32 value onto the stack.
-///
-/// When the value is 0, PUSH operation is replaced with PAD. When the value is 1, PUSH operation
-/// is replaced with PAD INCR because in most cases this will be more efficient than doing a PUSH.
-fn push_u32_value(span: &mut SpanBuilder, value: u32) {
-    use Operation::*;
-
-    if value == 0 {
-        span.push_op(Pad);
-    } else if value == 1 {
-        span.push_op(Pad);
-        span.push_op(Incr);
-    } else {
-        span.push_op(Push(Felt::from(value)));
-    }
-}
-
-/// This is a helper function that appends a PUSH operation to the span block which puts the
-/// provided field element onto the stack.
-///
-/// When the value is 0, PUSH operation is replaced with PAD. When the value is 1, PUSH operation
-/// is replaced with PAD INCR because in most cases this will be more efficient than doing a PUSH.
-fn push_felt(span: &mut SpanBuilder, value: Felt) {
-    use Operation::*;
-
-    if value == ZERO {
-        span.push_op(Pad);
-    } else if value == ONE {
-        span.push_op(Pad);
-        span.push_op(Incr);
-    } else {
-        span.push_op(Push(value));
-    }
-}
-
 /// Returns an error if the specified value is smaller than or equal to min or greater than or
 /// equal to max. Otherwise, returns Ok(()).
 fn validate_param<I, R>(value: I, range: R) -> Result<(), AssemblyError>

--- a/assembly/src/assembler/instruction/u32_ops.rs
+++ b/assembly/src/assembler/instruction/u32_ops.rs
@@ -1,6 +1,6 @@
 use super::{
     field_ops::append_pow2_op,
-    push_u32_value, validate_param, AssemblyError, CodeBlock, Felt,
+    validate_param, AssemblyError, CodeBlock, Felt,
     Operation::{self, *},
     SpanBuilder,
 };
@@ -295,8 +295,7 @@ pub fn u32rotr(
     match (imm, op_mode) {
         (Some(imm), U32OpMode::Checked) if imm == 0 => {
             // if rotation is performed by 0, just verify that stack top is u32
-            span.push_ops([Pad, U32assert2, Drop]);
-            return Ok(None);
+            return span.add_ops([Pad, U32assert2, Drop]);
         }
         (Some(imm), U32OpMode::Checked) => {
             validate_param(imm, 1..=MAX_U32_ROTATE_VALUE)?;
@@ -304,8 +303,7 @@ pub fn u32rotr(
         }
         (Some(imm), U32OpMode::Unchecked) if imm == 0 => {
             // if rotation is performed by 0, do nothing (Noop)
-            span.push_op(Noop);
-            return Ok(None);
+            return span.add_op(Noop);
         }
         (Some(imm), U32OpMode::Unchecked) => {
             validate_param(imm, 1..=MAX_U32_ROTATE_VALUE)?;
@@ -399,7 +397,7 @@ fn handle_arithmetic_operation(
     let mut assert_u32_res = false;
 
     if let Some(imm) = imm {
-        push_u32_value(span, imm);
+        span.push_felt(Felt::from(imm));
     }
 
     match op_mode {
@@ -436,7 +434,7 @@ fn handle_division(
         if imm == 0 {
             return Err(AssemblyError::division_by_zero());
         }
-        push_u32_value(span, imm);
+        span.push_felt(Felt::from(imm));
     }
 
     match op_mode {
@@ -472,8 +470,7 @@ fn prepare_bitwise<const MAX_VALUE: u8>(
     match (imm, op_mode) {
         (Some(imm), U32OpMode::Checked) if imm == 0 => {
             // if shift/rotation is performed by 0, just verify that stack top is u32
-            span.push_ops([Pad, U32assert2, Drop]);
-            return Ok(None);
+            return span.add_ops([Pad, U32assert2, Drop]);
         }
         (Some(imm), U32OpMode::Checked) => {
             validate_param(imm, 1..=MAX_VALUE)?;
@@ -481,8 +478,7 @@ fn prepare_bitwise<const MAX_VALUE: u8>(
         }
         (Some(imm), U32OpMode::Unchecked) if imm == 0 => {
             // if shift/rotation is performed by 0, do nothing (Noop)
-            span.push_op(Noop);
-            return Ok(None);
+            return span.add_op(Noop);
         }
         (Some(imm), U32OpMode::Unchecked) => {
             span.push_op(Push(Felt::new(1 << imm)));
@@ -510,7 +506,7 @@ fn prepare_bitwise<const MAX_VALUE: u8>(
 /// - u32checked_eq.b: 3 cycles
 pub fn u32eq(span: &mut SpanBuilder, imm: Option<u32>) -> Result<Option<CodeBlock>, AssemblyError> {
     if let Some(imm) = imm {
-        push_u32_value(span, imm);
+        span.push_felt(Felt::from(imm));
     }
 
     span.add_ops([U32assert2, Eq])
@@ -529,7 +525,7 @@ pub fn u32neq(
     imm: Option<u32>,
 ) -> Result<Option<CodeBlock>, AssemblyError> {
     if let Some(imm) = imm {
-        push_u32_value(span, imm);
+        span.push_felt(Felt::from(imm));
     }
 
     span.add_ops([U32assert2, Eq, Not])


### PR DESCRIPTION
## Describe your changes

The changes are mostly cosmetic, it just reduces the line count a bit.

- drops `push_u32_value` in favor fo `push_felt` with `Felt::from`
- change code to use `add_` variants instead of `push_` whenever possible
- moves `push_felt` to `SpanBuilder`, since one is required to use it anyways

The changes are cosmetic, let me know if the PR should be closed instead of merged.

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
