### PR TITLE
chore: specify simple-smt branch for crypto crate

### DIFF
--- a/miden/src/cli/data.rs
+++ b/miden/src/cli/data.rs
@@ -197,9 +197,7 @@ impl InputFile {
                 }
                 MerkleData::SparseMerkleTree(data) => {
                     let entries = Self::parse_sparse_merkle_tree(data)?;
-                    let tree = SimpleSmt::new(u64::BITS as u8)
-                        .expect("failed to instantiate a sparse Merkle tree")
-                        .with_leaves(entries)
+                    let tree = SimpleSmt::with_leaves(u64::BITS as u8, entries)
                         .map_err(|e| format!("failed to parse a sparse Merkle tree: {e}"))?;
                     merkle_store.extend(tree.inner_nodes());
                 }


### PR DESCRIPTION
This PR modifies the invocation of the `SimpleSmt::with_leaves(..)` constructor to support the new api.  We will use this branch to prepare downstream branches (`midne-base`) for the new `SimpleSmt` api.