### PR TITLE
feat: add assembly SourceLocation

### DIFF
--- a/assembly/src/lib.rs
+++ b/assembly/src/lib.rs
@@ -31,6 +31,7 @@ pub use vm_core::utils::{
 };
 
 mod tokens;
+pub use tokens::SourceLocation;
 use tokens::{Token, TokenStream};
 
 mod errors;

--- a/assembly/src/parsers/mod.rs
+++ b/assembly/src/parsers/mod.rs
@@ -228,8 +228,9 @@ pub fn parse_program(source: &str) -> Result<ProgramAst, ParsingError> {
     context.parse_procedures(&mut tokens, false)?;
 
     // make sure program body is present
-    let next_token =
-        tokens.read().ok_or_else(|| ParsingError::unexpected_eof(*tokens.location()))?;
+    let next_token = tokens
+        .read()
+        .ok_or_else(|| ParsingError::unexpected_eof(*tokens.eof_location()))?;
     if next_token.parts()[0] != Token::BEGIN {
         return Err(ParsingError::unexpected_token(next_token, Token::BEGIN));
     }
@@ -242,7 +243,7 @@ pub fn parse_program(source: &str) -> Result<ProgramAst, ParsingError> {
 
     // make sure there is something to be read
     if tokens.eof() {
-        return Err(ParsingError::unexpected_eof(*tokens.location()));
+        return Err(ParsingError::unexpected_eof(*tokens.eof_location()));
     }
 
     let mut body = Vec::<Node>::new();

--- a/assembly/src/parsers/mod.rs
+++ b/assembly/src/parsers/mod.rs
@@ -229,7 +229,7 @@ pub fn parse_program(source: &str) -> Result<ProgramAst, ParsingError> {
 
     // make sure program body is present
     let next_token =
-        tokens.read().ok_or_else(|| ParsingError::unexpected_eof(tokens.num_lines()))?;
+        tokens.read().ok_or_else(|| ParsingError::unexpected_eof(*tokens.location()))?;
     if next_token.parts()[0] != Token::BEGIN {
         return Err(ParsingError::unexpected_token(next_token, Token::BEGIN));
     }
@@ -242,7 +242,7 @@ pub fn parse_program(source: &str) -> Result<ProgramAst, ParsingError> {
 
     // make sure there is something to be read
     if tokens.eof() {
-        return Err(ParsingError::unexpected_eof(tokens.num_lines()));
+        return Err(ParsingError::unexpected_eof(*tokens.location()));
     }
 
     let mut body = Vec::<Node>::new();

--- a/assembly/src/parsers/tests.rs
+++ b/assembly/src/parsers/tests.rs
@@ -4,6 +4,7 @@ use super::{
     parse_module, parse_program, BTreeMap, Instruction, LocalProcMap, ModuleAst, Node,
     ParsingError, ProcedureAst, ProcedureId, ProgramAst, Token,
 };
+use crate::SourceLocation;
 
 // UNIT TESTS
 // ================================================================================================
@@ -696,14 +697,16 @@ fn test_ast_program_serde_control_flow() {
 fn assert_parsing_line_unmatched_begin() {
     let source = format!("\n\nbegin\npush.1.2\n\nadd mul");
     let err = parse_program(&source).err().unwrap();
-    assert_eq!(err, ParsingError::unmatched_begin(&Token::new("begin", 3)));
+    let location = SourceLocation::new(3, 1);
+    assert_eq!(err, ParsingError::unmatched_begin(&Token::new("begin", location)));
 }
 
 #[test]
 fn assert_parsing_line_extra_param() {
     let source = format!("begin add.1.2\nend");
     let err = parse_program(&source).err().unwrap();
-    assert_eq!(err, ParsingError::extra_param(&Token::new("add.1.2", 1)));
+    let location = SourceLocation::new(1, 7);
+    assert_eq!(err, ParsingError::extra_param(&Token::new("add.1.2", location)));
 }
 
 #[test]
@@ -741,21 +744,24 @@ fn assert_parsing_line_invalid_op() {
 
     end";
     let err = parse_program(&source).err().unwrap();
-    assert_eq!(err, ParsingError::invalid_op(&Token::new("u32overflowing_mulx", 28)));
+    let location = SourceLocation::new(28, 13);
+    assert_eq!(err, ParsingError::invalid_op(&Token::new("u32overflowing_mulx", location)));
 }
 
 #[test]
 fn assert_parsing_line_unexpected_eof() {
     let source = format!("proc.foo\nadd\nend");
     let err = parse_program(&source).err().unwrap();
-    assert_eq!(err, ParsingError::unexpected_eof(3));
+    let location = SourceLocation::new(3, 1);
+    assert_eq!(err, ParsingError::unexpected_eof(location));
 }
 
 #[test]
 fn assert_parsing_line_unexpected_token() {
     let source = format!("proc.foo\nadd\nend\n\nmul");
     let err = parse_program(&source).err().unwrap();
-    assert_eq!(err, ParsingError::unexpected_token(&Token::new("mul", 5), "begin"));
+    let location = SourceLocation::new(5, 1);
+    assert_eq!(err, ParsingError::unexpected_token(&Token::new("mul", location), "begin"));
 }
 
 fn assert_program_output(source: &str, procedures: LocalProcMap, body: Vec<Node>) {

--- a/assembly/src/tokens/lines.rs
+++ b/assembly/src/tokens/lines.rs
@@ -226,7 +226,7 @@ impl<'a> LineInfo<'a> {
     /// ```
     ///
     /// `2` is returned.
-    pub const fn _char_offset(&self) -> u32 {
+    pub const fn char_offset(&self) -> u32 {
         self.char_offset
     }
 }

--- a/assembly/src/tokens/lines.rs
+++ b/assembly/src/tokens/lines.rs
@@ -1,5 +1,5 @@
 use super::{SourceLocation, Token, Vec};
-use core::{iter, mem, str::Lines};
+use core::{iter, str::Lines};
 
 // LINES STREAM
 // ================================================================================================
@@ -128,10 +128,10 @@ impl<'a> Iterator for LinesStream<'a> {
 /// A processed line with source location.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct LineInfo<'a> {
-    contents: Option<&'a str>,
-    docs: Vec<&'a str>,
-    line_number: u32,
-    char_offset: u32,
+    pub(super) contents: Option<&'a str>,
+    pub(super) docs: Vec<&'a str>,
+    pub(super) line_number: u32,
+    pub(super) char_offset: u32,
 }
 
 impl From<LineInfo<'_>> for SourceLocation {
@@ -237,165 +237,6 @@ impl<'a> LineInfo<'a> {
     pub const fn char_offset(&self) -> u32 {
         self.char_offset
     }
-}
-
-// LINE TOKENIZER
-// ================================================================================================
-
-#[derive(Debug, Clone)]
-pub struct LineTokenizer<'a> {
-    // current token variables
-    docs: Option<String>,
-    line: Option<&'a str>,
-    location: SourceLocation,
-
-    // internal variables
-    is_first: bool,
-    dangling_docs: Option<SourceLocation>,
-    lines: LinesStream<'a>,
-    module_docs: Option<String>,
-}
-
-impl<'a> From<&'a str> for LineTokenizer<'a> {
-    fn from(source: &'a str) -> Self {
-        LinesStream::from(source).into()
-    }
-}
-
-impl<'a> From<LinesStream<'a>> for LineTokenizer<'a> {
-    fn from(lines: LinesStream<'a>) -> Self {
-        Self {
-            docs: None,
-            line: None,
-            location: SourceLocation::default(),
-            is_first: true,
-            dangling_docs: None,
-            lines,
-            module_docs: None,
-        }
-    }
-}
-
-impl<'a> LineTokenizer<'a> {
-    // STATE MUTATORS
-    // --------------------------------------------------------------------------------------------
-
-    /// Takes dangling docs location, if present.
-    pub fn take_dangling_docs(&mut self) -> Option<SourceLocation> {
-        self.dangling_docs.take()
-    }
-
-    /// Takes the module docs, if present.
-    pub fn take_module_docs(&mut self) -> Option<String> {
-        self.module_docs.take()
-    }
-
-    // HELPERS
-    // --------------------------------------------------------------------------------------------
-
-    /// Fetches a new line with a token on its first position.
-    fn take_new_line(&mut self) -> Option<&'a str> {
-        let LineInfo {
-            contents,
-            docs,
-            line_number,
-            char_offset,
-        } = self.lines.next()?;
-
-        // set source location according to the provided offset
-        let is_first = mem::take(&mut self.is_first);
-        self.location = SourceLocation::new(line_number, char_offset + 1);
-
-        // if line contains doc comments, then it is dangling
-        if contents.and_then(|l| l.find(Token::DOC_COMMENT_PREFIX)).is_some() {
-            self.dangling_docs.replace(self.location);
-            return None;
-        }
-
-        // remove trailing comments & whitespaces
-        let line = contents
-            .map(|line| {
-                line.split_once(Token::COMMENT_PREFIX)
-                    .map(|(l, _comments)| l.trim_end())
-                    .unwrap_or(line)
-            })
-            .and_then(|line| {
-                line.find(|c: char| !c.is_whitespace()).map(|n| {
-                    self.location.move_column(n as u32);
-                    line.split_at(n).1
-                })
-            })
-            .filter(|line| !line.is_empty());
-
-        // if first line is empty & has docs, set the module docs
-        if line.is_none() && is_first && !docs.is_empty() {
-            self.module_docs = build_comment(&docs);
-            return self.take_new_line();
-        }
-
-        // if line is empty, then dangling docs as first line is already checked
-        if line.is_none() {
-            self.dangling_docs.replace(self.location);
-            return None;
-        }
-
-        // set token docs & return
-        self.docs = build_comment(&docs);
-        line
-    }
-}
-
-impl<'a> Iterator for LineTokenizer<'a> {
-    type Item = LineToken<'a>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        let line = self.line.take().or_else(|| self.take_new_line())?;
-        let location = self.location;
-        let docs = self.docs.take();
-
-        // fetch token & move offset
-        let (token, remainder) = line.split_once(char::is_whitespace).unwrap_or((line, ""));
-        self.location.move_column(token.len() as u32);
-
-        // update remainder line
-        self.line = remainder.find(|c: char| !c.is_whitespace()).map(|n| {
-            self.location.move_column(n as u32 + 1);
-            remainder.split_at(n).1
-        });
-
-        Some(LineToken {
-            docs,
-            location,
-            token,
-        })
-    }
-}
-
-// LINE TOKEN
-// ================================================================================================
-
-/// A processed line with source location.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct LineToken<'a> {
-    pub docs: Option<String>,
-    pub location: SourceLocation,
-    pub token: &'a str,
-}
-
-// HELPERS
-// ================================================================================================
-
-fn build_comment(docs: &[&str]) -> Option<String> {
-    let last = docs.len().saturating_sub(1);
-    let docs: String = docs
-        .iter()
-        .enumerate()
-        .map(|(i, d)| {
-            let lb = if last == i { "" } else { "\n" };
-            format!("{d}{lb}")
-        })
-        .collect();
-    (!docs.is_empty()).then_some(docs)
 }
 
 #[cfg(test)]

--- a/assembly/src/tokens/lines.rs
+++ b/assembly/src/tokens/lines.rs
@@ -1,5 +1,5 @@
-use super::{Token, Vec};
-use core::{iter, str::Lines};
+use super::{SourceLocation, Token, Vec};
+use core::{iter, mem, str::Lines};
 
 // LINES STREAM
 // ================================================================================================
@@ -134,6 +134,14 @@ pub struct LineInfo<'a> {
     char_offset: u32,
 }
 
