### PR TITLE
Add public mutators to `AdviceInputs` struct

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -10,8 +10,8 @@ pub use ::crypto::{Word, ONE, WORD_SIZE, ZERO};
 pub mod crypto {
     pub mod merkle {
         pub use ::crypto::merkle::{
-            EmptySubtreeRoots, MerkleError, MerklePath, MerklePathSet, MerkleStore, MerkleTree,
-            Mmr, MmrPeaks, NodeIndex, SimpleSmt,
+            EmptySubtreeRoots, InnerNodeInfo, MerkleError, MerklePath, MerklePathSet, MerkleStore,
+            MerkleTree, Mmr, MmrPeaks, NodeIndex, SimpleSmt,
         };
     }
 

--- a/processor/src/advice/inputs.rs
+++ b/processor/src/advice/inputs.rs
@@ -1,4 +1,4 @@
-use super::{BTreeMap, Felt, InputError, MerkleStore, Vec};
+use super::{BTreeMap, Felt, InnerNodeInfo, InputError, MerkleStore, Vec};
 
 // ADVICE INPUTS
 // ================================================================================================
@@ -65,6 +65,33 @@ impl AdviceInputs {
     pub fn with_merkle_store(mut self, store: MerkleStore) -> Self {
         self.store = store;
         self
+    }
+
+    // PUBLIC MUTATORS
+    // --------------------------------------------------------------------------------------------
+
+    /// Extends the stack with the given elements.
+    pub fn extend_stack<I>(&mut self, iter: I)
+    where
+        I: IntoIterator<Item = Felt>,
+    {
+        self.stack.extend(iter);
+    }
+
+    /// Extends the map of values with the given argument, replacing previously inserted items.
+    pub fn extend_map<I>(&mut self, iter: I)
+    where
+        I: IntoIterator<Item = ([u8; 32], Vec<Felt>)>,
+    {
+        self.map.extend(iter);
+    }
+
+    /// Extends the [MerkleStore] with the given nodes.
+    pub fn extend_merkle_store<I>(&mut self, iter: I)
+    where
+        I: Iterator<Item = InnerNodeInfo>,
+    {
+        self.store.extend(iter);
     }
 
     // PUBLIC ACCESSORS

--- a/processor/src/advice/mod.rs
+++ b/processor/src/advice/mod.rs
@@ -1,6 +1,6 @@
 use super::{ExecutionError, Felt, InputError, StarkField, Word};
 use vm_core::{
-    crypto::merkle::{MerklePath, MerkleStore, NodeIndex},
+    crypto::merkle::{InnerNodeInfo, MerklePath, MerkleStore, NodeIndex},
     utils::{
         collections::{BTreeMap, Vec},
         IntoBytes,


### PR DESCRIPTION
## Describe your changes
This PR introduces three methods on the `AdviceInputs` struct.  These methods allow the `AdviceInputs` struct to be extended without it being consumed. This supports our efforts to introduce and implement `AdviceInputsBuilder` and `ToAdviceInputs` traits in `miden-base`.

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
