### PR TITLE
feat: add SourceLocation to Node

### DIFF
--- a/assembly/src/library/mod.rs
+++ b/assembly/src/library/mod.rs
@@ -10,6 +10,9 @@ pub use masl::MaslLibrary;
 mod path;
 pub use path::LibraryPath;
 
+#[cfg(test)]
+mod tests;
+
 // LIBRARY
 // ================================================================================================
 
@@ -88,6 +91,30 @@ impl Module {
         (self.path.first() == namespace.as_str()).then_some(()).ok_or_else(|| {
             LibraryError::inconsistent_namespace(self.path.first(), namespace.as_str())
         })
+    }
+
+    // STATE MUTATORS
+    // --------------------------------------------------------------------------------------------
+
+    /// Clears the source locations from this module.
+    pub fn clear_locations(&mut self) {
+        self.ast.clear_locations()
+    }
+
+    // SERIALIZATION / DESERIALIZATION
+    // --------------------------------------------------------------------------------------------
+
+    /// Loads the [SourceLocation] of the procedures via [ModuleAst::load_source_locations].
+    pub fn load_source_locations<R: ByteReader>(
+        &mut self,
+        source: &mut R,
+    ) -> Result<(), DeserializationError> {
+        self.ast.load_source_locations(source)
+    }
+
+    /// Writes the [SourceLocation] of the procedures via [ModuleAst::write_source_locations].
+    pub fn write_source_locations<W: ByteWriter>(&self, target: &mut W) {
+        self.ast.write_source_locations(target)
     }
 }
 

--- a/assembly/src/library/tests.rs
+++ b/assembly/src/library/tests.rs
@@ -1,0 +1,57 @@
+use super::{LibraryNamespace, LibraryPath, MaslLibrary, Module, ModuleAst, Version};
+use vm_core::utils::{Deserializable, Serializable, SliceReader};
+
+#[test]
+fn masl_locations_serialization() {
+    // declare foo module
+    let foo = r#"
+        export.foo
+            add
+        end
+        export.foo_mul
+            mul
+        end
+    "#;
+    let path = LibraryPath::new("test::foo").unwrap();
+    let ast = ModuleAst::parse(foo).unwrap();
+    let foo = Module::new(path, ast);
+
+    // declare bar module
+    let bar = r#"
+        export.bar
+            mtree_get
+        end
+        export.bar_mul
+            mul
+        end
+    "#;
+    let path = LibraryPath::new("test::bar").unwrap();
+    let ast = ModuleAst::parse(bar).unwrap();
+    let bar = Module::new(path, ast);
+    let modules = [foo, bar].to_vec();
+
+    // create the bundle with locations
+    let namespace = LibraryNamespace::new("test").unwrap();
+    let version = Version::MIN;
+    let locations = true;
+    let bundle = MaslLibrary::new(namespace, version, locations, modules.clone()).unwrap();
+
+    // serialize/deserialize the bundle
+    let mut bytes = Vec::new();
+    bundle.write_into(&mut bytes);
+    let deserialized = MaslLibrary::read_from(&mut SliceReader::new(&bytes)).unwrap();
+    assert_eq!(bundle, deserialized);
+
+    // create the bundle without locations
+    let namespace = LibraryNamespace::new("test").unwrap();
+    let locations = false;
+    let mut bundle = MaslLibrary::new(namespace, version, locations, modules).unwrap();
+
+    // serialize/deserialize the bundle
+    let mut bytes = Vec::new();
+    bundle.write_into(&mut bytes);
+    let deserialized = MaslLibrary::read_from(&mut SliceReader::new(&bytes)).unwrap();
+    assert_ne!(bundle, deserialized, "sanity check");
+    bundle.clear_locations();
+    assert_eq!(bundle, deserialized);
+}