+impl From<LineInfo<'_>> for SourceLocation {
+    fn from(info: LineInfo<'_>) -> Self {
+        let line = info.line_number();
+        let column = info.char_offset();
+        Self::new(line, column)
+    }
+}
+
 impl<'a> LineInfo<'a> {
     // CONSTRUCTORS
     // --------------------------------------------------------------------------------------------
@@ -231,6 +239,165 @@ impl<'a> LineInfo<'a> {
     }
 }
 
+// LINE TOKENIZER
+// ================================================================================================
+
+#[derive(Debug, Clone)]
+pub struct LineTokenizer<'a> {
+    // current token variables
+    docs: Option<String>,
+    line: Option<&'a str>,
+    location: SourceLocation,
+
+    // internal variables
+    is_first: bool,
+    dangling_docs: Option<SourceLocation>,
+    lines: LinesStream<'a>,
+    module_docs: Option<String>,
+}
+
+impl<'a> From<&'a str> for LineTokenizer<'a> {
+    fn from(source: &'a str) -> Self {
+        LinesStream::from(source).into()
+    }
+}
+
+impl<'a> From<LinesStream<'a>> for LineTokenizer<'a> {
+    fn from(lines: LinesStream<'a>) -> Self {
+        Self {
+            docs: None,
+            line: None,
+            location: SourceLocation::default(),
+            is_first: true,
+            dangling_docs: None,
+            lines,
+            module_docs: None,
+        }
+    }
+}
+
+impl<'a> LineTokenizer<'a> {
+    // STATE MUTATORS
+    // --------------------------------------------------------------------------------------------
+
+    /// Takes dangling docs location, if present.
+    pub fn take_dangling_docs(&mut self) -> Option<SourceLocation> {
+        self.dangling_docs.take()
+    }
+
+    /// Takes the module docs, if present.
+    pub fn take_module_docs(&mut self) -> Option<String> {
+        self.module_docs.take()
+    }
+
+    // HELPERS
+    // --------------------------------------------------------------------------------------------
+
+    /// Fetches a new line with a token on its first position.
+    fn take_new_line(&mut self) -> Option<&'a str> {
+        let LineInfo {
+            contents,
+            docs,
+            line_number,
+            char_offset,
+        } = self.lines.next()?;
+
+        // set source location according to the provided offset
+        let is_first = mem::take(&mut self.is_first);
+        self.location = SourceLocation::new(line_number, char_offset + 1);
+
+        // if line contains doc comments, then it is dangling
+        if contents.and_then(|l| l.find(Token::DOC_COMMENT_PREFIX)).is_some() {
+            self.dangling_docs.replace(self.location);
+            return None;
+        }
+
+        // remove trailing comments & whitespaces
+        let line = contents
+            .map(|line| {
+                line.split_once(Token::COMMENT_PREFIX)
+                    .map(|(l, _comments)| l.trim_end())
+                    .unwrap_or(line)
+            })
+            .and_then(|line| {
+                line.find(|c: char| !c.is_whitespace()).map(|n| {
+                    self.location.move_column(n as u32);
+                    line.split_at(n).1
+                })
+            })
+            .filter(|line| !line.is_empty());
+
+        // if first line is empty & has docs, set the module docs
+        if line.is_none() && is_first && !docs.is_empty() {
+            self.module_docs = build_comment(&docs);
+            return self.take_new_line();
+        }
+
+        // if line is empty, then dangling docs as first line is already checked
+        if line.is_none() {
+            self.dangling_docs.replace(self.location);
+            return None;
+        }
+
+        // set token docs & return
+        self.docs = build_comment(&docs);
+        line
+    }
+}
+
+impl<'a> Iterator for LineTokenizer<'a> {
+    type Item = LineToken<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let line = self.line.take().or_else(|| self.take_new_line())?;
+        let location = self.location;
+        let docs = self.docs.take();
+
+        // fetch token & move offset
+        let (token, remainder) = line.split_once(char::is_whitespace).unwrap_or((line, ""));
+        self.location.move_column(token.len() as u32);
+
+        // update remainder line
+        self.line = remainder.find(|c: char| !c.is_whitespace()).map(|n| {
+            self.location.move_column(n as u32 + 1);
+            remainder.split_at(n).1
+        });
+
+        Some(LineToken {
+            docs,
+            location,
+            token,
+        })
+    }
+}
+
+// LINE TOKEN
+// ================================================================================================
+
+/// A processed line with source location.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct LineToken<'a> {
+    pub docs: Option<String>,
+    pub location: SourceLocation,
+    pub token: &'a str,
+}
+
+// HELPERS
+// ================================================================================================
+
+fn build_comment(docs: &[&str]) -> Option<String> {
+    let last = docs.len().saturating_sub(1);
+    let docs: String = docs
+        .iter()
+        .enumerate()
+        .map(|(i, d)| {
+            let lb = if last == i { "" } else { "\n" };
+            format!("{d}{lb}")
+        })
+        .collect();
+    (!docs.is_empty()).then_some(docs)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -245,6 +412,25 @@ mod tests {
         "#;
         let mut lines = LinesStream::from(source);
         assert_eq!(t(2, 8, "begin"), lines.next());
+        assert_eq!(None, lines.next());
+    }
+
+    #[test]
+    fn token_lines_single_comment() {
+        let source = r#"
+        # foo
+        "#;
+        let mut lines = LinesStream::from(source);
+        assert_eq!(None, lines.next());
+    }
+
+    #[test]
+    fn token_lines_single_doc_comment() {
+        let source = r#"
+        #! foo
+        "#;
+        let mut lines = LinesStream::from(source);
+        assert_eq!(tdangling(2, 0, ["foo"]), lines.next());
         assert_eq!(None, lines.next());
     }
 

--- a/assembly/src/tokens/lines.rs
+++ b/assembly/src/tokens/lines.rs
@@ -128,10 +128,10 @@ impl<'a> Iterator for LinesStream<'a> {
 /// A processed line with source location.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct LineInfo<'a> {
-    pub(super) contents: Option<&'a str>,
-    pub(super) docs: Vec<&'a str>,
-    pub(super) line_number: u32,
-    pub(super) char_offset: u32,
+    contents: Option<&'a str>,
+    docs: Vec<&'a str>,
+    line_number: u32,
+    char_offset: u32,
 }
 
 impl From<LineInfo<'_>> for SourceLocation {
@@ -510,12 +510,10 @@ end
     // TESTS HELPERS
     // ============================================================================================
 
-    #[cfg(test)]
     fn t(num: u32, offset: u32, contents: &str) -> Option<LineInfo> {
         Some(LineInfo::new(num, offset).with_contents(contents))
     }
 
-    #[cfg(test)]
     fn tdocs<'a, I>(num: u32, offset: u32, contents: &'a str, docs: I) -> Option<LineInfo<'a>>
     where
         I: IntoIterator<Item = &'a str>,
