### PR TITLE
stark verifier: save trace length to memory

### DIFF
--- a/stdlib/asm/crypto/stark/random_coin.masm
+++ b/stdlib/asm/crypto/stark/random_coin.masm
@@ -9,6 +9,8 @@ const.LDE_SIZE_PTR=4294967292
 const.ZERO_WORD_PTR=4294967278
 const.ZERO_ZERO_ZERO_ONE_PTR=4294967277
 
+const.TRACE_LENGTH_PTR=4294967296
+
 #! Helper procedure to compute addition of two words component-wise.
 #! Input: [b3, b2, b1, b0, a3, a2, a1, a0]
 #! Output: [c3, c2, c1, c0]
@@ -83,6 +85,9 @@ export.init_seed
     pow2
     u32split assertz
     #=> [trace_length, log(trace_length), num_queries, log(blowup), grinding]
+
+    ## Save the trace length to memory
+    dup.0 push.TRACE_LENGTH_PTR mem_store
 
     ## Assert blowup is equal to 8
     ##  Cycles: 6


### PR DESCRIPTION
## Describe your changes

Review/Merge after #897 

This saves the trace_length to memory so that it can later be used to compute the periodic values.


## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
