### PR TITLE
fix(assembly): allow programs with only advice injectors

### DIFF
--- a/assembly/src/tests.rs
+++ b/assembly/src/tests.rs
@@ -4,7 +4,7 @@ use core::slice::Iter;
 // SIMPLE PROGRAMS
 // ================================================================================================
 #[test]
-fn simple_new_instrctns() {
+fn simple_new_instructions() {
     let assembler = super::Assembler::default();
     let source = "begin push.0 assertz end";
     let program = assembler.compile(source).unwrap();
@@ -384,6 +384,29 @@ fn const_conversion_failed_to_u32() {
     let expected_error =
         "failed to convert u64 constant used in `mem_load.CONSTANT` to required type u32";
     assert_eq!(expected_error, err.to_string());
+}
+
+// ADVICE INJECTION
+// ================================================================================================
+
+#[test]
+fn advice_injection() {
+    let source = format!(
+        "\
+    begin
+        adv.keyval
+    end
+    "
+    );
+    let assembler = super::Assembler::default();
+    let expected = "\
+    begin \
+        span \
+            noop \
+        end \
+    end";
+    let program = assembler.compile(source).unwrap();
+    assert_eq!(expected, format!("{program}"));
 }
 
 // NESTED CONTROL BLOCKS


### PR DESCRIPTION
## Describe your changes
Addresses #832. Allows programs with only advice injectors and no operations and only panics if AsmOp decorators are present without operations.

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