@@ -523,7 +521,6 @@ end
         Some(LineInfo::new(num, offset).with_contents(contents).with_docs(docs))
     }
 
-    #[cfg(test)]
     fn tdangling<'a, I>(num: u32, offset: u32, docs: I) -> Option<LineInfo<'a>>
     where
         I: IntoIterator<Item = &'a str>,

--- a/assembly/src/tokens/location.rs
+++ b/assembly/src/tokens/location.rs
@@ -1,4 +1,3 @@
-use super::LineInfo;
 use core::fmt;
 
 // SOURCE LOCATION
@@ -15,14 +14,6 @@ pub struct SourceLocation {
 impl Default for SourceLocation {
     fn default() -> Self {
         Self { line: 1, column: 1 }
-    }
-}
-
-impl From<LineInfo<'_>> for SourceLocation {
-    fn from(info: LineInfo<'_>) -> Self {
-        let line = info.line_number();
-        let column = info.char_offset();
-        Self::new(line, column)
     }
 }
 

--- a/assembly/src/tokens/location.rs
+++ b/assembly/src/tokens/location.rs
@@ -1,0 +1,59 @@
+use super::LineInfo;
+use core::fmt;
+
+// SOURCE LOCATION
+// ================================================================================================
+
+/// A struct containing information about the location of a source item.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct SourceLocation {
+    // TODO add uri
+    line: u32,
+    column: u32,
+}
+
+impl Default for SourceLocation {
+    fn default() -> Self {
+        Self { line: 1, column: 1 }
+    }
+}
+
+impl From<LineInfo<'_>> for SourceLocation {
+    fn from(info: LineInfo<'_>) -> Self {
+        let line = info.line_number();
+        let column = info.char_offset();
+        Self::new(line, column)
+    }
+}
+
+impl SourceLocation {
+    // CONSTRUCTORS
+    // -------------------------------------------------------------------------------------------------
+
+    /// Creates a new instance of [SourceLocation].
+    pub const fn new(line: u32, column: u32) -> Self {
+        Self { line, column }
+    }
+
+    // PUBLIC ACCESSORS
+    // -------------------------------------------------------------------------------------------------
+
+    /// Returns the line of the location.
+    pub const fn line(&self) -> u32 {
+        self.line
+    }
+
+    // STATE MUTATORS
+    // -------------------------------------------------------------------------------------------------
+
+    /// Moves the column by the given offset.
+    pub fn move_column(&mut self, offset: u32) {
+        self.column += offset;
+    }
+}
+
+impl fmt::Display for SourceLocation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "[{}:{}]", self.line, self.column)
+    }
+}