--- a/assembly/src/parsers/body.rs
+++ b/assembly/src/parsers/body.rs
@@ -1,0 +1,116 @@
+use super::{Node, SourceLocation};
+use core::{iter, slice};
+
+// CODE BODY
+// ================================================================================================
+
+/// A parsed code container to bind a contiguous sequence of [Node] to their optional
+/// [SourceLocation].
+///
+/// Will yield an iterator of each [Node] with its respective [SourceLocation]. The iterator will
+/// be empty if the [SourceLocation] isn't provided.
+#[derive(Clone, Default, Eq, Debug)]
+pub struct CodeBody {
+    nodes: Vec<Node>,
+    locations: Vec<SourceLocation>,
+}
+
+impl PartialEq for CodeBody {
+    fn eq(&self, other: &Self) -> bool {
+        // TODO deserialized node will not restore location, but equality must hold
+        let nodes = self.nodes == other.nodes;
+        let locations = self.locations == other.locations;
+        let left_empty = self.locations.is_empty();
+        let right_empty = other.locations.is_empty();
+        nodes && (locations || left_empty || right_empty)
+    }
+}
+
+impl FromIterator<Node> for CodeBody {
+    fn from_iter<T: IntoIterator<Item = Node>>(nodes: T) -> Self {
+        Self {
+            nodes: nodes.into_iter().collect(),
+            locations: Vec::new(),
+        }
+    }
+}
+
+impl FromIterator<(Node, SourceLocation)> for CodeBody {
+    fn from_iter<T: IntoIterator<Item = (Node, SourceLocation)>>(nodes: T) -> Self {
+        let (nodes, locations) = nodes.into_iter().unzip();
+        Self { nodes, locations }
+    }
+}
+
+impl CodeBody {
+    // CONSTRUCTOR
+    // --------------------------------------------------------------------------------------------
+
+    /// Creates a new instance with the provided `nodes`.
+    pub fn new<N>(nodes: N) -> Self
+    where
+        N: IntoIterator<Item = Node>,
+    {
+        Self {
+            nodes: nodes.into_iter().collect(),
+            locations: Vec::new(),
+        }
+    }
+
+    /// Binds [SourceLocation] to their respective [Node].
+    ///
+    /// It is expected to have the `locations` length equal to the `self.nodes` length.
+    pub fn with_source_locations<L>(mut self, locations: L) -> Self
+    where
+        L: IntoIterator<Item = SourceLocation>,
+    {
+        self.locations = locations.into_iter().collect();
+        self
+    }
+
+    // STATE MUTATORS
+    // --------------------------------------------------------------------------------------------
+
+    /// Pushes the provided location to the structure.
+    ///
+    /// Locations are expected to map `1:1` to their nodes; except for the block termination that
+    /// is always the last location.
+    pub fn push_location(&mut self, location: SourceLocation) {
+        self.locations.push(location);
+    }
+
+    /// Replaces the source locations for this instance.
+    pub fn replace_locations(&mut self, locations: Vec<SourceLocation>) {
+        self.locations = locations;
+    }
+
+    // PUBLIC ACCESSORS
+    // --------------------------------------------------------------------------------------------
+
+    /// Returns the [Node] sequence.
+    pub fn nodes(&self) -> &[Node] {
+        &self.nodes
+    }
+
+    /// Returns the [SourceLocations] bound to the nodes of this body structure.
+    pub fn locations(&self) -> &[SourceLocation] {
+        &self.locations
+    }
+
+    // DESTRUCTURING
+    // --------------------------------------------------------------------------------------------
+
+    /// Returns the internal parts of this parsed code.
+    pub fn into_parts(self) -> (Vec<Node>, Vec<SourceLocation>) {
+        (self.nodes, self.locations)
+    }
+}
+
+impl<'a> IntoIterator for &'a CodeBody {
+    type Item = (&'a Node, &'a SourceLocation);
+    type IntoIter = iter::Zip<slice::Iter<'a, Node>, slice::Iter<'a, SourceLocation>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.nodes.iter().zip(self.locations.iter())
+    }
+}

--- a/assembly/src/parsers/nodes.rs
+++ b/assembly/src/parsers/nodes.rs
@@ -1,4 +1,4 @@
-use super::{Felt, ProcedureId, Vec};
+use super::{CodeBody, Felt, ProcedureId, Vec};
 use core::fmt;
 
 // NODES
