### PR TITLE
Use half-open intervals in documentation

### DIFF
--- a/docs/src/design/chiplets/hasher.md
+++ b/docs/src/design/chiplets/hasher.md
@@ -107,7 +107,7 @@ Computing a 2-to-1 hash involves the following steps:
 
 1. Initialize hasher state with $8$ field elements, setting the second capacity element to $domain$ if the domain is provided (as in the case of [control block hashing](../programs.md#program-hash-computation)) or else $0$, and the remaining capacity elements to $0$.
 2. Apply Rescue Prime Optimized permutation.
-3. Return elements ${4, ..., 7}$ of the hasher state as output.
+3. Return elements $[4, 8)$ of the hasher state as output.
 
 The chiplet accomplishes the above by executing the following instructions:
 
@@ -135,7 +135,7 @@ Computing a linear hash of $n$ elements consists of the following steps:
 2. Apply Rescue Prime Optimized permutation.
 3. Absorb the next set of elements into the state (up to $8$ elements), while keeping capacity elements unchanged.
 4. Repeat steps 2 and 3 until all $n$ elements have been absorbed.
-5. Return elements ${4, ..., 7}$ of the hasher state as output.
+5. Return elements $[4, 8)$ of the hasher state as output.
 
 The chiplet accomplishes the above by executing the following instructions (for hashing $16$ elements):
 
@@ -151,7 +151,7 @@ Execution trace for this computation would look as illustrated below.
 
 ![hash_linear_hash_n](../../assets/design/chiplets/hasher/hash_linear_hash_n.png)
 
-In the above, the value absorbed into hasher state between rows $7$ and $8$ is the delta between values $t_i$ and $s_i$. Thus, if we define $b_i = t_i - s_i$ for $i \in \{0, ..., 7\}$, the above computes the following:
+In the above, the value absorbed into hasher state between rows $7$ and $8$ is the delta between values $t_i$ and $s_i$. Thus, if we define $b_i = t_i - s_i$ for $i \in [0, 8)$, the above computes the following:
 
 $$
 \{r_0, r_1, r_2, r_3\} \leftarrow hash(a_0, ..., a_7, b_0, ..., b_7)
@@ -168,7 +168,7 @@ Verifying a Merkle path involves the following steps:
 3. Copy the result of the hash to the next row, and absorb the next node of the Merkle path into the hasher state.
    a. Remove a single bit from the index, and use it to determine how to place the copied result and absorbed node in the state.
 4. Repeat steps 2 and 3 until all nodes of the Merkle path have been absorbed.
-5. Return elements ${4, ..., 7}$ of the hasher state as output.
+5. Return elements $[4, 8)$ of the hasher state as output.
    a. Also, make sure the index value has been reduced to $0$.
 
 The chiplet accomplishes the above by executing the following instructions (for Merkle tree of depth $3$):
@@ -333,13 +333,13 @@ Hasher state columns $h_0, ..., h_{11}$ should behave as follows:
 - For the first $7$ row of every $8$-row cycle (i.e., when $k_0=0$), we need to apply [Rescue Prime Optimized](https://eprint.iacr.org/2022/1577) round constraints to the hasher state. For brevity, we omit these constraints from this note.
 - On the $8$th row of every $8$-row cycle, we apply the constraints based on which transition flag is set as described in the table below.
 
-Specifically, when absorbing the next set of elements into the state during linear hash computation (i.e., $f_{abp} = 1$), the first $4$ elements (the capacity portion) are carried over to the next row. For $j \in \{0, ..., 3\}$ this can be described as follows:
+Specifically, when absorbing the next set of elements into the state during linear hash computation (i.e., $f_{abp} = 1$), the first $4$ elements (the capacity portion) are carried over to the next row. For $j \in [0, 4)$ this can be described as follows:
 
 >$$
 f_{abp} \cdot (h'_j - h_j) = 0 \text{ | degree} = 5
 $$
 
-When absorbing the next node during Merkle path computation (i.e., $f_{mp} + f_{mv} + f_{mu}=1$), the result of the previous hash ($h_4, ..., h_7$) are copied over either to $(h_4', ..., h_7')$ or to $(h_8', ..., h_{11}')$ depending on the value of $b$, which is defined in the same way as in the previous section. For $j \in \{0, ..., 3\}$ this can be described as follows:
+When absorbing the next node during Merkle path computation (i.e., $f_{mp} + f_{mv} + f_{mu}=1$), the result of the previous hash ($h_4, ..., h_7$) are copied over either to $(h_4', ..., h_7')$ or to $(h_8', ..., h_{11}')$ depending on the value of $b$, which is defined in the same way as in the previous section. For $j \in [0, 4)$ this can be described as follows:
 
 >$$
 (f_{mp} + f_{mv} + f_{mu}) \cdot ((1 - b) \cdot (h_{j +4}' - h_{j+4}) + b \cdot (h_{j + 8}' - h_{j + 4})) = 0 \text{ | degree} = 6
@@ -350,7 +350,7 @@ Note, that when a computation is completed (i.e., $f_{out}=1$), the next hasher 
 ### Multiset check constraints
 In this sections we describe constraints which enforce updates for [multiset check columns](../multiset.md) $p_0$ and $p_1$. These columns can be updated only on rows which are multiples of $8$ or $1$ less than a multiple of $8$. On all other rows the values in the columns remain the same.
 
-To simplify description of the constraints, we define the following variables. Below, we denote random values sent by the verifier after the prover commits to the main execution trace as $\alpha_0$, $\alpha_1$, $\alpha_2$ etc..
+To simplify description of the constraints, we define the following variables. Below, we denote random values sent by the verifier after the prover commits to the main execution trace as $\alpha_0$, $\alpha_1$, $\alpha_2$ etc.
 
 $$
 m = op_{label} + 2^4 \cdot k_0 + 2^5 \cdot k_2 \\

--- a/docs/src/design/decoder/constraints.md
+++ b/docs/src/design/decoder/constraints.md
@@ -65,7 +65,7 @@ $$
 Also, when `END` operation is executed and the next operation is `REPEAT`, values in $h_0, ..., h_4$ (the hash of the current block and the `is_loop_body` flag) must be copied to the next row:
 
 > $$
-f_{end} \cdot f_{repeat}' \cdot (h_i' - h_i) = 0 \text { for } i \in 0..4 \text{ | degree} = 9
+f_{end} \cdot f_{repeat}' \cdot (h_i' - h_i) = 0 \text { for } i \in [0, 5) \text{ | degree} = 9
 $$
 
 A `HALT` instruction can be followed only by another `HALT` instruction:
@@ -83,7 +83,7 @@ $$
 Values in `op_bits` columns must be binary (i.e., either $1$ or $0$):
 
 > $$
-b_i^2 - b_i = 0 \text{ for } i \in 0..6 \text{ | degree} = 2
+b_i^2 - b_i = 0 \text{ for } i \in [0, 7) \text{ | degree} = 2
 $$
 
 When the value in `in_span` column is set to $1$, control flow operations cannot be executed on the VM, but when `in_span` flag is $0$, only control flow operations can be executed on the VM:
@@ -498,7 +498,7 @@ These flags can be set to $1$ only when we are executing `SPAN` or `RESPAN` oper
 All batch flags must be binary:
 
 > $$
-bc_i^2 - bc_i = 0 \text{ for } i \in 0..2 \text{ | degree} = 2
+bc_i^2 - bc_i = 0 \text{ for } i \in [0, 3) \text{ | degree} = 2
 $$
 
 When `SPAN` or `RESPAN` operations is executed, one of the batch flags must be set to $1$.
@@ -510,7 +510,7 @@ $$
 When we have at most 4 groups in a batch, registers $h_4, ..., h_7$ should be set to $0$'s.
 
 > $$
-(f_{g1} + f_{g2} + f_{g4}) \cdot h_i = 0 \text{ for } i \in 4..7 \text{ | degree} = 4
+(f_{g1} + f_{g2} + f_{g4}) \cdot h_i = 0 \text{ for } i \in [4, 8) \text{ | degree} = 4
 $$
 
 When we have at most 2 groups in a batch, registers $h_2$ and $h_3$ should also be set to $0$'s.
@@ -539,7 +539,7 @@ $$
 v_i = \alpha_0 + \alpha_1 \cdot a' + \alpha_2 \cdot (gc - i) + \alpha_3 \cdot h_{i} \text{ | degree} = 1
 $$
 
-Where $i \in 1..7$. Thus, $v_1$ defines row value for group in $h_1$, $v_2$ defines row value for group $h_2$ etc. Note that batch address column comes from the next row of the block address column ($a'$).
+Where $i \in [1, 8)$. Thus, $v_1$ defines row value for group in $h_1$, $v_2$ defines row value for group $h_2$ etc. Note that batch address column comes from the next row of the block address column ($a'$).
 
 We compute the value of the row to be removed from the op group table as follows:
 

--- a/docs/src/design/decoder/main.md
+++ b/docs/src/design/decoder/main.md
@@ -517,7 +517,7 @@ Then, with every step the next operation is removed from $g_0$, and by step $9$,
 1. Decrements `group_count` register by $1$.
 2. Sets `op bits` registers at the next step to the first operation of $g_1$.
 3. Sets `hasher` register $h_0$ to the value of $g_1$ with the first operation removed (denoted as $g_1'$).
-4. Removes row `(blk, 7, g1)` from the op group table. This row can be obtained by taking values from registers: `addr`, `group_count`, and $h_0' + \sum_{i=0}^6(2^i \cdot b_i')$ for $i \in 0..6$, where $h_0'$ and $b_i'$ refer to values in the next row for the first hasher column and `op_bits` columns respectively.
+4. Removes row `(blk, 7, g1)` from the op group table. This row can be obtained by taking values from registers: `addr`, `group_count`, and $h_0' + \displaystyle\sum_{i=0}^6(2^i \cdot b_i')$ for $i \in [0, 7)$, where $h_0'$ and $b_i'$ refer to values in the next row for the first hasher column and `op_bits` columns respectively.
 
 Note that we rely on the `group_count` column to construct the row to be removed from the op group table. Since group count is decremented from the total number of groups to $0$, to remove groups from the op group table in correct order, we need to assign group position to groups in the op group table in the reverse order. For example, the first group to be removed should have position $7$, the second group to be removed should have position $6$ etc.
 

--- a/docs/src/design/stack/op_constraints.md
+++ b/docs/src/design/stack/op_constraints.md
@@ -8,7 +8,7 @@ To describe how operation-specific constraints work, let's use an example with `
 
 $$
 f_{dup} \cdot (s'_0 - s_0) = 0 \\
-f_{dup} \cdot (s'_{i+1} - s_i) = 0 \ \text{ for } i \in \{0, .., 14\}
+f_{dup} \cdot (s'_{i+1} - s_i) = 0 \ \text{ for } i \in [0, 15)
 $$
 
 The first constraint enforces that the top stack item in the next row is the same as the top stack item in the current row. The second constraint enforces that all stack items (starting from item $0$) are shifted to the right by $1$. We also need to impose all the constraints discussed in the previous section, be we omit them here.
@@ -17,7 +17,7 @@ Let's write similar constraints for `DUP1` operation, which pushes a copy of the
 
 $$
 f_{dup1} \cdot (s'_0 - s_1) = 0 \\
-f_{dup1} \cdot (s'_{i+1} - s_i) = 0 \ \text{ for } i \in \{0, .., 14\}
+f_{dup1} \cdot (s'_{i+1} - s_i) = 0 \ \text{ for } i \in [0, 15)
 $$
 
 It is easy to notice that while the first constraint changed, the second constraint remained the same - i.e., we are still just shifting the stack to the right.

--- a/docs/src/design/stack/stack_ops.md
+++ b/docs/src/design/stack/stack_ops.md
@@ -117,32 +117,32 @@ The effect of this operation on the rest of the stack is:
 * **No change** starting from position $16$.
 
 ## SWAPDW
-The `SWAPDW` operation swaps stack elements $\{0, ..., 7\}$ with elements $\{8, ..., 15\}$. The diagram below illustrates this graphically.
+The `SWAPDW` operation swaps stack elements $[0, 8)$ with elements $[8, 16)$. The diagram below illustrates this graphically.
 
 ![swapdw](../../assets/design/stack/stack_ops/SWAPDW.png)
 
 Stack transition for this operation must satisfy the following constraints:
 
 >$$
-s_i' - s_{i+8} = 0 \text{ for } i \in \{0, ..., 7\}   \text{ | degree} = 1
+s_i' - s_{i+8} = 0 \text{ for } i \in [0, 8)   \text{ | degree} = 1
 $$
 
 >$$
-s_{i+8}' - s_i = 0 \text{ for } i \in \{0, ..., 7\}   \text{ | degree} = 1
+s_{i+8}' - s_i = 0 \text{ for } i \in [0, 8)   \text{ | degree} = 1
 $$
 
 The effect of this operation on the rest of the stack is:
 * **No change** starting from position $16$.
 
 ## MOVUP(n)
-The `MOVUP(n)` operation moves the $n$-th element of the stack to the top of the stack. For example, `MOVUP2` moves element at depth $2$ to the top of the stack. All elements with depth less than $n$ are shifted to the right by one, while elements with depth greater than $n$ remain in place, and the depth of the stack does not change. This operation is valid for $n \in \{2, ..., 8\}$. The diagram below illustrates this graphically.
+The `MOVUP(n)` operation moves the $n$-th element of the stack to the top of the stack. For example, `MOVUP2` moves element at depth $2$ to the top of the stack. All elements with depth less than $n$ are shifted to the right by one, while elements with depth greater than $n$ remain in place, and the depth of the stack does not change. This operation is valid for $n \in [2, 9)$. The diagram below illustrates this graphically.
 
 ![movup](../../assets/design/stack/stack_ops/MOVUP(n).png)
 
 Stack transition for this operation must satisfy the following constraints:
 
 >$$
-s_0' - s_n = 0 \text{ for } n \in \{2, ..., 8\} \text{ | degree} = 1
+s_0' - s_n = 0 \text{ for } n \in [2, 9) \text{ | degree} = 1
 $$
 
 where $n$ is the depth of the element which is moved moved to the top of the stack.
@@ -152,14 +152,14 @@ The effect of this operation on the rest of the stack is:
 * **No change** starting from position $n+1$.
 
 ## MOVDN(n)
-The `MOVDN(n)` operation moves the top element of the stack to the $n$-th position. For example, `MOVDN2` moves the top element of the stack to depth $2$. All the elements with depth less than $n$ are shifted to the left by one, while elements with depth greater than $n$ remain in place, and the depth of the stack does not change. This operation is valid for $n \in \{2, ..., 8\}$. The diagram below illustrates this graphically.
+The `MOVDN(n)` operation moves the top element of the stack to the $n$-th position. For example, `MOVDN2` moves the top element of the stack to depth $2$. All the elements with depth less than $n$ are shifted to the left by one, while elements with depth greater than $n$ remain in place, and the depth of the stack does not change. This operation is valid for $n \in [2, 9)$. The diagram below illustrates this graphically.
 
 ![movdn](../../assets/design/stack/stack_ops/MOVDN(n).png)
 
 Stack transition for this operation must satisfy the following constraints:
 
 >$$
-s_n' - s_0 = 0 \text{ for } n \in \{2, ..., 8\} \text{ | degree} = 1
+s_n' - s_0 = 0 \text{ for } n \in [2, 9) \text{ | degree} = 1
 $$
 
 where $n$ is the depth to which the top stack element is moved.
@@ -212,11 +212,11 @@ $$
 Stack transition for this operation must satisfy the following constraints:
 
 >$$
-s_i' - s_0 \cdot s_{i+5} - (1-s_0) \cdot s_{i+1} = 0 \text{ for } i \in \{0..3\}  \text{ | degree} = 2
+s_i' - s_0 \cdot s_{i+5} - (1-s_0) \cdot s_{i+1} = 0 \text{ for } i \in [0, 4)  \text{ | degree} = 2
 $$
 
 >$$
-s_{i+4}' - s_0 \cdot s_{i+1} - (1-s_0) \cdot s_{i+5} = 0 \text{ for } i \in \{0..3\} \text{ | degree} = 2
+s_{i+4}' - s_0 \cdot s_{i+1} - (1-s_0) \cdot s_{i+5} = 0 \text{ for } i \in [0, 4) \text{ | degree} = 2
 $$
 
 We also need to enforce that the value in $s_0$ is binary. This can be done with the following constraint:

--- a/docs/src/design/stack/system_ops.md
+++ b/docs/src/design/stack/system_ops.md
@@ -7,11 +7,11 @@ The `NOOP` operation advances the cycle counter but does not change the state of
 The `NOOP` operation does not impose any constraints besides the ones needed to ensure that the entire state of the stack is copied over. This constraint looks like so:
 
 >$$
-s'_i - s_i = 0 \ \text{ for } i \in \{0, .., 15\} \text { | degree} = 1
+s'_i - s_i = 0 \ \text{ for } i \in [0, 16) \text { | degree} = 1
 $$
 
 ## ASSERT
-The `ASSERT` operation pops an element off the stack and checks if the popped element is equal to $1$. If the element is not equal to $1$, program execution fails..
+The `ASSERT` operation pops an element off the stack and checks if the popped element is equal to $1$. If the element is not equal to $1$, program execution fails.
 
 ![assert](../../assets/design/stack/system_ops/ASSERT.png)
 

--- a/docs/src/user_docs/assembly/io_operations.md
+++ b/docs/src/user_docs/assembly/io_operations.md
@@ -27,7 +27,7 @@ In both case the values must still encode valid field elements.
 | Instruction     | Stack_input | Stack_output | Notes                                      |
 | --------------- | ----------- | ------------ | ------------------------------------------ |
 | sdepth <br> - *(1 cycle)*        | [ ... ] | [d, ... ] | $d \leftarrow stack.depth()$ <br> Pushes the current depth of the stack onto the stack. |
-| caller <br> - *(1 cycle)*        | [ A, b, ... ] | [H, b, ... ] | $H \leftarrow context.fn\_hash()$ <br> Overwrites the top four stack items with the hash of a function which initiated the current SYSCALL. <br> Executing this instruction outside of SYSCALL context will fail. |
+| caller <br> - *(1 cycle)*        | [A, b, ... ] | [H, b, ... ] | $H \leftarrow context.fn\_hash()$ <br> Overwrites the top four stack items with the hash of a function which initiated the current SYSCALL. <br> Executing this instruction outside of SYSCALL context will fail. |
 | locaddr.*i* <br> - *(2 cycles)*  | [ ... ] | [a, ... ] | $a \leftarrow address\_of(i)$ <br> Pushes the absolute memory address of local memory at index $i$ onto the stack. |
 | clk <br> - *(1 cycle)*           | [ ... ] | [t, ... ] | $t \leftarrow clock\_value()$ <br> Pushes the current value of the clock cycle counter onto the stack. |
 


### PR DESCRIPTION
This PR adds usage of half-open intervals `[a, b)` in documentation.

To keep consistency, not only `a..b` was changed, but also `{a, ..., b}` .