--- a/assembly/src/tokens/mod.rs
+++ b/assembly/src/tokens/mod.rs
@@ -6,6 +6,8 @@ use core::fmt;
 mod lines;
 pub use lines::{LineInfo, LinesStream};
 
+mod location;
+pub use location::SourceLocation;
 mod stream;
 pub use stream::TokenStream;
 
@@ -19,8 +21,8 @@ pub use stream::TokenStream;
 pub struct Token<'a> {
     /// The dot-separated parts of a token, e.g. `push.1` is split into `['push', '1']`.
     parts: Vec<&'a str>,
-    /// The line number linked to this token
-    line: usize,
+    /// Source location linked to this token.
+    location: SourceLocation,
 }
 
 impl<'a> Token<'a> {
@@ -54,20 +56,20 @@ impl<'a> Token<'a> {
     ///
     /// # Panics
     /// Panic if the `token` parameter is an empty string.
-    pub fn new(token: &'a str, line: usize) -> Self {
+    pub fn new(token: &'a str, location: SourceLocation) -> Self {
         assert!(!token.is_empty(), "token cannot be an empty string");
         Self {
             parts: token.split('.').collect(),
-            line,
+            location,
         }
     }
 
     // PUBLIC ACCESSORS
     // --------------------------------------------------------------------------------------------
 
-    /// Returns the line number of this token in the source.
-    pub const fn line(&self) -> usize {
-        self.line
+    /// Returns the [SourceLocation] linked to this [Token].
+    pub const fn location(&self) -> &SourceLocation {
+        &self.location
     }
 
     /// Returns the number of parts in this token.
@@ -86,11 +88,11 @@ impl<'a> Token<'a> {
     ///
     /// # Panics
     /// Panic is the `token` parameter is an empty string.
-    pub fn update(&mut self, token: &'a str, line: usize) {
+    pub fn update(&mut self, token: &'a str, location: SourceLocation) {
         assert!(!token.is_empty(), "token cannot be an empty string");
         self.parts.clear();
         token.split('.').for_each(|part| self.parts.push(part));
-        self.line = line;
+        self.location = location;
     }
 
     // CONTROL TOKEN PARSERS / VALIDATORS

--- a/assembly/src/tokens/mod.rs
+++ b/assembly/src/tokens/mod.rs
@@ -4,13 +4,16 @@ use super::{
 use core::fmt;
 
 mod lines;
-pub use lines::{LineToken, LineTokenizer};
+pub use lines::{LineInfo, LinesStream};
 
 mod location;
 pub use location::SourceLocation;
 
 mod stream;
 pub use stream::TokenStream;
+
+mod tokenizer;
+pub use tokenizer::{LineToken, LineTokenizer};
 
 // TOKEN
 // ================================================================================================

--- a/assembly/src/tokens/mod.rs
+++ b/assembly/src/tokens/mod.rs
@@ -13,7 +13,7 @@ mod stream;
 pub use stream::TokenStream;
 
 mod tokenizer;
-pub use tokenizer::{LineToken, LineTokenizer};
+pub use tokenizer::LineTokenizer;
 
 // TOKEN
 // ================================================================================================

--- a/assembly/src/tokens/mod.rs
+++ b/assembly/src/tokens/mod.rs
@@ -4,10 +4,11 @@ use super::{
 use core::fmt;
 
 mod lines;
-pub use lines::{LineInfo, LinesStream};
+pub use lines::{LineToken, LineTokenizer};
 
 mod location;
 pub use location::SourceLocation;
+
 mod stream;
 pub use stream::TokenStream;
 

--- a/assembly/src/tokens/stream.rs
+++ b/assembly/src/tokens/stream.rs
@@ -1,5 +1,7 @@
-use super::{BTreeMap, LineToken, LineTokenizer, ParsingError, SourceLocation, String, Token, Vec};
-use core::fmt;
+use super::{
+    BTreeMap, LineTokenizer, LinesStream, ParsingError, SourceLocation, String, Token, Vec,
+};
+use core::{fmt, mem};
 
 // TOKEN STREAM
 // ================================================================================================
@@ -24,29 +26,51 @@ impl<'a> TokenStream<'a> {
         let mut tokens = Vec::new();
         let mut locations = Vec::new();
         let mut proc_comments = BTreeMap::new();
-        let mut tokenizer = LineTokenizer::from(source);
+        let mut module_comment = None;
 
-        for token in tokenizer.by_ref() {
-            let LineToken {
-                docs,
-                location,
-                token,
-            } = token;
+        for info in LinesStream::from(source) {
+            let mut docs = info.docs();
+            let mut tokenizer = LineTokenizer::from(&info);
 
-            // bind doc comments to proc/export; halt otherwise
-            if token.starts_with(Token::EXPORT) || token.starts_with(Token::PROC) {
-                proc_comments.insert(tokens.len(), docs);
-            } else if docs.is_some() {
+            // first dangling docs are module docs
+            if tokens.is_empty() && info.contents().is_none() {
+                let docs = mem::take(&mut docs);
+                let docs = build_comment(docs);
+                module_comment = docs;
+            } else if info.contents().is_none() {
+                let location = SourceLocation::new(info.line_number(), 1);
                 return Err(ParsingError::dangling_procedure_comment(location));
             }
 
-            tokens.push(token);
-            locations.push(location);
-        }
+            // first token from stream might be export or proc; take docs
+            if !docs.is_empty() {
+                match tokenizer.next() {
+                    Some((token, location))
+                        if token.starts_with(Token::EXPORT) || token.starts_with(Token::PROC) =>
+                    {
+                        let docs = mem::take(&mut docs);
+                        let docs = build_comment(docs);
+                        proc_comments.insert(tokens.len(), docs);
+                        tokens.push(token);
+                        locations.push(location);
+                    }
+                    _ => {
+                        return Err(ParsingError::dangling_procedure_comment(SourceLocation::new(
+                            info.line_number(),
+                            1,
+                        )))
+                    }
+                }
+            }
 
-        // halt if dangling docs
-        if let Some(location) = tokenizer.take_dangling_docs() {
-            return Err(ParsingError::dangling_procedure_comment(location));
+            for (token, location) in tokenizer.by_ref() {
+                tokens.push(token);
+                locations.push(location);
+            }
+
+            if let Some(location) = tokenizer.take_dangling() {
+                return Err(ParsingError::dangling_procedure_comment(location));
+            }
         }
 
         // invalid if no tokens
@@ -54,8 +78,6 @@ impl<'a> TokenStream<'a> {
             return Err(ParsingError::empty_source());
         }
 
-        // set module comment & return
-        let module_comment = tokenizer.take_module_docs();
         let location = SourceLocation::default();
         let current = Token::new(tokens[0], location);
         Ok(Self {
@@ -139,4 +161,20 @@ impl<'a> fmt::Display for TokenStream<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{:?}", &self.tokens[self.pos..])
     }
+}
+
+// HELPERS
+// ================================================================================================
+
+fn build_comment(docs: &[&str]) -> Option<String> {
+    let last = docs.len().saturating_sub(1);
+    let docs: String = docs
+        .iter()
+        .enumerate()
+        .map(|(i, d)| {
+            let lb = if last == i { "" } else { "\n" };
+            format!("{d}{lb}")
+        })
+        .collect();
+    (!docs.is_empty()).then_some(docs)
 }

--- a/assembly/src/tokens/stream.rs
+++ b/assembly/src/tokens/stream.rs
@@ -77,8 +77,8 @@ impl<'a> TokenStream<'a> {
         self.pos
     }
 
-    /// Returns the [SourceLocation] linked to the current [Token].
-    pub fn location(&self) -> &SourceLocation {
+    /// Returns the [SourceLocation] linked to the end-of-file of the source.
+    pub fn eof_location(&self) -> &SourceLocation {
         let idx = self.pos.min(self.locations.len().saturating_sub(1));
         &self.locations[idx]
     }

--- a/assembly/src/tokens/stream.rs
+++ b/assembly/src/tokens/stream.rs
@@ -40,7 +40,8 @@ impl<'a> TokenStream<'a> {
                     }
 
                     // break the line into tokens and record their locations
-                    let mut tokenizer = LineTokenizer::from(&line_info);
+                    let mut tokenizer = LineTokenizer::new(&line_info)
+                        .expect("line contents are checked and present");
                     for (token, location) in tokenizer.by_ref() {
                         tokens.push(token);
                         locations.push(location);

--- a/assembly/src/tokens/tokenizer.rs
+++ b/assembly/src/tokens/tokenizer.rs
@@ -1,0 +1,164 @@
+use super::{LineInfo, LinesStream, SourceLocation, Token};
+use core::mem;
+
+// LINE TOKENIZER
+// ================================================================================================
+
+#[derive(Debug, Clone)]
+pub struct LineTokenizer<'a> {
+    // current token variables
+    docs: Option<String>,
+    line: Option<&'a str>,
+    location: SourceLocation,
+
+    // internal variables
+    is_first: bool,
+    dangling_docs: Option<SourceLocation>,
+    lines: LinesStream<'a>,
+    module_docs: Option<String>,
+}
+
+impl<'a> From<&'a str> for LineTokenizer<'a> {
+    fn from(source: &'a str) -> Self {
+        LinesStream::from(source).into()
+    }
+}
+
+impl<'a> From<LinesStream<'a>> for LineTokenizer<'a> {
+    fn from(lines: LinesStream<'a>) -> Self {
+        Self {
+            docs: None,
+            line: None,
+            location: SourceLocation::default(),
+            is_first: true,
+            dangling_docs: None,
+            lines,
+            module_docs: None,
+        }
+    }
+}
+
+impl<'a> LineTokenizer<'a> {
+    // STATE MUTATORS
+    // --------------------------------------------------------------------------------------------
+
+    /// Takes dangling docs location, if present.
+    pub fn take_dangling_docs(&mut self) -> Option<SourceLocation> {
+        self.dangling_docs.take()
+    }
+
+    /// Takes the module docs, if present.
+    pub fn take_module_docs(&mut self) -> Option<String> {
+        self.module_docs.take()
+    }
+
+    // HELPERS
+    // --------------------------------------------------------------------------------------------
+
+    /// Fetches a new line with a token on its first position.
+    fn take_new_line(&mut self) -> Option<&'a str> {
+        let LineInfo {
+            contents,
+            docs,
+            line_number,
+            char_offset,
+        } = self.lines.next()?;
+
+        // set source location according to the provided offset
+        let is_first = mem::take(&mut self.is_first);
+        self.location = SourceLocation::new(line_number, char_offset + 1);
+
+        // if line contains doc comments, then it is dangling
+        if contents.and_then(|l| l.find(Token::DOC_COMMENT_PREFIX)).is_some() {
+            self.dangling_docs.replace(self.location);
+            return None;
+        }
+
+        // remove trailing comments & whitespaces
+        let line = contents
+            .map(|line| {
+                line.split_once(Token::COMMENT_PREFIX)
+                    .map(|(l, _comments)| l.trim_end())
+                    .unwrap_or(line)
+            })
+            .and_then(|line| {
+                line.find(|c: char| !c.is_whitespace()).map(|n| {
+                    self.location.move_column(n as u32);
+                    line.split_at(n).1
+                })
+            })
+            .filter(|line| !line.is_empty());
+
+        // if first line is empty & has docs, set the module docs
+        if line.is_none() && is_first && !docs.is_empty() {
+            self.module_docs = build_comment(&docs);
+            return self.take_new_line();
+        }
+
+        // if line is empty, then dangling docs as first line is already checked
+        if line.is_none() {
+            self.dangling_docs.replace(self.location);
+            return None;
+        }
+
+        // set token docs & return
+        self.docs = build_comment(&docs);
+        line
+    }
+}
+
+impl<'a> Iterator for LineTokenizer<'a> {
+    type Item = LineToken<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let line = self.line.take().or_else(|| self.take_new_line())?;
+        let location = self.location;
+        let docs = self.docs.take();
+
+        // fetch token & move offset
+        let (token, remainder) = line.split_once(char::is_whitespace).unwrap_or((line, ""));
+        self.location.move_column(token.len() as u32);
+
+        // update remainder line
+        self.line = remainder
+            .find(|c: char| !c.is_whitespace())
+            .map(|n| {
+                self.location.move_column(n as u32 + 1);
+                remainder.split_at(n).1
+            })
+            .filter(|line| !line.is_empty());
+
+        Some(LineToken {
+            docs,
+            location,
+            token,
+        })
+    }
+}
+
+// LINE TOKEN
+// ================================================================================================
+
+/// A processed line with source location.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct LineToken<'a> {
+    pub docs: Option<String>,
+    pub location: SourceLocation,
+    pub token: &'a str,
+}
+
+// HELPERS
+// ================================================================================================
+
+fn build_comment(docs: &[&str]) -> Option<String> {
+    let last = docs.len().saturating_sub(1);
+    let docs: String = docs
+        .iter()
+        .enumerate()
+        .map(|(i, d)| {
+            let lb = if last == i { "" } else { "\n" };
+            format!("{d}{lb}")
+        })
+        .collect();
+    (!docs.is_empty()).then_some(docs)
+}


### PR DESCRIPTION
This commit introduces [SourceLocation], a structure linked to a [Token] via [TokenStream].

It will allow the link between a MASM source and a parsed [Operation].

related issue: https://github.com/0xPolygonMiden/miden-vm/issues/857