@@ -8,9 +8,17 @@ use core::fmt;
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub enum Node {
     Instruction(Instruction),
-    IfElse(Vec<Node>, Vec<Node>),
-    Repeat(u32, Vec<Node>),
-    While(Vec<Node>),
+    IfElse {
+        true_case: CodeBody,
+        false_case: CodeBody,
+    },
+    Repeat {
+        times: u32,
+        body: CodeBody,
+    },
+    While {
+        body: CodeBody,
+    },
 }
 
 /// This holds the list of instructions supported in a Miden program.

--- a/assembly/src/parsers/serde/mod.rs
+++ b/assembly/src/parsers/serde/mod.rs
@@ -1,6 +1,6 @@
 use super::{
-    ByteReader, ByteWriter, Deserializable, DeserializationError, Felt, Instruction, Node,
-    ProcedureId, Serializable,
+    ByteReader, ByteWriter, CodeBody, Deserializable, DeserializationError, Felt, Instruction,
+    Node, ProcedureId, Serializable,
 };
 use crate::MAX_PUSH_INPUTS;
 use num_enum::TryFromPrimitive;

--- a/assembly/src/parsers/serde/serialization.rs
+++ b/assembly/src/parsers/serde/serialization.rs
@@ -9,32 +9,37 @@ impl Serializable for Node {
         // the body parser
 
         match self {
-            Self::Instruction(i) => i.write_into(target),
-            Self::IfElse(if_clause, else_clause) => {
+            // TODO this initial implementation will store location only for in-memory compilation
+            // and will not serialize it.
+            Self::Instruction(inner) => inner.write_into(target),
+            Self::IfElse {
+                true_case,
+                false_case,
+            } => {
                 OpCode::IfElse.write_into(target);
 
-                assert!(if_clause.len() <= u16::MAX as usize, "too many body nodes");
-                target.write_u16(if_clause.len() as u16);
-                if_clause.write_into(target);
+                assert!(true_case.nodes().len() <= u16::MAX as usize, "too many body nodes");
+                target.write_u16(true_case.nodes().len() as u16);
+                true_case.nodes().write_into(target);
 
-                assert!(else_clause.len() <= u16::MAX as usize, "too many body nodes");
-                target.write_u16(else_clause.len() as u16);
-                else_clause.write_into(target);
+                assert!(false_case.nodes().len() <= u16::MAX as usize, "too many body nodes");
+                target.write_u16(false_case.nodes().len() as u16);
+                false_case.nodes().write_into(target);
             }
-            Self::Repeat(times, nodes) => {
+            Self::Repeat { times, body } => {
                 OpCode::Repeat.write_into(target);
                 target.write_u32(*times);
 
-                assert!(nodes.len() <= u16::MAX as usize, "too many body nodes");
-                target.write_u16(nodes.len() as u16);
-                nodes.write_into(target);
+                assert!(body.nodes().len() <= u16::MAX as usize, "too many body nodes");
+                target.write_u16(body.nodes().len() as u16);
+                body.nodes().write_into(target);
             }
-            Self::While(nodes) => {
+            Self::While { body } => {
                 OpCode::While.write_into(target);
 
-                assert!(nodes.len() <= u16::MAX as usize, "too many body nodes");
-                target.write_u16(nodes.len() as u16);
-                nodes.write_into(target);
+                assert!(body.nodes().len() <= u16::MAX as usize, "too many body nodes");
+                target.write_u16(body.nodes().len() as u16);
+                body.nodes().write_into(target);
             }
         }
     }

--- a/assembly/src/parsers/tests.rs
+++ b/assembly/src/parsers/tests.rs
@@ -1,10 +1,9 @@
-use vm_core::Felt;
-
 use super::{
-    BTreeMap, Instruction, LocalProcMap, ModuleAst, Node, ParsingError, ProcedureAst, ProcedureId,
-    ProgramAst, Token,
+    BTreeMap, CodeBody, Instruction, LocalProcMap, ModuleAst, Node, ParsingError, ProcedureAst,
+    ProcedureId, ProgramAst, SourceLocation, Token,
 };
-use crate::SourceLocation;
+use core::mem;
+use vm_core::Felt;
 
 // UNIT TESTS
 // ================================================================================================
@@ -100,21 +99,40 @@ fn test_ast_parsing_program_proc() {
         exec.foo
         exec.bar
     end";
-    let proc_body1: Vec<Node> = vec![Node::Instruction(Instruction::LocLoad(0))];
+
     let mut procedures: LocalProcMap = BTreeMap::new();
     procedures.insert(
         String::from("foo"),
         (
             0,
-            ProcedureAst::new(String::from("foo").try_into().unwrap(), 1, proc_body1, false, None),
+            ProcedureAst::new(
+                String::from("foo").try_into().unwrap(),
+                1,
+                [Node::Instruction(Instruction::LocLoad(0))].to_vec(),
+                false,
+                None,
+            )
+            .with_source_locations(
+                [SourceLocation::new(2, 9), SourceLocation::new(3, 5)],
+                SourceLocation::new(1, 1),
+            ),
         ),
     );
-    let proc_body2: Vec<Node> = vec![Node::Instruction(Instruction::PadW)];
     procedures.insert(
         String::from("bar"),
         (
             1,
-            ProcedureAst::new(String::from("bar").try_into().unwrap(), 2, proc_body2, false, None),
+            ProcedureAst::new(
+                String::from("bar").try_into().unwrap(),
+                2,
+                [Node::Instruction(Instruction::PadW)].to_vec(),
+                false,
+                None,
+            )
+            .with_source_locations(
+                [SourceLocation::new(5, 9), SourceLocation::new(6, 5)],
+                SourceLocation::new(4, 5),
+            ),
         ),
     );
     let nodes: Vec<Node> = vec![
@@ -131,12 +149,21 @@ fn test_ast_parsing_module() {
         loc_load.0
     end";
     let mut procedures: LocalProcMap = BTreeMap::new();
-    let proc_body: Vec<Node> = vec![Node::Instruction(Instruction::LocLoad(0))];
     procedures.insert(
         String::from("foo"),
         (
             0,
-            ProcedureAst::new(String::from("foo").try_into().unwrap(), 1, proc_body, true, None),
+            ProcedureAst::new(
+                String::from("foo").try_into().unwrap(),
+                1,
+                [Node::Instruction(Instruction::LocLoad(0))].to_vec(),
+                true,
+                None,
+            )
+            .with_source_locations(
+                [SourceLocation::new(2, 9), SourceLocation::new(3, 5)],
+                SourceLocation::new(1, 1),
+            ),
         ),
     );
     ProgramAst::parse(source).expect_err("Program should contain body and no export");
@@ -211,34 +238,57 @@ fn test_ast_parsing_module_nested_if() {
     end";
 
     let mut procedures: LocalProcMap = BTreeMap::new();
-    let proc_body: Vec<Node> = vec![
+    let proc_body_nodes = [
         Node::Instruction(Instruction::PushU8(1)),
-        Node::IfElse(
-            [
+        Node::IfElse {
+            true_case: CodeBody::new([
                 Node::Instruction(Instruction::PushU8(0)),
                 Node::Instruction(Instruction::PushU8(1)),
-                Node::IfElse(
-                    [
+                Node::IfElse {
+                    true_case: CodeBody::new([
                         Node::Instruction(Instruction::PushU8(0)),
                         Node::Instruction(Instruction::Sub),
-                    ]
-                    .to_vec(),
-                    [
+                    ])
+                    .with_source_locations([
+                        SourceLocation::new(7, 17),
+                        SourceLocation::new(8, 17),
+                        SourceLocation::new(12, 13),
+                    ]),
+                    false_case: CodeBody::new([
                         Node::Instruction(Instruction::PushU8(1)),
                         Node::Instruction(Instruction::Sub),
-                    ]
-                    .to_vec(),
-                ),
-            ]
-            .to_vec(),
-            vec![],
-        ),
-    ];
+                    ])
+                    .with_source_locations([
+                        SourceLocation::new(10, 17),
+                        SourceLocation::new(11, 17),
+                        SourceLocation::new(12, 13),
+                    ]),
+                },
+            ])
+            .with_source_locations([
+                SourceLocation::new(4, 13),
+                SourceLocation::new(5, 13),
+                SourceLocation::new(6, 13),
+                SourceLocation::new(13, 9),
+            ]),
+            false_case: CodeBody::default(),
+        },
+    ]
+    .to_vec();
+    let proc_body_locations =
+        [SourceLocation::new(2, 9), SourceLocation::new(3, 9), SourceLocation::new(14, 5)];
     procedures.insert(
         String::from("foo"),
         (
             0,
-            ProcedureAst::new(String::from("foo").try_into().unwrap(), 0, proc_body, false, None),
+            ProcedureAst::new(
+                String::from("foo").try_into().unwrap(),
+                0,
+                proc_body_nodes,
+                false,
+                None,
+            )
+            .with_source_locations(proc_body_locations, SourceLocation::new(1, 1)),
         ),
     );
     ProgramAst::parse(source).expect_err("Program should contain body and no export");
@@ -274,28 +324,60 @@ fn test_ast_parsing_module_sequential_if() {
     end";
 
     let mut procedures: LocalProcMap = BTreeMap::new();
-    let proc_body: Vec<Node> = vec![
+    let proc_body_nodes = [
         Node::Instruction(Instruction::PushU8(1)),
-        Node::IfElse(
-            [
+        Node::IfElse {
+            true_case: CodeBody::new([
                 Node::Instruction(Instruction::PushU8(5)),
                 Node::Instruction(Instruction::PushU8(1)),
-            ]
-            .to_vec(),
-            vec![],
-        ),
-        Node::IfElse(
-            [Node::Instruction(Instruction::PushU8(0)), Node::Instruction(Instruction::Sub)]
-                .to_vec(),
-            [Node::Instruction(Instruction::PushU8(1)), Node::Instruction(Instruction::Sub)]
-                .to_vec(),
-        ),
+            ])
+            .with_source_locations([
+                SourceLocation::new(4, 13),
+                SourceLocation::new(5, 13),
+                SourceLocation::new(6, 9),
+            ]),
+            false_case: CodeBody::default(),
+        },
+        Node::IfElse {
+            true_case: CodeBody::new([
+                Node::Instruction(Instruction::PushU8(0)),
+                Node::Instruction(Instruction::Sub),
+            ])
+            .with_source_locations([
+                SourceLocation::new(8, 13),
+                SourceLocation::new(9, 13),
+                SourceLocation::new(13, 9),
+            ]),
+            false_case: CodeBody::new([
+                Node::Instruction(Instruction::PushU8(1)),
+                Node::Instruction(Instruction::Sub),
+            ])
+            .with_source_locations([
+                SourceLocation::new(11, 13),
+                SourceLocation::new(12, 13),
+                SourceLocation::new(13, 9),
+            ]),
+        },
+    ]
+    .to_vec();
+    let proc_body_locations = [
+        SourceLocation::new(2, 9),
+        SourceLocation::new(3, 9),
+        SourceLocation::new(7, 9),
+        SourceLocation::new(14, 5),
     ];
     procedures.insert(
         String::from("foo"),
         (
             0,
-            ProcedureAst::new(String::from("foo").try_into().unwrap(), 0, proc_body, false, None),
+            ProcedureAst::new(
+                String::from("foo").try_into().unwrap(),
+                0,
+                proc_body_nodes,
+                false,
+                None,
+            )
+            .with_source_locations(proc_body_locations, SourceLocation::new(1, 1)),
         ),
     );
     ProgramAst::parse(source).expect_err("Program should contain body and no export");
@@ -310,6 +392,49 @@ fn test_ast_parsing_module_sequential_if() {
             proc
         );
     }
+}
+
+#[test]
+fn parsed_while_if_body() {
+    let source = "\
+    begin
+        push.1
+        while.true
+            mul
+        end
+        add
+        if.true
+            div
+        end
+        mul
+    end
+    ";
+
+    let body = ProgramAst::parse(source).unwrap().body;
+    let expected = CodeBody::new([
+        Node::Instruction(Instruction::PushU8(1)),
+        Node::While {
+            body: CodeBody::new([Node::Instruction(Instruction::Mul)])
+                .with_source_locations([SourceLocation::new(4, 13), SourceLocation::new(5, 9)]),
+        },
+        Node::Instruction(Instruction::Add),
+        Node::IfElse {
+            true_case: CodeBody::new([Node::Instruction(Instruction::Div)])
+                .with_source_locations([SourceLocation::new(8, 13), SourceLocation::new(9, 9)]),
+            false_case: CodeBody::default(),
+        },
+        Node::Instruction(Instruction::Mul),
+    ])
+    .with_source_locations([
+        SourceLocation::new(2, 9),
+        SourceLocation::new(3, 9),
+        SourceLocation::new(6, 9),
+        SourceLocation::new(7, 9),
+        SourceLocation::new(10, 9),
+        SourceLocation::new(11, 5),
+    ]);
+
+    assert_eq!(body, expected);
 }
 
 // PROCEDURE IMPORTS
@@ -380,14 +505,17 @@ fn test_ast_parsing_simple_docs() {
         loc_load.0
     end";
 
-    let proc_body_foo: Vec<Node> = vec![Node::Instruction(Instruction::LocLoad(0))];
     let docs_foo = "proc doc".to_string();
     let procedure = ProcedureAst::new(
         String::from("foo").try_into().unwrap(),
         1,
-        proc_body_foo,
+        [Node::Instruction(Instruction::LocLoad(0))].to_vec(),
         true,
         Some(docs_foo),
+    )
+    .with_source_locations(
+        [SourceLocation::new(3, 9), SourceLocation::new(4, 5)],
+        SourceLocation::new(2, 5),
     );
 
     let module = ModuleAst::parse(source).unwrap();
@@ -427,7 +555,6 @@ export.baz.3
     push.0
 end";
     let mut procedures: LocalProcMap = BTreeMap::new();
-    let proc_body_foo: Vec<Node> = vec![Node::Instruction(Instruction::LocLoad(0))];
     let docs_foo =
         "Test documenation for export procedure foo in parsing test. Lorem ipsum dolor sit amet,
 consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
@@ -441,14 +568,17 @@ of the comments is correctly parsed. There was a bug here earlier."
             ProcedureAst::new(
                 String::from("foo").try_into().unwrap(),
                 1,
-                proc_body_foo,
+                [Node::Instruction(Instruction::LocLoad(0))].to_vec(),
                 true,
                 Some(docs_foo),
+            )
+            .with_source_locations(
+                [SourceLocation::new(11, 5), SourceLocation::new(12, 1)],
+                SourceLocation::new(10, 1),
             ),
         ),
     );
 
-    let proc_body_bar: Vec<Node> = vec![Node::Instruction(Instruction::PadW)];
     procedures.insert(
         String::from("bar"),
         (
@@ -456,15 +586,17 @@ of the comments is correctly parsed. There was a bug here earlier."
             ProcedureAst::new(
                 String::from("bar").try_into().unwrap(),
                 2,
-                proc_body_bar,
+                [Node::Instruction(Instruction::PadW)].to_vec(),
                 false,
                 None,
+            )
+            .with_source_locations(
+                [SourceLocation::new(18, 5), SourceLocation::new(19, 1)],
+                SourceLocation::new(17, 1),
             ),
         ),
     );
 
-    let proc_body_baz: Vec<Node> =
-        vec![Node::Instruction(Instruction::PadW), Node::Instruction(Instruction::PushU8(0))];
     let docs_baz =
         "Test documenation for export procedure baz in parsing test. Lorem ipsum dolor sit amet,
 consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna
@@ -477,15 +609,24 @@ aliqua."
             ProcedureAst::new(
                 String::from("baz").try_into().unwrap(),
                 3,
-                proc_body_baz,
+                [Node::Instruction(Instruction::PadW), Node::Instruction(Instruction::PushU8(0))]
+                    .to_vec(),
                 true,
                 Some(docs_baz),
+            )
+            .with_source_locations(
+                [
+                    SourceLocation::new(25, 5),
+                    SourceLocation::new(26, 5),
+                    SourceLocation::new(27, 1),
+                ],
+                SourceLocation::new(24, 1),
             ),
         ),
     );
 
     ProgramAst::parse(source).expect_err("Program should contain body and no export");
-    let module = ModuleAst::parse(source).unwrap();
+    let mut module = ModuleAst::parse(source).unwrap();
 
     let module_docs =
         "Test documenation for the whole module in parsing test. Lorem ipsum dolor sit amet,
@@ -507,6 +648,7 @@ of the comments is correctly parsed. There was a bug here earlier."
     let module_serialized = module.to_bytes();
     let module_deserialized = ModuleAst::from_bytes(module_serialized.as_slice()).unwrap();
 
+    clear_procs_loc_module(&mut module);
     assert_eq!(module, module_deserialized);
 }
 
@@ -583,10 +725,11 @@ fn test_ast_parsing_module_docs_fail() {
 #[test]
 fn test_ast_program_serde_simple() {
     let source = "begin push.0xabc234 push.0 assertz end";
-    let program = ProgramAst::parse(source).unwrap();
+    let mut program = ProgramAst::parse(source).unwrap();
     let program_serialized = program.to_bytes();
     let program_deserialized = ProgramAst::from_bytes(program_serialized.as_slice()).unwrap();
 
+    clear_procs_loc_program(&mut program);
     assert_eq!(program, program_deserialized);
 }
 
@@ -603,10 +746,11 @@ fn test_ast_program_serde_local_procs() {
         exec.foo
         exec.bar
     end";
-    let program = ProgramAst::parse(source).unwrap();
+    let mut program = ProgramAst::parse(source).unwrap();
     let program_serialized = program.to_bytes();
     let program_deserialized = ProgramAst::from_bytes(program_serialized.as_slice()).unwrap();
 
+    clear_procs_loc_program(&mut program);
     assert_eq!(program, program_deserialized);
 }
 
@@ -619,10 +763,11 @@ fn test_ast_program_serde_exported_procs() {
     export.bar.2
         padw
     end";
-    let module = ModuleAst::parse(source).unwrap();
+    let mut module = ModuleAst::parse(source).unwrap();
     let module_serialized = module.to_bytes();
     let module_deserialized = ModuleAst::from_bytes(module_serialized.as_slice()).unwrap();
 
+    clear_procs_loc_module(&mut module);
     assert_eq!(module, module_deserialized);
 }
 
@@ -656,10 +801,11 @@ fn test_ast_program_serde_control_flow() {
 
     end";
 
-    let program = ProgramAst::parse(source).unwrap();
+    let mut program = ProgramAst::parse(source).unwrap();
     let program_serialized = program.to_bytes();
     let program_deserialized = ProgramAst::from_bytes(program_serialized.as_slice()).unwrap();
 
+    clear_procs_loc_program(&mut program);
     assert_eq!(program, program_deserialized);
 }
 
@@ -736,7 +882,7 @@ fn assert_parsing_line_unexpected_token() {
 
 fn assert_program_output(source: &str, procedures: LocalProcMap, body: Vec<Node>) {
     let program = ProgramAst::parse(source).unwrap();
-    assert_eq!(program.body, body);
+    assert_eq!(program.body.nodes(), body);
     assert_eq!(program.local_procs.len(), procedures.len());
     for (i, proc) in program.local_procs.iter().enumerate() {
         assert_eq!(
@@ -747,4 +893,33 @@ fn assert_program_output(source: &str, procedures: LocalProcMap, body: Vec<Node>
             proc
         );
     }
+}
+
+// HELPER FUNCTIONS
+// ================================================================================================
+
+/// Clears the proc locations.
+///
+/// Currently, the locations are not part of the serialized libraries; thus, they have to be
+/// cleaned before equality is checked for tests
+#[cfg(test)]
+fn clear_procs_loc_module(module: &mut ModuleAst) {
+    module.local_procs.iter_mut().for_each(|m| {
+        m.body = CodeBody::new(mem::take(&mut m.body).into_parts().0);
+        m.start = SourceLocation::default();
+    });
+}
+
+/// Clears the proc locations.
+///
+/// Currently, the locations are not part of the serialized libraries; thus, they have to be
+/// cleaned before equality is checked for tests
+#[cfg(test)]
+fn clear_procs_loc_program(program: &mut ProgramAst) {
+    program.start = SourceLocation::default();
+    program.local_procs.iter_mut().for_each(|m| {
+        m.body = CodeBody::new(mem::take(&mut m.body).into_parts().0);
+        m.start = SourceLocation::default();
+    });
+    program.body = CodeBody::new(mem::take(&mut program.body).into_parts().0);
 }

--- a/assembly/src/tokens/location.rs
+++ b/assembly/src/tokens/location.rs
@@ -1,3 +1,4 @@
+use super::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable};
 use core::fmt;
 
 // SOURCE LOCATION
@@ -46,5 +47,20 @@ impl SourceLocation {
 impl fmt::Display for SourceLocation {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "[{}:{}]", self.line, self.column)
+    }
+}
+
+impl Serializable for SourceLocation {
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        target.write_u32(self.line);
+        target.write_u32(self.column);
+    }
+}
+
+impl Deserializable for SourceLocation {
+    fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
+        let line = source.read_u32()?;
+        let column = source.read_u32()?;
+        Ok(Self { line, column })
     }
 }

--- a/assembly/src/tokens/mod.rs
+++ b/assembly/src/tokens/mod.rs
@@ -1,4 +1,7 @@
-use super::{BTreeMap, LibraryPath, ParsingError, ProcedureName, String, ToString, Vec};
+use super::{
+    BTreeMap, ByteReader, ByteWriter, Deserializable, DeserializationError, LibraryPath,
+    ParsingError, ProcedureName, Serializable, String, ToString, Vec,
+};
 use core::fmt;
 
 mod lines;

--- a/assembly/src/tokens/stream.rs
+++ b/assembly/src/tokens/stream.rs
@@ -70,7 +70,7 @@ impl<'a> TokenStream<'a> {
             return Err(ParsingError::empty_source());
         }
 
-        let location = SourceLocation::default();
+        let location = locations[0];
         let current = Token::new(tokens[0], location);
         Ok(Self {
             tokens,

--- a/stdlib/build.rs
+++ b/stdlib/build.rs
@@ -30,7 +30,8 @@ fn main() -> io::Result<()> {
 
     let namespace = LibraryNamespace::try_from("std".to_string()).expect("invalid base namespace");
     let version = Version::try_from(env!("CARGO_PKG_VERSION")).expect("invalid cargo version");
-    let stdlib = MaslLibrary::read_from_dir(ASM_DIR_PATH, namespace, version)?;
+    let locations = true; // store & load locations by default
+    let stdlib = MaslLibrary::read_from_dir(ASM_DIR_PATH, namespace, locations, version)?;
     let docs = stdlib
         .modules()
         .map(|module| (module.path.to_string(), module.ast.clone()))


### PR DESCRIPTION
This commit adds source location to parsed nodes, allowing the construction of source mapping.

It modifies the [Node] structure based on the discussion that took place here:

https://github.com/0xPolygonMiden/miden-vm/issues/866#issuecomment-1524230664

The implementation is slightly different than the one discussed as every instruction individually will contain a [SourceLocation] - it will be less expensive to store it like that instead of creating sets for each of the block variants.

The [SourceLocation] itself is a cheap type that will contain integers only.

This commit doesn't touch the serialization question for ModuleAst with SourceLocation. These additional bytes might be optional, and including them might be optional as they will consume additional production storage when they will provide functionality only for debug/development environments.