### PR TITLE
Procedures to simulate candidate new instructions RCOMB

### DIFF
--- a/stdlib/asm/crypto/stark/random_combine.masm
+++ b/stdlib/asm/crypto/stark/random_combine.masm
@@ -12,16 +12,16 @@
 #!
 #! The stack transition of the instruction can be visualized as follows:
 #!
-#! +------+------+------+------+------+------+------+------+------+------+------+------+------+------+------+------+
-#! |  T7  |  T6  |  T5  |  T4  |  T3  |  T2  |  T1  |  T0  |  p1  |  p0  |  r1  |  r0  |x_addr|z_addr|a_addr|  b   |
-#! +------+------+------+------+------+------+------+------+------+------+------+------+------+------+------+------+
+#! +------+------+------+------+------+------+------+------+------+------+------+------+------+------+------+---+
+#! |  T7  |  T6  |  T5  |  T4  |  T3  |  T2  |  T1  |  T0  |  p1  |  p0  |  r1  |  r0  |x_addr|z_addr|a_addr| - |
+#! +------+------+------+------+------+------+------+------+------+------+------+------+------+------+------+---+
 #! 
 #!                                                       ||
 #!                                                       \/
 #!                                                    
-#! +------+------+------+------+------+------+------+------+------+------+------+------+------+--------+--------+-------+
-#! |  T0  |  T7  |  T6  |  T5  |  T4  |  T3  |  T2  |  T1  |  p1' |  p0' |  r1' |  r0' |x_addr|z_addr+1|a_addr+b|  1-b  |
-#! +------+------+------+------+------+------+------+------+------+------+------+------+------+--------+--------+-------+
+#! +------+------+------+------+------+------+------+------+------+------+------+------+------+--------+--------+---+
+#! |  T0  |  T7  |  T6  |  T5  |  T4  |  T3  |  T2  |  T1  |  p1' |  p0' |  r1' |  r0' |x_addr|z_addr+1|a_addr+1| - |
+#! +------+------+------+------+------+------+------+------+------+------+------+------+------+--------+--------+---+
 #! 
 #! 
 #! Here:
@@ -29,82 +29,76 @@
 #! 2- (p0, p1) stands for an extension field element accumulating the values for the quotients with common denominator (x - gz).
 #! 3- (r0, r1) stands for an extension field element accumulating the values for the quotients with common denominator (x - z).
 #! 4- x_addr is the memory address from which we are loading the Ti's using the MSTREAM instruction.
-#! 5- z_addr is the memory address to the i-th OOD evaluation frame at z and gz i.e. T_i(z):= (T_i(z)0, T_i(z)1) and T_i(gz):= (T_i(gz)0, T_i(gz)1)
+#! 5- z_addr is the memory address to the i-th OOD evaluation frame at z and gz i.e. T_i(z):= (T_i(z)0, T_i(z)1)
+#!  and T_i(gz):= (T_i(gz)0, T_i(gz)1)
 #! 6- a_addr is the memory address of the i-th random element used in batching the trace polynomial quotients. 
-#! Since each memory address holds two random values and only one is used for the current step, we use a binary flag to decide
-#! on which of the two random elements to use in the current step.
-#! 7- b is a binary flag to select between a := (a0, a1) and  a' := (a0', a1') where [a0, a1, a0', a1']
-#! is the word currently pointed to by a_addr.
+#!  The random elements a := (a0, a1) are stored in memory as [0, 0, a0, a1].
 #! 
-#! Input: [T7, T6, T5, T4, T3, T2, T1, T0, p1, p0, r1, r0, x_addr, z_addr, a_addr, b]
-#! Output: [T0, T7, T6, T5, T4, T3, T2, T1, p1', p0', r1', r0', x_addr, z_addr', a_addr', 1-b]
-export.main_1
-    #=> [T7, T6, T5, T4, T3, T2, T1, T0, p1, p0, r1, r0, x_addr, z_addr, a_addr, b]
+#! Input: [T7, T6, T5, T4, T3, T2, T1, T0, p1, p0, r1, r0, x_addr, z_addr, a_addr, 0]
+#! Output: [T0, T7, T6, T5, T4, T3, T2, T1, p1', p0', r1', r0', x_addr, z_addr+1, a_addr+1, 0]
+export.main
 
     # 1) Shift trace columns values left
     movup.7   
-    #=> [T0, T7, T6, T5, T4, T3, T2, T1, p1, p0, r1, r0, x_addr, z_addr, a_addr, b]
+    #=> [T0, T7, T6, T5, T4, T3, T2, T1, p1, p0, r1, r0, x_addr, z_addr, a_addr, 0]
 
-    # 2) Get a_addr and b and update a_addr. This is done here before these elements become inaccessible.
+    # 2) Get a_addr and update it. This is done here before the element becomes inaccessible.
     
     # Update a_addr
-    dup.15 dup.15 add swap.15
-    #=> [a_addr, T0, T7, T6, T5, T4, T3, T2, T1, p1, p0, r1, r0, x_addr, z_addr, a_addr', b]
+    dup.14 add.1 swap.15
+    #=> [a_addr, T0, T7, T6, T5, T4, T3, T2, T1, p1, p0, r1, r0, x_addr, z_addr, a_addr', 0]
 
     # 3) Load i-th OOD frame portion. This assumes that the OOD frame has been serialized with `current` and `next` rows interleaved.
     # This also updates the z_addr pointer.
     dup.14 add.1 swap.15
     push.0.0.0.0 movup.4 mem_loadw
-    #=> [Tgz1, Tgz0, Tz1, Tz0, a_addr, T0, T7, T6, T5, T4, T3, T2, T1, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
+    #=> [Tgz1, Tgz0, Tz1, Tz0, a_addr, T0, T7, T6, T5, T4, T3, T2, T1, p1, p0, r1, r0, x_addr, z_addr', a_addr', 0]
 
     # 4) Compute the numerators
 
     # a) Compute T_i - T_i(z). This equals, in the case of T0, (-Tz1, T0 - Tz0)
     dup.5
     movup.4
-    #=> [Tz0, T0, Tgz1, Tgz0, Tz1, a_addr, T0, T7, T6, T5, T4, T3, T2, T1, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
+    #=> [Tz0, T0, Tgz1, Tgz0, Tz1, a_addr, T0, T7, T6, T5, T4, T3, T2, T1, p1, p0, r1, r0, x_addr, z_addr', a_addr', 0]
 
     sub
-    #=> [T0 - Tz0, Tgz1, Tgz0, Tz1, a_addr, T0, T7, T6, T5, T4, T3, T2, T1, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
+    #=> [T0 - Tz0, Tgz1, Tgz0, Tz1, a_addr, T0, T7, T6, T5, T4, T3, T2, T1, p1, p0, r1, r0, x_addr, z_addr', a_addr', 0]
     
     swap.3 neg swap.2
-    #=> [Tgz0, Tgz1, -Tz1, T0 - Tz0, a_addr, T0, T7, T6, T5, T4, T3, T2, T1, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
+    #=> [Tgz0, Tgz1, -Tz1, T0 - Tz0, a_addr, T0, T7, T6, T5, T4, T3, T2, T1, p1, p0, r1, r0, x_addr, z_addr', a_addr', 0]
     
     # b) Compute T_i - T_i(gz). This equals, in the case of T0, (-Tgz1, T0 - Tgz0)
     dup.5 swap sub
-    #=> [T0 - Tgz0, Tgz1, -Tz1, T0 - Tz0, a_addr, T0, T7, T6, T5, T4, T3, T2, T1, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
+    #=> [T0 - Tgz0, Tgz1, -Tz1, T0 - Tz0, a_addr, T0, T7, T6, T5, T4, T3, T2, T1, p1, p0, r1, r0, x_addr, z_addr', a_addr', 0]
     
     swap
     neg
-    #=> [-Tgz1, T0 - Tgz0, -Tz1, T0 - Tz0, a_addr, T0, T7, T6, T5, T4, T3, T2, T1, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
-    #=> [Δg1, Δg0, Δ1, Δ0, a_addr, T0, T7, T6, T5, T4, T3, T2, T1, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
+    #=> [-Tgz1, T0 - Tgz0, -Tz1, T0 - Tz0, a_addr, T0, T7, T6, T5, T4, T3, T2, T1, p1, p0, r1, r0, x_addr, z_addr', a_addr', 0]
+    #=> [Δg1, Δg0, Δ1, Δ0, a_addr, T0, T7, T6, T5, T4, T3, T2, T1, p1, p0, r1, r0, x_addr, z_addr', a_addr', 0]
     # where Δg1 := -Tgz1, Δg0 := T0 - Tgz0, Δ1 := -Tz1 and Δ0 := T0 - Tz0
 
     # 5) Multiply by randomness
 
     # a) Load randomness from memory
     push.0.0.0.0
-    movup.8 mem_loadw
-    #=> [a1', a0', a1, a0, Δg1, Δg0, Δ1, Δ0, T0, T7, T6, T5, T4, T3, T2, T1, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
+    movup.8 mem_loadw drop drop
+    #=> [a1, a0, Δg1, Δg0, Δ1, Δ0, T0, T7, T6, T5, T4, T3, T2, T1, p1, p0, r1, r0, x_addr, z_addr', a_addr', 0]
 
-    # b) Use b to choose between a and a'. Since b is inaccessible, we "hard-code" b by creating two versions of `random_combinate`.
-    drop drop
-
-    # c) Multiply (Δ0, Δ1)
+    # b) Multiply (Δ0, Δ1)
     dup.1 dup.1
     movup.7 movup.7
-    #=> [Δ1, Δ0, a1, a0, a1, a0, Δg1, Δg0, T0, T7, T6, T5, T4, T3, T2, T1, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
+    #=> [Δ1, Δ0, a1, a0, a1, a0, Δg1, Δg0, T0, T7, T6, T5, T4, T3, T2, T1, p1, p0, r1, r0, x_addr, z_addr', a_addr', 0]
 
     ext2mul
-    #=> [prod1, prod0, a1, a0, Δg1, Δg0, T0, T7, T6, T5, T4, T3, T2, T1, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
+    #=> [prod1, prod0, a1, a0, Δg1, Δg0, T0, T7, T6, T5, T4, T3, T2, T1, p1, p0, r1, r0, x_addr, z_addr', a_addr', 0]
     #   where (prod0, prod1) := (Δ0, Δ1) * (a0, a1)
 
     movdn.5 movdn.5
-    #=> [a1, a0, Δg1, Δg0, prod1, prod0, T0, T7, T6, T5, T4, T3, T2, T1, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
+    #=> [a1, a0, Δg1, Δg0, prod1, prod0, T0, T7, T6, T5, T4, T3, T2, T1, p1, p0, r1, r0, x_addr, z_addr', a_addr', 0]
 
-    # d) Multiply (Δg0, Δg1)
+    # c) Multiply (Δg0, Δg1)
     ext2mul
-    #=> [prodg1, prodg0, prod1, prod0, T0, T7, T6, T5, T4, T3, T2, T1, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
+    #=> [prodg1, prodg0, prod1, prod0, T0, T7, T6, T5, T4, T3, T2, T1, p1, p0, r1, r0, x_addr, z_addr', a_addr', 0]
     #   where (prodg0, prodg1) := (Δg0, Δg1) * (a0, a1)
 
     # 6) Accumulate into (p0, p1) and (r0, r1)
@@ -112,114 +106,17 @@ export.main_1
 
     # a) Accumulate into (r0, r1)
     movup.7 movup.7 
-    #=> [prod1, prod0, p1, p0, r1, r0, prodg1, prodg0, T0, T7, T6, T5, T4, T3, T2, T1, x_addr, z_addr', a_addr', b]
+    #=> [prod1, prod0, p1, p0, r1, r0, prodg1, prodg0, T0, T7, T6, T5, T4, T3, T2, T1, x_addr, z_addr', a_addr', 0]
     movup.5 movup.5 ext2add
-    #=> [r1', r0', p1, p0, prodg1, prodg0, T0, T7, T6, T5, T4, T3, T2, T1, x_addr, z_addr', a_addr', b]
+    #=> [r1', r0', p1, p0, prodg1, prodg0, T0, T7, T6, T5, T4, T3, T2, T1, x_addr, z_addr', a_addr', 0]
     
     # b) Accumulate into (p0, p1)
     movdn.5 movdn.5 ext2add    
-    #=> [p1', p0', r1', r0', T0, T7, T6, T5, T4, T3, T2, T1, x_addr, z_addr', a_addr', b]
+    #=> [p1', p0', r1', r0', T0, T7, T6, T5, T4, T3, T2, T1, x_addr, z_addr', a_addr', 0]
 
-    # c) Prepare for next iteration. This includes updating b.
-    swapw.3
-    movup.3 not movdn.3
-    movdnw.3
-    #=> [T0, T7, T6, T5, T4, T3, T2, T1, p1', p0', r1', r0', x_addr, z_addr', a_addr', 1-b]
-end
-
-#! Similar to `random_combine::main_1` but chooses the second random element at address `a_addr`.
-#! This mimics the function of `b` because `b` is unreachable when needed on the stack.
-#! 
-#! Input: [T7, T6, T5, T4, T3, T2, T1, T0, p1, p0, r1, r0, x_addr, z_addr, a_addr, b]
-#! Output: [T0, T7, T6, T5, T4, T3, T2, T1, p1', p0', r1', r0', x_addr, z_addr', a_addr', 1-b]
-export.main_2
-    #=> [T7, T6, T5, T4, T3, T2, T1, T0, p1, p0, r1, r0, x_addr, z_addr, a_addr, b]
-
-    # 1) Shift trace columns values left
-    movup.7   
-    #=> [T0, T7, T6, T5, T4, T3, T2, T1, p1, p0, r1, r0, x_addr, z_addr, a_addr, b]
-
-    # 2) Get a_addr and b and update a_addr. This is done here before these elements become inaccessible.
-    
-    # Update a_addr
-    dup.15 dup.15 add swap.15
-    #=> [a_addr, T0, T7, T6, T5, T4, T3, T2, T1, p1, p0, r1, r0, x_addr, z_addr, a_addr', b]
-
-    # 3) Load i-th OOD frame portion. This assumes that the OOD frame has been serialized with `current` and `next` rows interleaved.
-    # This also updates the z_addr pointer.
-    dup.14 add.1 swap.15
-    push.0.0.0.0 movup.4 mem_loadw
-    #=> [Tgz1, Tgz0, Tz1, Tz0, a_addr, T0, T7, T6, T5, T4, T3, T2, T1, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
-
-    # 4) Compute the numerators
-
-    # a) Compute T_i - T_i(z). This equals, in the case of T0, (-Tz1, T0 - Tz0)
-    dup.5
-    movup.4
-    #=> [Tz0, T0, Tgz1, Tgz0, Tz1, a_addr, T0, T7, T6, T5, T4, T3, T2, T1, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
-
-    sub
-    #=> [T0 - Tz0, Tgz1, Tgz0, Tz1, a_addr, T0, T7, T6, T5, T4, T3, T2, T1, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
-    
-    swap.3 neg swap.2
-    #=> [Tgz0, Tgz1, -Tz1, T0 - Tz0, a_addr, T0, T7, T6, T5, T4, T3, T2, T1, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
-    
-    # b) Compute T_i - T_i(gz). This equals, in the case of T0, (-Tgz1, T0 - Tgz0)
-    dup.5 swap sub
-    #=> [T0 - Tgz0, Tgz1, -Tz1, T0 - Tz0, a_addr, T0, T7, T6, T5, T4, T3, T2, T1, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
-    
-    swap
-    neg
-    #=> [-Tgz1, T0 - Tgz0, -Tz1, T0 - Tz0, a_addr, T0, T7, T6, T5, T4, T3, T2, T1, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
-    #=> [Δg1, Δg0, Δ1, Δ0, a_addr, T0, T7, T6, T5, T4, T3, T2, T1, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
-    # where Δg1 := -Tgz1, Δg0 := T0 - Tgz0, Δ1 := -Tz1 and Δ0 := T0 - Tz0
-
-    # 5) Multiply by randomness
-
-    # a) Load randomness from memory
-    push.0.0.0.0
-    movup.8 mem_loadw
-    #=> [a1', a0', a1, a0, Δg1, Δg0, Δ1, Δ0, T0, T7, T6, T5, T4, T3, T2, T1, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
-
-    # b) Use b to choose between a and a'. Since b is inaccessible, we "hard-code" b by creating two versions of `random_combinate`.
-    movup.2 drop movup.2 drop
-
-    # c) Multiply (Δ0, Δ1)
-    dup.1 dup.1
-    movup.7 movup.7
-    #=> [Δ1, Δ0, a1, a0, a1, a0, Δg1, Δg0, T0, T7, T6, T5, T4, T3, T2, T1, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
-
-    ext2mul
-    #=> [prod1, prod0, a1, a0, Δg1, Δg0, T0, T7, T6, T5, T4, T3, T2, T1, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
-    #   where (prod0, prod1) := (Δ0, Δ1) * (a0, a1)
-
-    movdn.5 movdn.5
-    #=> [a1, a0, Δg1, Δg0, prod1, prod0, T0, T7, T6, T5, T4, T3, T2, T1, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
-
-    # d) Multiply (Δg0, Δg1)
-    ext2mul
-    #=> [prodg1, prodg0, prod1, prod0, T0, T7, T6, T5, T4, T3, T2, T1, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
-    #   where (prodg0, prodg1) := (Δg0, Δg1) * (a0, a1)
-
-    # 6) Accumulate into (p0, p1) and (r0, r1)
-    movupw.3
-
-    # a) Accumulate into (r0, r1)
-    movup.7 movup.7 
-    #=> [prod1, prod0, p1, p0, r1, r0, prodg1, prodg0, T0, T7, T6, T5, T4, T3, T2, T1, x_addr, z_addr', a_addr', b]
-    movup.5 movup.5 ext2add
-    #=> [r1', r0', p1, p0, prodg1, prodg0, T0, T7, T6, T5, T4, T3, T2, T1, x_addr, z_addr', a_addr', b]
-    
-    # b) Accumulate into (p0, p1)
-    movdn.5 movdn.5 ext2add    
-    #=> [p1', p0', r1', r0', T0, T7, T6, T5, T4, T3, T2, T1, x_addr, z_addr', a_addr', b]
-
-    # c) Prepare for next iteration. This includes updating b.
-    swapw.3
-    movup.3 not movdn.3
-    movdnw.3
-    #=> [T0, T7, T6, T5, T4, T3, T2, T1, p1', p0', r1', r0', x_addr, z_addr', a_addr', 1-b]
-    
+    # c) Prepare for next iteration.
+    movdnw.2
+    #=> [T0, T7, T6, T5, T4, T3, T2, T1, p1', p0', r1', r0', x_addr, z_addr', a_addr', 0]
 end
 
 #! Computes a single step of the random linear combination defining the DEEP composition polynomial
@@ -236,16 +133,16 @@ end
 #!
 #! The stack transition of the instruction can be visualized as follows:
 #!
-#! +-------+-------+-------+-------+-------+-------+-------+-------+------+------+------+------+------+------+------+------+
-#! |  T31  |  T30  |  T21  |  T20  |  T11  |  T10  |  T01  |  T00  |  p1  |  p0  |  r1  |  r0  |x_addr|z_addr|a_addr|  b   |
-#! +-------+-------+-------+-------+-------+-------+-------+-------+------+------+------+------+------+------+------+------+
+#! +-------+-------+-------+-------+-------+-------+-------+-------+------+------+------+------+------+------+------+---+
+#! |  T31  |  T30  |  T21  |  T20  |  T11  |  T10  |  T01  |  T00  |  p1  |  p0  |  r1  |  r0  |x_addr|z_addr|a_addr| - |
+#! +-------+-------+-------+-------+-------+-------+-------+-------+------+------+------+------+------+------+------+---+
 #! 
 #!                                                       ||
 #!                                                       \/
 #!                                                         
-#! +-------+-------+-------+-------+-------+-------+-------+-------+------+------+------+------+------+--------+--------+-------+
-#! |  T31  |  T30  |  T21  |  T20  |  T11  |  T10  |  T01  |  T00  |  p1' |  p0' |  r1' |  r0' |x_addr|z_addr+1|a_addr+b|  1-b  |
-#! +-------+-------+-------+-------+-------+-------+-------+-------+------+------+------+------+------+--------+--------+-------+
+#! +-------+-------+-------+-------+-------+-------+-------+-------+------+------+------+------+------+--------+--------+-----+
+#! |  T31  |  T30  |  T21  |  T20  |  T11  |  T10  |  T01  |  T00  |  p1' |  p0' |  r1' |  r0' |x_addr|z_addr+1|a_addr+b|  -  |
+#! +-------+-------+-------+-------+-------+-------+-------+-------+------+------+------+------+------+--------+--------------+
 #! 
 #! 
 #! Here:
@@ -256,82 +153,76 @@ end
 #! 4- x_addr is the memory address from which we are loading the Ti's using the MSTREAM instruction.
 #! 5- z_addr is the memory address to the i-th OOD evaluation frame at z and gz i.e. T_i(z):= (T_i(z)0, T_i(z)1) and T_i(gz):= (T_i(gz)0, T_i(gz)1)
 #! 6- a_addr is the memory address of the i-th random element used in batching the trace polynomial quotients.
-#! Since each memory address holds two random values and only one is used for the current step, we use a binary flag
-#! to decide on which of the two random elements to use in the current step.
-#! 7- b is a binary flag to select between a := (a0, a1) and  a' := (a0', a1') where [a0, a1, a0', a1'] is the word currently pointed to by a_addr.
+#! The random elements a := (a0, a1) are stored in memory as [0, 0, a0, a1].
 #!
-#! Input: [T31, T30, T21, T20, T11, T10, T01, T00, p1, p0, r1, r0, x_addr, z_addr, a_addr, b]
-#! Output: [T01, T00, T31, T30, T21, T20, T11, T10, p1', p0', r1', r0', x_addr, z_addr', a_addr', 1-b]
-export.aux_1
-    #=> [T31, T30, T21, T20, T11, T10, T01, T00, p1, p0, r1, r0, x_addr, z_addr, a_addr, b]
+#! Input: [T31, T30, T21, T20, T11, T10, T01, T00, p1, p0, r1, r0, x_addr, z_addr, a_addr, 0]
+#! Output: [T01, T00, T31, T30, T21, T20, T11, T10, p1', p0', r1', r0', x_addr, z_addr', a_addr', 0]
+export.aux
 
     # 1) Shift trace columns values (as quadratic extension field element) left
     movup.7 movup.7   
-    #=> [T01, T00, T31, T30, T21, T20, T11, T10, p1, p0, r1, r0, x_addr, z_addr, a_addr, b]
+    #=> [T01, T00, T31, T30, T21, T20, T11, T10, p1, p0, r1, r0, x_addr, z_addr, a_addr, 0]
 
-    # 2) Get a_addr and b and update a_addr. This is done here before these elements become inaccessible.
+    # 2) Get a_addr and update it. This is done here before it becomes inaccessible.
     
     # Update a_addr
-    dup.15 dup.15 add swap.15
-    #=> [a_addr, T01, T00, T31, T30, T21, T20, T11, T10, p1, p0, r1, r0, x_addr, z_addr, a_addr',b]
+    dup.14 add.1 swap.15
+    #=> [a_addr, T01, T00, T31, T30, T21, T20, T11, T10, p1, p0, r1, r0, x_addr, z_addr, a_addr', 0]
 
     # 3) Load i-th OOD frame portion. This assumes that the OOD frame has been serialized with `current` and `next` rows interleaved.
     # This also updates the z_addr pointer.
     dup.14 add.1 swap.15
     push.0.0.0.0 movup.4 mem_loadw
-    #=> [Tgz1, Tgz0, Tz1, Tz0, a_addr, T01, T00, T31, T30, T21, T20, T11, T10, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
+    #=> [Tgz1, Tgz0, Tz1, Tz0, a_addr, T01, T00, T31, T30, T21, T20, T11, T10, p1, p0, r1, r0, x_addr, z_addr', a_addr', 0]
 
     # 4) Compute the numerators
 
     # a) Compute T_i - T_i(z). This equals, in the case of T0, (T01 - Tz1, T00 - Tz0)
     dup.6 dup.6
     movup.5 movup.5
-    #=> [Tz1, Tz0, T01, T00, Tgz1, Tgz0, a_addr, T01, T00, T31, T30, T21, T20, T11, T10, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
+    #=> [Tz1, Tz0, T01, T00, Tgz1, Tgz0, a_addr, T01, T00, T31, T30, T21, T20, T11, T10, p1, p0, r1, r0, x_addr, z_addr', a_addr', 0]
 
     ext2sub
-    #=> [T01 - Tz1, T00 - Tz0, Tgz1, Tgz0, a_addr, T01, T00, T31, T30, T21, T20, T11, T10, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
+    #=> [T01 - Tz1, T00 - Tz0, Tgz1, Tgz0, a_addr, T01, T00, T31, T30, T21, T20, T11, T10, p1, p0, r1, r0, x_addr, z_addr', a_addr', 0]
 
     movdn.3 movdn.3
-    #=> [Tgz1, Tgz0, T01 - Tz1, T00 - Tz0, a_addr, T01, T00, T31, T30, T21, T20, T11, T10, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
+    #=> [Tgz1, Tgz0, T01 - Tz1, T00 - Tz0, a_addr, T01, T00, T31, T30, T21, T20, T11, T10, p1, p0, r1, r0, x_addr, z_addr', a_addr', 0]
     
     # b) Compute T_i - T_i(gz). This equals, in the case of T0, (T01 - Tgz1, T00 - Tgz0)
 
     # Compute first -(T_i - T_i(gz))
     dup.6 dup.6
     ext2sub
-    #=> [Tgz1 - T01, Tgz0 - T00, T01 - Tz1, T00 - Tz0, a_addr, T01, T00, T31, T30, T21, T20, T11, T10, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
+    #=> [Tgz1 - T01, Tgz0 - T00, T01 - Tz1, T00 - Tz0, a_addr, T01, T00, T31, T30, T21, T20, T11, T10, p1, p0, r1, r0, x_addr, z_addr', a_addr', 0]
     
     # Negate both coordinates
     neg swap neg swap
-    #=> [T01 - Tgz1, T00 - Tgz0, T01 - Tz1, T00 - Tz0, a_addr, T01, T00, T31, T30, T21, T20, T11, T10, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
-    #=> [Δg1, Δg0, Δ1, Δ0, a_addr, T01, T00, T31, T30, T21, T20, T11, T10, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
+    #=> [T01 - Tgz1, T00 - Tgz0, T01 - Tz1, T00 - Tz0, a_addr, T01, T00, T31, T30, T21, T20, T11, T10, p1, p0, r1, r0, x_addr, z_addr', a_addr', 0]
+    #=> [Δg1, Δg0, Δ1, Δ0, a_addr, T01, T00, T31, T30, T21, T20, T11, T10, p1, p0, r1, r0, x_addr, z_addr', a_addr', 0]
     # where Δg1 := T01 - Tgz1, Δg0 := T00 - Tgz0, Δ1 := T01 - Tz1 and Δ0 := T00 - Tz0
 
     # 5) Multiply by randomness
 
     # a) Load randomness from memory
     push.0.0.0.0
-    movup.8 mem_loadw
-    #=> [a1', a0', a1, a0, Δg1, Δg0, Δ1, Δ0, T01, T00, T31, T30, T21, T20, T11, T10, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
+    movup.8 mem_loadw drop drop
+    #=> [a1', a0', a1, a0, Δg1, Δg0, Δ1, Δ0, T01, T00, T31, T30, T21, T20, T11, T10, p1, p0, r1, r0, x_addr, z_addr', a_addr', 0]
 
-    # b) Use b to choose between a and a'. Since b is inaccessible, we "hard-code" b by creating two versions of `random_combinate_aux`.
-    drop drop
-
-    # c) Multiply (Δ0, Δ1)
+    # b) Multiply (Δ0, Δ1)
     dup.1 dup.1
     movup.7 movup.7
-    #=> [Δ1, Δ0, a1, a0, a1, a0, Δg1, Δg0, T01, T00, T31, T30, T21, T20, T11, T10, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
+    #=> [Δ1, Δ0, a1, a0, a1, a0, Δg1, Δg0, T01, T00, T31, T30, T21, T20, T11, T10, p1, p0, r1, r0, x_addr, z_addr', a_addr', 0]
 
     ext2mul
-    #=> [prod1, prod0, a1, a0, Δg1, Δg0, T01, T00, T31, T30, T21, T20, T11, T10, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
+    #=> [prod1, prod0, a1, a0, Δg1, Δg0, T01, T00, T31, T30, T21, T20, T11, T10, p1, p0, r1, r0, x_addr, z_addr', a_addr', 0]
     #   where (prod0, prod1) := (Δ0, Δ1) * (a0, a1)
 
     movdn.5 movdn.5
-    #=> [a1, a0, Δg1, Δg0, prod1, prod0, T01, T00, T31, T30, T21, T20, T11, T10, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
+    #=> [a1, a0, Δg1, Δg0, prod1, prod0, T01, T00, T31, T30, T21, T20, T11, T10, p1, p0, r1, r0, x_addr, z_addr', a_addr', 0]
 
-    # d) Multiply (Δg0, Δg1)
+    # c) Multiply (Δg0, Δg1)
     ext2mul
-    #=> [prodg1, prodg0, prod1, prod0, T01, T00, T31, T30, T21, T20, T11, T10, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
+    #=> [prodg1, prodg0, prod1, prod0, T01, T00, T31, T30, T21, T20, T11, T10, p1, p0, r1, r0, x_addr, z_addr', a_addr', 0]
     #   where (prodg0, prodg1) := (Δg0, Δg1) * (a0, a1)
 
     # 6) Accumulate into (p0, p1) and (r0, r1)
@@ -339,114 +230,15 @@ export.aux_1
 
     # a) Accumulate into (r0, r1)
     movup.7 movup.7 
-    #=> [prod1, prod0, p1, p0, r1, r0, prodg1, prodg0, T01, T00, T31, T30, T21, T20, T11, T10, x_addr, z_addr', a_addr', b]
+    #=> [prod1, prod0, p1, p0, r1, r0, prodg1, prodg0, T01, T00, T31, T30, T21, T20, T11, T10, x_addr, z_addr', a_addr', 0]
     movup.5 movup.5 ext2add
-    #=> [r1', r0', p1, p0, prodg1, prodg0, T01, T00, T31, T30, T21, T20, T11, T10, x_addr, z_addr', a_addr', b]
+    #=> [r1', r0', p1, p0, prodg1, prodg0, T01, T00, T31, T30, T21, T20, T11, T10, x_addr, z_addr', a_addr', 0]
     
     # b) Accumulate into (p0, p1)
     movdn.5 movdn.5 ext2add    
-    #=> [p1', p0', r1', r0', T01, T00, T31, T30, T21, T20, T11, T10, x_addr, z_addr', a_addr', b]
+    #=> [p1', p0', r1', r0', T01, T00, T31, T30, T21, T20, T11, T10, x_addr, z_addr', a_addr', 0]
 
     # c) Prepare for next iteration
-    swapw.3
-    movup.3 not movdn.3
-    movdnw.3
-    #=> [T01, T00, T31, T30, T21, T20, T11, T10, p1', p0', r1', r0', x_addr, z_addr', a_addr', 1-b]
-end
-
-#! Similar to `random_combine::aux_1` but chooses the second random element at address `a_addr`.
-#! This mimics the function of `b` because `b` is unreachable when needed on the stack.
-#!
-#! Input: [T31, T30, T21, T20, T11, T10, T01, T00, p1, p0, r1, r0, x_addr, z_addr, a_addr, b]
-#! Output: [T01, T00, T31, T30, T21, T20, T11, T10, p1', p0', r1', r0', x_addr, z_addr', a_addr', 1-b]
-export.aux_2
-    #=> [T31, T30, T21, T20, T11, T10, T01, T00, p1, p0, r1, r0, x_addr, z_addr, a_addr, b]
-
-    # 1) Shift trace columns values (as quadratic extension field element) left
-    movup.7 movup.7   
-    #=> [T01, T00, T31, T30, T21, T20, T11, T10, p1, p0, r1, r0, x_addr, z_addr, a_addr, b]
-
-    # 2) Get a_addr and b and update a_addr. This is done here before these elements become inaccessible.
-    
-    # Update a_addr
-    dup.15 dup.15 add swap.15
-    #=> [a_addr, T01, T00, T31, T30, T21, T20, T11, T10, p1, p0, r1, r0, x_addr, z_addr, a_addr', b]
-
-    # 3) Load i-th OOD frame portion. This assumes that the OOD frame has been serialized with `current` and `next` rows interleaved.
-    # This also updates the z_addr pointer.
-    dup.14 add.1 swap.15
-    push.0.0.0.0 movup.4 mem_loadw
-    #=> [Tgz1, Tgz0, Tz1, Tz0, a_addr, T01, T00, T31, T30, T21, T20, T11, T10, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
-
-    # 4) Compute the numerators
-
-    # a) Compute T_i - T_i(z). This equals, in the case of T0, (T01 - Tz1, T00 - Tz0)
-    dup.6 dup.6
-    movup.5 movup.5
-    #=> [Tz1, Tz0, T01, T00, Tgz1, Tgz0, a_addr, T01, T00, T31, T30, T21, T20, T11, T10, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
-
-    ext2sub
-    #=> [T01 - Tz1, T00 - Tz0, Tgz1, Tgz0, a_addr, T01, T00, T31, T30, T21, T20, T11, T10, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
-
-    movdn.3 movdn.3
-    #=> [Tgz1, Tgz0, T01 - Tz1, T00 - Tz0, a_addr, T01, T00, T31, T30, T21, T20, T11, T10, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
-    
-    # b) Compute T_i - T_i(gz). This equals, in the case of T0, (T01 - Tgz1, T00 - Tgz0)
-
-    # Compute first -(T_i - T_i(gz))
-    dup.6 dup.6
-    ext2sub
-    #=> [Tgz1 - T01, Tgz0 - T00, T01 - Tz1, T00 - Tz0, a_addr, T01, T00, T31, T30, T21, T20, T11, T10, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
-    
-    # Negate both coordinates
-    neg swap neg swap
-    #=> [T01 - Tgz1, T00 - Tgz0, T01 - Tz1, T00 - Tz0, a_addr, T01, T00, T31, T30, T21, T20, T11, T10, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
-    #=> [Δg1, Δg0, Δ1, Δ0, a_addr, T01, T00, T31, T30, T21, T20, T11, T10, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
-    # where Δg1 := T01 - Tgz1, Δg0 := T00 - Tgz0, Δ1 := T01 - Tz1 and Δ0 := T00 - Tz0
-
-    # 5) Multiply by randomness
-
-    # a) Load randomness from memory
-    push.0.0.0.0
-    movup.8 mem_loadw
-    #=> [a1', a0', a1, a0, Δg1, Δg0, Δ1, Δ0, T01, T00, T31, T30, T21, T20, T11, T10, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
-
-    # b) Use b to choose between a and a'. Since b is inaccessible, we "hard-code" b by creating two versions of `random_combinate_aux`.
-    movup.2 drop movup.2 drop
-
-    # c) Multiply (Δ0, Δ1)
-    dup.1 dup.1
-    movup.7 movup.7
-    #=> [Δ1, Δ0, a1, a0, a1, a0, Δg1, Δg0, T01, T00, T31, T30, T21, T20, T11, T10, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
-
-    ext2mul
-    #=> [prod1, prod0, a1, a0, Δg1, Δg0, T01, T00, T31, T30, T21, T20, T11, T10, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
-    #   where (prod0, prod1) := (Δ0, Δ1) * (a0, a1)
-
-    movdn.5 movdn.5
-    #=> [a1, a0, Δg1, Δg0, prod1, prod0, T01, T00, T31, T30, T21, T20, T11, T10, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
-
-    # d) Multiply (Δg0, Δg1)
-    ext2mul
-    #=> [prodg1, prodg0, prod1, prod0, T01, T00, T31, T30, T21, T20, T11, T10, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
-    #   where (prodg0, prodg1) := (Δg0, Δg1) * (a0, a1)
-
-    # 6) Accumulate into (p0, p1) and (r0, r1)
-    movupw.3
-
-    # a) Accumulate into (r0, r1)
-    movup.7 movup.7 
-    #=> [prod1, prod0, p1, p0, r1, r0, prodg1, prodg0, T01, T00, T31, T30, T21, T20, T11, T10, x_addr, z_addr', a_addr', b]
-    movup.5 movup.5 ext2add
-    #=> [r1', r0', p1, p0, prodg1, prodg0, T01, T00, T31, T30, T21, T20, T11, T10, x_addr, z_addr', a_addr', b]
-    
-    # b) Accumulate into (p0, p1)
-    movdn.5 movdn.5 ext2add    
-    #=> [p1', p0', r1', r0', T01, T00, T31, T30, T21, T20, T11, T10, x_addr, z_addr', a_addr', b]
-
-    # c) Prepare for next iteration
-    swapw.3
-    movup.3 not movdn.3
-    movdnw.3
-    #=> [T01, T00, T31, T30, T21, T20, T11, T10, p1', p0', r1', r0', x_addr, z_addr', a_addr', 1-b]
+    movdnw.2
+    #=> [T01, T00, T31, T30, T21, T20, T11, T10, p1', p0', r1', r0', x_addr, z_addr', a_addr', 0]
 end

--- a/stdlib/asm/crypto/stark/random_combine.masm
+++ b/stdlib/asm/crypto/stark/random_combine.masm
@@ -1,0 +1,452 @@
+#! Computes a single step of the random linear combination defining the DEEP composition polynomial
+#! that is the input to the FRI protocol. More precisely, the sum in question is:
+#! $$
+#! \sum_{i=0}^k{\alpha_i \cdot \left(\frac{T_i(x) - T_i(z)}{x - z} + 
+#!            \frac{T_i(x) - T_i(z \cdot g)}{x - z \cdot g} \right)}
+#! $$
+#!
+#! and the following instruction computes the denominators $\alpha_i \cdot (T_i(x) - T_i(z))$ and
+#! $\alpha_i \cdot (T_i(x) - T_i(z \cdot g))$ and stores the values in two accumulators $r$ and $p$,
+#! respectively. This instruction is specialized to main trace columns i.e. the values $T_i(x)$ are
+#! base field elements.
+#!
+#! The stack transition of the instruction can be visualized as follows:
+#!
+#! +------+------+------+------+------+------+------+------+------+------+------+------+------+------+------+------+
+#! |  T7  |  T6  |  T5  |  T4  |  T3  |  T2  |  T1  |  T0  |  p1  |  p0  |  r1  |  r0  |x_addr|z_addr|a_addr|  b   |
+#! +------+------+------+------+------+------+------+------+------+------+------+------+------+------+------+------+
+#! 
+#!                                                       ||
+#!                                                       \/
+#!                                                    
+#! +------+------+------+------+------+------+------+------+------+------+------+------+------+--------+--------+-------+
+#! |  T0  |  T7  |  T6  |  T5  |  T4  |  T3  |  T2  |  T1  |  p1' |  p0' |  r1' |  r0' |x_addr|z_addr+1|a_addr+b|  1-b  |
+#! +------+------+------+------+------+------+------+------+------+------+------+------+------+--------+--------+-------+
+#! 
+#! 
+#! Here:
+#! 1- Ti for i in 0..=7 stands for the the value of the i-th trace polynomial for the current query i.e. T_i(x).
+#! 2- (p0, p1) stands for an extension field element accumulating the values for the quotients with common denominator (x - gz).
+#! 3- (r0, r1) stands for an extension field element accumulating the values for the quotients with common denominator (x - z).
+#! 4- x_addr is the memory address from which we are loading the Ti's using the MSTREAM instruction.
+#! 5- z_addr is the memory address to the i-th OOD evaluation frame at z and gz i.e. T_i(z):= (T_i(z)0, T_i(z)1) and T_i(gz):= (T_i(gz)0, T_i(gz)1)
+#! 6- a_addr is the memory address of the i-th random element used in batching the trace polynomial quotients. 
+#! Since each memory address holds two random values and only one is used for the current step, we use a binary flag to decide
+#! on which of the two random elements to use in the current step.
+#! 7- b is a binary flag to select between a := (a0, a1) and  a' := (a0', a1') where [a0, a1, a0', a1']
+#! is the word currently pointed to by a_addr.
+#! 
+#! Input: [T7, T6, T5, T4, T3, T2, T1, T0, p1, p0, r1, r0, x_addr, z_addr, a_addr, b]
+#! Output: [T0, T7, T6, T5, T4, T3, T2, T1, p1', p0', r1', r0', x_addr, z_addr', a_addr', 1-b]
+export.main_1
+    #=> [T7, T6, T5, T4, T3, T2, T1, T0, p1, p0, r1, r0, x_addr, z_addr, a_addr, b]
+
+    # 1) Shift trace columns values left
+    movup.7   
+    #=> [T0, T7, T6, T5, T4, T3, T2, T1, p1, p0, r1, r0, x_addr, z_addr, a_addr, b]
+
+    # 2) Get a_addr and b and update a_addr. This is done here before these elements become inaccessible.
+    
+    # Update a_addr
+    dup.15 dup.15 add swap.15
+    #=> [a_addr, T0, T7, T6, T5, T4, T3, T2, T1, p1, p0, r1, r0, x_addr, z_addr, a_addr', b]
+
+    # 3) Load i-th OOD frame portion. This assumes that the OOD frame has been serialized with `current` and `next` rows interleaved.
+    # This also updates the z_addr pointer.
+    dup.14 add.1 swap.15
+    push.0.0.0.0 movup.4 mem_loadw
+    #=> [Tgz1, Tgz0, Tz1, Tz0, a_addr, T0, T7, T6, T5, T4, T3, T2, T1, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
+
+    # 4) Compute the numerators
+
+    # a) Compute T_i - T_i(z). This equals, in the case of T0, (-Tz1, T0 - Tz0)
+    dup.5
+    movup.4
+    #=> [Tz0, T0, Tgz1, Tgz0, Tz1, a_addr, T0, T7, T6, T5, T4, T3, T2, T1, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
+
+    sub
+    #=> [T0 - Tz0, Tgz1, Tgz0, Tz1, a_addr, T0, T7, T6, T5, T4, T3, T2, T1, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
+    
+    swap.3 neg swap.2
+    #=> [Tgz0, Tgz1, -Tz1, T0 - Tz0, a_addr, T0, T7, T6, T5, T4, T3, T2, T1, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
+    
+    # b) Compute T_i - T_i(gz). This equals, in the case of T0, (-Tgz1, T0 - Tgz0)
+    dup.5 swap sub
+    #=> [T0 - Tgz0, Tgz1, -Tz1, T0 - Tz0, a_addr, T0, T7, T6, T5, T4, T3, T2, T1, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
+    
+    swap
+    neg
+    #=> [-Tgz1, T0 - Tgz0, -Tz1, T0 - Tz0, a_addr, T0, T7, T6, T5, T4, T3, T2, T1, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
+    #=> [Δg1, Δg0, Δ1, Δ0, a_addr, T0, T7, T6, T5, T4, T3, T2, T1, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
+    # where Δg1 := -Tgz1, Δg0 := T0 - Tgz0, Δ1 := -Tz1 and Δ0 := T0 - Tz0
+
+    # 5) Multiply by randomness
+
+    # a) Load randomness from memory
+    push.0.0.0.0
+    movup.8 mem_loadw
+    #=> [a1', a0', a1, a0, Δg1, Δg0, Δ1, Δ0, T0, T7, T6, T5, T4, T3, T2, T1, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
+
+    # b) Use b to choose between a and a'. Since b is inaccessible, we "hard-code" b by creating two versions of `random_combinate`.
+    drop drop
+
+    # c) Multiply (Δ0, Δ1)
+    dup.1 dup.1
+    movup.7 movup.7
+    #=> [Δ1, Δ0, a1, a0, a1, a0, Δg1, Δg0, T0, T7, T6, T5, T4, T3, T2, T1, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
+
+    ext2mul
+    #=> [prod1, prod0, a1, a0, Δg1, Δg0, T0, T7, T6, T5, T4, T3, T2, T1, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
+    #   where (prod0, prod1) := (Δ0, Δ1) * (a0, a1)
+
+    movdn.5 movdn.5
+    #=> [a1, a0, Δg1, Δg0, prod1, prod0, T0, T7, T6, T5, T4, T3, T2, T1, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
+
+    # d) Multiply (Δg0, Δg1)
+    ext2mul
+    #=> [prodg1, prodg0, prod1, prod0, T0, T7, T6, T5, T4, T3, T2, T1, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
+    #   where (prodg0, prodg1) := (Δg0, Δg1) * (a0, a1)
+
+    # 6) Accumulate into (p0, p1) and (r0, r1)
+    movupw.3
+
+    # a) Accumulate into (r0, r1)
+    movup.7 movup.7 
+    #=> [prod1, prod0, p1, p0, r1, r0, prodg1, prodg0, T0, T7, T6, T5, T4, T3, T2, T1, x_addr, z_addr', a_addr', b]
+    movup.5 movup.5 ext2add
+    #=> [r1', r0', p1, p0, prodg1, prodg0, T0, T7, T6, T5, T4, T3, T2, T1, x_addr, z_addr', a_addr', b]
+    
+    # b) Accumulate into (p0, p1)
+    movdn.5 movdn.5 ext2add    
+    #=> [p1', p0', r1', r0', T0, T7, T6, T5, T4, T3, T2, T1, x_addr, z_addr', a_addr', b]
+
+    # c) Prepare for next iteration. This includes updating b.
+    swapw.3
+    movup.3 not movdn.3
+    movdnw.3
+    #=> [T0, T7, T6, T5, T4, T3, T2, T1, p1', p0', r1', r0', x_addr, z_addr', a_addr', 1-b]
+end
+
+#! Similar to `random_combine::main_1` but chooses the second random element at address `a_addr`.
+#! This mimics the function of `b` because `b` is unreachable when needed on the stack.
+#! 
+#! Input: [T7, T6, T5, T4, T3, T2, T1, T0, p1, p0, r1, r0, x_addr, z_addr, a_addr, b]
+#! Output: [T0, T7, T6, T5, T4, T3, T2, T1, p1', p0', r1', r0', x_addr, z_addr', a_addr', 1-b]
+export.main_2
+    #=> [T7, T6, T5, T4, T3, T2, T1, T0, p1, p0, r1, r0, x_addr, z_addr, a_addr, b]
+
+    # 1) Shift trace columns values left
+    movup.7   
+    #=> [T0, T7, T6, T5, T4, T3, T2, T1, p1, p0, r1, r0, x_addr, z_addr, a_addr, b]
+
+    # 2) Get a_addr and b and update a_addr. This is done here before these elements become inaccessible.
+    
+    # Update a_addr
+    dup.15 dup.15 add swap.15
+    #=> [a_addr, T0, T7, T6, T5, T4, T3, T2, T1, p1, p0, r1, r0, x_addr, z_addr, a_addr', b]
+
+    # 3) Load i-th OOD frame portion. This assumes that the OOD frame has been serialized with `current` and `next` rows interleaved.
+    # This also updates the z_addr pointer.
+    dup.14 add.1 swap.15
+    push.0.0.0.0 movup.4 mem_loadw
+    #=> [Tgz1, Tgz0, Tz1, Tz0, a_addr, T0, T7, T6, T5, T4, T3, T2, T1, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
+
+    # 4) Compute the numerators
+
+    # a) Compute T_i - T_i(z). This equals, in the case of T0, (-Tz1, T0 - Tz0)
+    dup.5
+    movup.4
+    #=> [Tz0, T0, Tgz1, Tgz0, Tz1, a_addr, T0, T7, T6, T5, T4, T3, T2, T1, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
+
+    sub
+    #=> [T0 - Tz0, Tgz1, Tgz0, Tz1, a_addr, T0, T7, T6, T5, T4, T3, T2, T1, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
+    
+    swap.3 neg swap.2
+    #=> [Tgz0, Tgz1, -Tz1, T0 - Tz0, a_addr, T0, T7, T6, T5, T4, T3, T2, T1, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
+    
+    # b) Compute T_i - T_i(gz). This equals, in the case of T0, (-Tgz1, T0 - Tgz0)
+    dup.5 swap sub
+    #=> [T0 - Tgz0, Tgz1, -Tz1, T0 - Tz0, a_addr, T0, T7, T6, T5, T4, T3, T2, T1, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
+    
+    swap
+    neg
+    #=> [-Tgz1, T0 - Tgz0, -Tz1, T0 - Tz0, a_addr, T0, T7, T6, T5, T4, T3, T2, T1, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
+    #=> [Δg1, Δg0, Δ1, Δ0, a_addr, T0, T7, T6, T5, T4, T3, T2, T1, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
+    # where Δg1 := -Tgz1, Δg0 := T0 - Tgz0, Δ1 := -Tz1 and Δ0 := T0 - Tz0
+
+    # 5) Multiply by randomness
+
+    # a) Load randomness from memory
+    push.0.0.0.0
+    movup.8 mem_loadw
+    #=> [a1', a0', a1, a0, Δg1, Δg0, Δ1, Δ0, T0, T7, T6, T5, T4, T3, T2, T1, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
+
+    # b) Use b to choose between a and a'. Since b is inaccessible, we "hard-code" b by creating two versions of `random_combinate`.
+    movup.2 drop movup.2 drop
+
+    # c) Multiply (Δ0, Δ1)
+    dup.1 dup.1
+    movup.7 movup.7
+    #=> [Δ1, Δ0, a1, a0, a1, a0, Δg1, Δg0, T0, T7, T6, T5, T4, T3, T2, T1, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
+
+    ext2mul
+    #=> [prod1, prod0, a1, a0, Δg1, Δg0, T0, T7, T6, T5, T4, T3, T2, T1, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
+    #   where (prod0, prod1) := (Δ0, Δ1) * (a0, a1)
+
+    movdn.5 movdn.5
+    #=> [a1, a0, Δg1, Δg0, prod1, prod0, T0, T7, T6, T5, T4, T3, T2, T1, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
+
+    # d) Multiply (Δg0, Δg1)
+    ext2mul
+    #=> [prodg1, prodg0, prod1, prod0, T0, T7, T6, T5, T4, T3, T2, T1, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
+    #   where (prodg0, prodg1) := (Δg0, Δg1) * (a0, a1)
+
+    # 6) Accumulate into (p0, p1) and (r0, r1)
+    movupw.3
+
+    # a) Accumulate into (r0, r1)
+    movup.7 movup.7 
+    #=> [prod1, prod0, p1, p0, r1, r0, prodg1, prodg0, T0, T7, T6, T5, T4, T3, T2, T1, x_addr, z_addr', a_addr', b]
+    movup.5 movup.5 ext2add
+    #=> [r1', r0', p1, p0, prodg1, prodg0, T0, T7, T6, T5, T4, T3, T2, T1, x_addr, z_addr', a_addr', b]
+    
+    # b) Accumulate into (p0, p1)
+    movdn.5 movdn.5 ext2add    
+    #=> [p1', p0', r1', r0', T0, T7, T6, T5, T4, T3, T2, T1, x_addr, z_addr', a_addr', b]
+
+    # c) Prepare for next iteration. This includes updating b.
+    swapw.3
+    movup.3 not movdn.3
+    movdnw.3
+    #=> [T0, T7, T6, T5, T4, T3, T2, T1, p1', p0', r1', r0', x_addr, z_addr', a_addr', 1-b]
+    
+end
+
+#! Computes a single step of the random linear combination defining the DEEP composition polynomial
+#! that is the input to the FRI protocol. More precisely, the sum in question is:
+#! $$
+#! \sum_{i=0}^k{\alpha_i \cdot \left(\frac{T_i(x) - T_i(z)}{x - z} + 
+#!            \frac{T_i(x) - T_i(z \cdot g)}{x - z \cdot g} \right)}
+#! $$
+#!
+#! and the following instruction computes the denominators $\alpha_i \cdot (T_i(x) - T_i(z))$ and
+#! $\alpha_i \cdot (T_i(x) - T_i(z \cdot g))$ and stores the values in two accumulators $r$ and $p$,
+#! respectively. This instruction is specialized to auxiliary trace columns i.e. the values $T_i(x)$
+#! are field elements in a quadratic extension field.
+#!
+#! The stack transition of the instruction can be visualized as follows:
+#!
+#! +-------+-------+-------+-------+-------+-------+-------+-------+------+------+------+------+------+------+------+------+
+#! |  T31  |  T30  |  T21  |  T20  |  T11  |  T10  |  T01  |  T00  |  p1  |  p0  |  r1  |  r0  |x_addr|z_addr|a_addr|  b   |
+#! +-------+-------+-------+-------+-------+-------+-------+-------+------+------+------+------+------+------+------+------+
+#! 
+#!                                                       ||
+#!                                                       \/
+#!                                                         
+#! +-------+-------+-------+-------+-------+-------+-------+-------+------+------+------+------+------+--------+--------+-------+
+#! |  T31  |  T30  |  T21  |  T20  |  T11  |  T10  |  T01  |  T00  |  p1' |  p0' |  r1' |  r0' |x_addr|z_addr+1|a_addr+b|  1-b  |
+#! +-------+-------+-------+-------+-------+-------+-------+-------+------+------+------+------+------+--------+--------+-------+
+#! 
+#! 
+#! Here:
+#! 1- Tij for i in 0..=3 and j=0,1 stands for the the value of the j-th coordinate in the quadratic extension field
+#! of the i-th auxiliary trace polynomial for the current query i.e. $T_i(x)$.
+#! 2- (p0, p1) stands for an extension field element accumulating the values for the quotients with common denominator (x - gz).
+#! 3- (r0, r1) stands for an extension field element accumulating the values for the quotients with common denominator (x - z).
+#! 4- x_addr is the memory address from which we are loading the Ti's using the MSTREAM instruction.
+#! 5- z_addr is the memory address to the i-th OOD evaluation frame at z and gz i.e. T_i(z):= (T_i(z)0, T_i(z)1) and T_i(gz):= (T_i(gz)0, T_i(gz)1)
+#! 6- a_addr is the memory address of the i-th random element used in batching the trace polynomial quotients.
+#! Since each memory address holds two random values and only one is used for the current step, we use a binary flag
+#! to decide on which of the two random elements to use in the current step.
+#! 7- b is a binary flag to select between a := (a0, a1) and  a' := (a0', a1') where [a0, a1, a0', a1'] is the word currently pointed to by a_addr.
+#!
+#! Input: [T31, T30, T21, T20, T11, T10, T01, T00, p1, p0, r1, r0, x_addr, z_addr, a_addr, b]
+#! Output: [T01, T00, T31, T30, T21, T20, T11, T10, p1', p0', r1', r0', x_addr, z_addr', a_addr', 1-b]
+export.aux_1
+    #=> [T31, T30, T21, T20, T11, T10, T01, T00, p1, p0, r1, r0, x_addr, z_addr, a_addr, b]
+
+    # 1) Shift trace columns values (as quadratic extension field element) left
+    movup.7 movup.7   
+    #=> [T01, T00, T31, T30, T21, T20, T11, T10, p1, p0, r1, r0, x_addr, z_addr, a_addr, b]
+
+    # 2) Get a_addr and b and update a_addr. This is done here before these elements become inaccessible.
+    
+    # Update a_addr
+    dup.15 dup.15 add swap.15
+    #=> [a_addr, T01, T00, T31, T30, T21, T20, T11, T10, p1, p0, r1, r0, x_addr, z_addr, a_addr',b]
+
+    # 3) Load i-th OOD frame portion. This assumes that the OOD frame has been serialized with `current` and `next` rows interleaved.
+    # This also updates the z_addr pointer.
+    dup.14 add.1 swap.15
+    push.0.0.0.0 movup.4 mem_loadw
+    #=> [Tgz1, Tgz0, Tz1, Tz0, a_addr, T01, T00, T31, T30, T21, T20, T11, T10, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
+
+    # 4) Compute the numerators
+
+    # a) Compute T_i - T_i(z). This equals, in the case of T0, (T01 - Tz1, T00 - Tz0)
+    dup.6 dup.6
+    movup.5 movup.5
+    #=> [Tz1, Tz0, T01, T00, Tgz1, Tgz0, a_addr, T01, T00, T31, T30, T21, T20, T11, T10, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
+
+    ext2sub
+    #=> [T01 - Tz1, T00 - Tz0, Tgz1, Tgz0, a_addr, T01, T00, T31, T30, T21, T20, T11, T10, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
+
+    movdn.3 movdn.3
+    #=> [Tgz1, Tgz0, T01 - Tz1, T00 - Tz0, a_addr, T01, T00, T31, T30, T21, T20, T11, T10, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
+    
+    # b) Compute T_i - T_i(gz). This equals, in the case of T0, (T01 - Tgz1, T00 - Tgz0)
+
+    # Compute first -(T_i - T_i(gz))
+    dup.6 dup.6
+    ext2sub
+    #=> [Tgz1 - T01, Tgz0 - T00, T01 - Tz1, T00 - Tz0, a_addr, T01, T00, T31, T30, T21, T20, T11, T10, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
+    
+    # Negate both coordinates
+    neg swap neg swap
+    #=> [T01 - Tgz1, T00 - Tgz0, T01 - Tz1, T00 - Tz0, a_addr, T01, T00, T31, T30, T21, T20, T11, T10, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
+    #=> [Δg1, Δg0, Δ1, Δ0, a_addr, T01, T00, T31, T30, T21, T20, T11, T10, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
+    # where Δg1 := T01 - Tgz1, Δg0 := T00 - Tgz0, Δ1 := T01 - Tz1 and Δ0 := T00 - Tz0
+
+    # 5) Multiply by randomness
+
+    # a) Load randomness from memory
+    push.0.0.0.0
+    movup.8 mem_loadw
+    #=> [a1', a0', a1, a0, Δg1, Δg0, Δ1, Δ0, T01, T00, T31, T30, T21, T20, T11, T10, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
+
+    # b) Use b to choose between a and a'. Since b is inaccessible, we "hard-code" b by creating two versions of `random_combinate_aux`.
+    drop drop
+
+    # c) Multiply (Δ0, Δ1)
+    dup.1 dup.1
+    movup.7 movup.7
+    #=> [Δ1, Δ0, a1, a0, a1, a0, Δg1, Δg0, T01, T00, T31, T30, T21, T20, T11, T10, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
+
+    ext2mul
+    #=> [prod1, prod0, a1, a0, Δg1, Δg0, T01, T00, T31, T30, T21, T20, T11, T10, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
+    #   where (prod0, prod1) := (Δ0, Δ1) * (a0, a1)
+
+    movdn.5 movdn.5
+    #=> [a1, a0, Δg1, Δg0, prod1, prod0, T01, T00, T31, T30, T21, T20, T11, T10, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
+
+    # d) Multiply (Δg0, Δg1)
+    ext2mul
+    #=> [prodg1, prodg0, prod1, prod0, T01, T00, T31, T30, T21, T20, T11, T10, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
+    #   where (prodg0, prodg1) := (Δg0, Δg1) * (a0, a1)
+
+    # 6) Accumulate into (p0, p1) and (r0, r1)
+    movupw.3
+
+    # a) Accumulate into (r0, r1)
+    movup.7 movup.7 
+    #=> [prod1, prod0, p1, p0, r1, r0, prodg1, prodg0, T01, T00, T31, T30, T21, T20, T11, T10, x_addr, z_addr', a_addr', b]
+    movup.5 movup.5 ext2add
+    #=> [r1', r0', p1, p0, prodg1, prodg0, T01, T00, T31, T30, T21, T20, T11, T10, x_addr, z_addr', a_addr', b]
+    
+    # b) Accumulate into (p0, p1)
+    movdn.5 movdn.5 ext2add    
+    #=> [p1', p0', r1', r0', T01, T00, T31, T30, T21, T20, T11, T10, x_addr, z_addr', a_addr', b]
+
+    # c) Prepare for next iteration
+    swapw.3
+    movup.3 not movdn.3
+    movdnw.3
+    #=> [T01, T00, T31, T30, T21, T20, T11, T10, p1', p0', r1', r0', x_addr, z_addr', a_addr', 1-b]
+end
+
+#! Similar to `random_combine::aux_1` but chooses the second random element at address `a_addr`.
+#! This mimics the function of `b` because `b` is unreachable when needed on the stack.
+#!
+#! Input: [T31, T30, T21, T20, T11, T10, T01, T00, p1, p0, r1, r0, x_addr, z_addr, a_addr, b]
+#! Output: [T01, T00, T31, T30, T21, T20, T11, T10, p1', p0', r1', r0', x_addr, z_addr', a_addr', 1-b]
+export.aux_2
+    #=> [T31, T30, T21, T20, T11, T10, T01, T00, p1, p0, r1, r0, x_addr, z_addr, a_addr, b]
+
+    # 1) Shift trace columns values (as quadratic extension field element) left
+    movup.7 movup.7   
+    #=> [T01, T00, T31, T30, T21, T20, T11, T10, p1, p0, r1, r0, x_addr, z_addr, a_addr, b]
+
+    # 2) Get a_addr and b and update a_addr. This is done here before these elements become inaccessible.
+    
+    # Update a_addr
+    dup.15 dup.15 add swap.15
+    #=> [a_addr, T01, T00, T31, T30, T21, T20, T11, T10, p1, p0, r1, r0, x_addr, z_addr, a_addr', b]
+
+    # 3) Load i-th OOD frame portion. This assumes that the OOD frame has been serialized with `current` and `next` rows interleaved.
+    # This also updates the z_addr pointer.
+    dup.14 add.1 swap.15
+    push.0.0.0.0 movup.4 mem_loadw
+    #=> [Tgz1, Tgz0, Tz1, Tz0, a_addr, T01, T00, T31, T30, T21, T20, T11, T10, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
+
+    # 4) Compute the numerators
+
+    # a) Compute T_i - T_i(z). This equals, in the case of T0, (T01 - Tz1, T00 - Tz0)
+    dup.6 dup.6
+    movup.5 movup.5
+    #=> [Tz1, Tz0, T01, T00, Tgz1, Tgz0, a_addr, T01, T00, T31, T30, T21, T20, T11, T10, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
+
+    ext2sub
+    #=> [T01 - Tz1, T00 - Tz0, Tgz1, Tgz0, a_addr, T01, T00, T31, T30, T21, T20, T11, T10, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
+
+    movdn.3 movdn.3
+    #=> [Tgz1, Tgz0, T01 - Tz1, T00 - Tz0, a_addr, T01, T00, T31, T30, T21, T20, T11, T10, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
+    
+    # b) Compute T_i - T_i(gz). This equals, in the case of T0, (T01 - Tgz1, T00 - Tgz0)
+
+    # Compute first -(T_i - T_i(gz))
+    dup.6 dup.6
+    ext2sub
+    #=> [Tgz1 - T01, Tgz0 - T00, T01 - Tz1, T00 - Tz0, a_addr, T01, T00, T31, T30, T21, T20, T11, T10, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
+    
+    # Negate both coordinates
+    neg swap neg swap
+    #=> [T01 - Tgz1, T00 - Tgz0, T01 - Tz1, T00 - Tz0, a_addr, T01, T00, T31, T30, T21, T20, T11, T10, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
+    #=> [Δg1, Δg0, Δ1, Δ0, a_addr, T01, T00, T31, T30, T21, T20, T11, T10, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
+    # where Δg1 := T01 - Tgz1, Δg0 := T00 - Tgz0, Δ1 := T01 - Tz1 and Δ0 := T00 - Tz0
+
+    # 5) Multiply by randomness
+
+    # a) Load randomness from memory
+    push.0.0.0.0
+    movup.8 mem_loadw
+    #=> [a1', a0', a1, a0, Δg1, Δg0, Δ1, Δ0, T01, T00, T31, T30, T21, T20, T11, T10, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
+
+    # b) Use b to choose between a and a'. Since b is inaccessible, we "hard-code" b by creating two versions of `random_combinate_aux`.
+    movup.2 drop movup.2 drop
+
+    # c) Multiply (Δ0, Δ1)
+    dup.1 dup.1
+    movup.7 movup.7
+    #=> [Δ1, Δ0, a1, a0, a1, a0, Δg1, Δg0, T01, T00, T31, T30, T21, T20, T11, T10, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
+
+    ext2mul
+    #=> [prod1, prod0, a1, a0, Δg1, Δg0, T01, T00, T31, T30, T21, T20, T11, T10, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
+    #   where (prod0, prod1) := (Δ0, Δ1) * (a0, a1)
+
+    movdn.5 movdn.5
+    #=> [a1, a0, Δg1, Δg0, prod1, prod0, T01, T00, T31, T30, T21, T20, T11, T10, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
+
+    # d) Multiply (Δg0, Δg1)
+    ext2mul
+    #=> [prodg1, prodg0, prod1, prod0, T01, T00, T31, T30, T21, T20, T11, T10, p1, p0, r1, r0, x_addr, z_addr', a_addr', b]
+    #   where (prodg0, prodg1) := (Δg0, Δg1) * (a0, a1)
+
+    # 6) Accumulate into (p0, p1) and (r0, r1)
+    movupw.3
+
+    # a) Accumulate into (r0, r1)
+    movup.7 movup.7 
+    #=> [prod1, prod0, p1, p0, r1, r0, prodg1, prodg0, T01, T00, T31, T30, T21, T20, T11, T10, x_addr, z_addr', a_addr', b]
+    movup.5 movup.5 ext2add
+    #=> [r1', r0', p1, p0, prodg1, prodg0, T01, T00, T31, T30, T21, T20, T11, T10, x_addr, z_addr', a_addr', b]
+    
+    # b) Accumulate into (p0, p1)
+    movdn.5 movdn.5 ext2add    
+    #=> [p1', p0', r1', r0', T01, T00, T31, T30, T21, T20, T11, T10, x_addr, z_addr', a_addr', b]
+
+    # c) Prepare for next iteration
+    swapw.3
+    movup.3 not movdn.3
+    movdnw.3
+    #=> [T01, T00, T31, T30, T21, T20, T11, T10, p1', p0', r1', r0', x_addr, z_addr', a_addr', 1-b]
+end

--- a/stdlib/tests/crypto/stark/mod.rs
+++ b/stdlib/tests/crypto/stark/mod.rs
@@ -4,10 +4,496 @@ use verifier_recursive::{generate_advice_inputs, VerifierData};
 
 use crate::build_test;
 use assembly::Assembler;
-use miden_air::{FieldExtension, HashFunction, PublicInputs};
+use miden_air::{FieldExtension, HashFunction, PublicInputs, Felt, StarkField, FieldElement};
 use test_utils::{
-    prove, AdviceInputs, MemAdviceProvider, ProgramInfo, ProofOptions, StackInputs, VerifierError,
+    prove, AdviceInputs, MemAdviceProvider, ProgramInfo, ProofOptions, StackInputs, VerifierError, rand::rand_value,
 };
+
+use self::verifier_recursive::QuadExt;
+
+#[test]
+fn random_combinate_main_1() {
+
+    let source = "
+        use.std::crypto::stark::random_combine
+
+        begin
+            # Store randomness [a0, a1, a0', a1']
+            mem_storew.1000
+            dropw
+
+            # Store OOD evaluation of column i at z and gz
+            mem_storew.2000
+            dropw
+
+            exec.random_combine::main_1
+        end
+        ";
+
+    let b = 0_u64;
+    let a_addr = 1000_u64;
+    let z_addr = 2000_u64;
+    let x_addr = 3000_u64;
+
+    let r0: Felt = rand_value();
+    let r1: Felt = rand_value();
+    let p0: Felt = rand_value();
+    let p1: Felt = rand_value();
+
+    let t0: Felt = rand_value();
+    let t1: Felt = rand_value();
+    let t2: Felt = rand_value();
+    let t3: Felt = rand_value();
+    let t4: Felt = rand_value();
+    let t5: Felt = rand_value();
+    let t6: Felt = rand_value();
+    let t7: Felt = rand_value();
+    
+    let tz0: Felt = rand_value();
+    let tz1: Felt = rand_value();
+    let tgz0: Felt = rand_value();
+    let tgz1: Felt = rand_value();
+
+    let a00: Felt = rand_value();
+    let a01: Felt = rand_value();
+    let a10: Felt = rand_value();
+    let a11: Felt = rand_value();
+
+    // Compute the result of ɑ_i * (T_i(x) - T_i(z)). `random_combine::main_1` uses the deepest of
+    // the two ɑ_i's while `random_combine::main_2` uses the other one.
+    let r_new = QuadExt::new(r0, r1);
+    let alpha_0 = QuadExt::new(a00, a01);
+    let t_i_x = QuadExt::new(t0, Felt::ZERO);
+    let t_i_z = QuadExt::new(tz0, tz1);
+    let res_z = r_new + alpha_0 * (t_i_x - t_i_z);
+    let (res_z0, res_z1) = (res_z.base_element(0), res_z.base_element(1));
+
+    // Compute the result of ɑ_i * (T_i(x) - T_i(gz))
+    let p_new = QuadExt::new(p0, p1);
+    let t_i_x = QuadExt::new(t0, Felt::ZERO);
+    let t_i_gz = QuadExt::new(tgz0, tgz1);
+    let res_gz = p_new + alpha_0 * (t_i_x - t_i_gz);
+    let (res_gz0, res_gz1) = (res_gz.base_element(0), res_gz.base_element(1));
+
+    let mut stack = vec![];
+
+    stack.push(b);
+    stack.push(a_addr);
+    stack.push(z_addr);
+    stack.push(x_addr);
+
+    stack.push(r0.as_int());
+    stack.push(r1.as_int());
+    stack.push(p0.as_int());
+    stack.push(p1.as_int());
+
+    stack.push(t0.as_int());
+    stack.push(t1.as_int());
+    stack.push(t2.as_int());
+    stack.push(t3.as_int());
+    stack.push(t4.as_int());
+    stack.push(t5.as_int());
+    stack.push(t6.as_int());
+    stack.push(t7.as_int());
+
+    stack.push(tz0.as_int());
+    stack.push(tz1.as_int());
+    stack.push(tgz0.as_int());
+    stack.push(tgz1.as_int());
+
+    stack.push(a00.as_int());
+    stack.push(a01.as_int());
+    stack.push(a10.as_int());
+    stack.push(a11.as_int());
+
+    let test = build_test!(source, &stack[..]);
+
+    let mut stack = vec![];
+
+    stack.push(1 - b);
+    stack.push(a_addr + b);
+    stack.push(z_addr + 1);
+    stack.push(x_addr);
+    stack.push(res_z0.as_int());
+    stack.push(res_z1.as_int());
+    stack.push(res_gz0.as_int());
+    stack.push(res_gz1.as_int());
+    stack.push(t1.as_int());
+    stack.push(t2.as_int());
+    stack.push(t3.as_int());
+    stack.push(t4.as_int());
+    stack.push(t5.as_int());
+    stack.push(t6.as_int());
+    stack.push(t7.as_int());
+    stack.push(t0.as_int());
+
+    stack.reverse();
+
+    test.expect_stack(&stack[..]);
+}
+
+#[test]
+fn random_combinate_main_2() {
+
+    let source = "
+        use.std::crypto::stark::random_combine
+
+        begin
+            # Store randomness [a0, a1, a0', a1']
+            mem_storew.1000
+            dropw
+
+            # Store OOD evaluation of column i at z and gz
+            mem_storew.2000
+            dropw
+
+            exec.random_combine::main_2
+        end
+        ";
+
+    let b = 1_u64;
+    let a_addr = 1000_u64;
+    let z_addr = 2000_u64;
+    let x_addr = 3000_u64;
+
+    let r0: Felt = rand_value();
+    let r1: Felt = rand_value();
+    let p0: Felt = rand_value();
+    let p1: Felt = rand_value();
+
+    let t0: Felt = rand_value();
+    let t1: Felt = rand_value();
+    let t2: Felt = rand_value();
+    let t3: Felt = rand_value();
+    let t4: Felt = rand_value();
+    let t5: Felt = rand_value();
+    let t6: Felt = rand_value();
+    let t7: Felt = rand_value();
+    
+    let tz0: Felt = rand_value();
+    let tz1: Felt = rand_value();
+    let tgz0: Felt = rand_value();
+    let tgz1: Felt = rand_value();
+
+    let a00: Felt = rand_value();
+    let a01: Felt = rand_value();
+    let a10: Felt = rand_value();
+    let a11: Felt = rand_value();
+
+    // Compute the result of ɑ_i * (T_i(x) - T_i(z)). `random_combine::main_1` uses the deepest of
+    // the two ɑ_i's while `random_combine::main_2` uses the other one.
+    let r_new = QuadExt::new(r0, r1);
+    let alpha_1 = QuadExt::new(a10, a11);
+    let t_i_x = QuadExt::new(t0, Felt::ZERO);
+    let t_i_z = QuadExt::new(tz0, tz1);
+    let res_z = r_new + alpha_1 * (t_i_x - t_i_z);
+    let (res_z0, res_z1) = (res_z.base_element(0), res_z.base_element(1));
+
+    // Compute the result of ɑ_i * (T_i(x) - T_i(gz))
+    let p_new = QuadExt::new(p0, p1);
+    let t_i_x = QuadExt::new(t0, Felt::ZERO);
+    let t_i_gz = QuadExt::new(tgz0, tgz1);
+    let res_gz = p_new + alpha_1 * (t_i_x - t_i_gz);
+    let (res_gz0, res_gz1) = (res_gz.base_element(0), res_gz.base_element(1));
+
+    let mut stack = vec![];
+
+    stack.push(b);
+    stack.push(a_addr);
+    stack.push(z_addr);
+    stack.push(x_addr);
+
+    stack.push(r0.as_int());
+    stack.push(r1.as_int());
+    stack.push(p0.as_int());
+    stack.push(p1.as_int());
+
+    stack.push(t0.as_int());
+    stack.push(t1.as_int());
+    stack.push(t2.as_int());
+    stack.push(t3.as_int());
+    stack.push(t4.as_int());
+    stack.push(t5.as_int());
+    stack.push(t6.as_int());
+    stack.push(t7.as_int());
+
+    stack.push(tz0.as_int());
+    stack.push(tz1.as_int());
+    stack.push(tgz0.as_int());
+    stack.push(tgz1.as_int());
+
+    stack.push(a00.as_int());
+    stack.push(a01.as_int());
+    stack.push(a10.as_int());
+    stack.push(a11.as_int());
+
+    let test = build_test!(source, &stack[..]);
+
+    let mut stack = vec![];
+
+    stack.push(1 - b);
+    stack.push(a_addr + b);
+    stack.push(z_addr + 1);
+    stack.push(x_addr);
+    stack.push(res_z0.as_int());
+    stack.push(res_z1.as_int());
+    stack.push(res_gz0.as_int());
+    stack.push(res_gz1.as_int());
+    stack.push(t1.as_int());
+    stack.push(t2.as_int());
+    stack.push(t3.as_int());
+    stack.push(t4.as_int());
+    stack.push(t5.as_int());
+    stack.push(t6.as_int());
+    stack.push(t7.as_int());
+    stack.push(t0.as_int());
+
+    stack.reverse();
+
+    test.expect_stack(&stack[..]);
+}
+
+#[test]
+fn random_combinate_aux_1() {
+
+    let source = "
+        use.std::crypto::stark::random_combine
+
+        begin
+            # Store randomness [a0, a1, a0', a1']
+            mem_storew.1000
+            dropw
+
+            # Store OOD evaluation of column i at z and gz
+            mem_storew.2000
+            dropw
+
+            exec.random_combine::aux_1
+        end
+        ";
+
+    let b = 0_u64;
+    let a_addr = 1000_u64;
+    let z_addr = 2000_u64;
+    let x_addr = 3000_u64;
+
+    let r0: Felt = rand_value();
+    let r1: Felt = rand_value();
+    let p0: Felt = rand_value();
+    let p1: Felt = rand_value();
+
+    let t00: Felt = rand_value();
+    let t01: Felt = rand_value();
+    let t10: Felt = rand_value();
+    let t11: Felt = rand_value();
+    let t20: Felt = rand_value();
+    let t21: Felt = rand_value();
+    let t30: Felt = rand_value();
+    let t31: Felt = rand_value();
+    
+    let tz0: Felt = rand_value();
+    let tz1: Felt = rand_value();
+    let tgz0: Felt = rand_value();
+    let tgz1: Felt = rand_value();
+
+    let a00: Felt = rand_value();
+    let a01: Felt = rand_value();
+    let a10: Felt = rand_value();
+    let a11: Felt = rand_value();
+
+    // Compute the result of ɑ_i * (T_i(x) - T_i(z)). `random_combine::aux_1` uses the deepest of
+    // the two ɑ_i's while `random_combine::aux_2` uses the other one.
+    let r_new = QuadExt::new(r0, r1);
+    let alpha_0 = QuadExt::new(a00, a01);
+    let t_i_x = QuadExt::new(t00, t01);
+    let t_i_z = QuadExt::new(tz0, tz1);
+    let res_z = r_new + alpha_0 * (t_i_x - t_i_z);
+    let (res_z0, res_z1) = (res_z.base_element(0), res_z.base_element(1));
+
+    // Compute the result of ɑ_i * (T_i(x) - T_i(gz))
+    let p_new = QuadExt::new(p0, p1);
+    let t_i_x = QuadExt::new(t00, t01);
+    let t_i_gz = QuadExt::new(tgz0, tgz1);
+    let res_gz = p_new + alpha_0 * (t_i_x - t_i_gz);
+    let (res_gz0, res_gz1) = (res_gz.base_element(0), res_gz.base_element(1));
+
+    let mut stack = vec![];
+
+    stack.push(b);
+    stack.push(a_addr);
+    stack.push(z_addr);
+    stack.push(x_addr);
+    
+    stack.push(r0.as_int());
+    stack.push(r1.as_int());
+    stack.push(p0.as_int());
+    stack.push(p1.as_int());
+
+    stack.push(t00.as_int());
+    stack.push(t01.as_int());
+    stack.push(t10.as_int());
+    stack.push(t11.as_int());
+    stack.push(t20.as_int());
+    stack.push(t21.as_int());
+    stack.push(t30.as_int());
+    stack.push(t31.as_int());
+
+    stack.push(tz0.as_int());
+    stack.push(tz1.as_int());
+    stack.push(tgz0.as_int());
+    stack.push(tgz1.as_int());
+
+    stack.push(a00.as_int());
+    stack.push(a01.as_int());
+    stack.push(a10.as_int());
+    stack.push(a11.as_int());
+
+    let test = build_test!(source, &stack[..]);
+
+    let mut stack = vec![];
+
+    stack.push(1 - b);
+    stack.push(a_addr + b);
+    stack.push(z_addr + 1);
+    stack.push(x_addr);
+    stack.push(res_z0.as_int());
+    stack.push(res_z1.as_int());
+    stack.push(res_gz0.as_int());
+    stack.push(res_gz1.as_int());
+    stack.push(t10.as_int());
+    stack.push(t11.as_int());
+    stack.push(t20.as_int());
+    stack.push(t21.as_int());
+    stack.push(t30.as_int());
+    stack.push(t31.as_int());
+    stack.push(t00.as_int());
+    stack.push(t01.as_int());
+
+    stack.reverse();
+
+    test.expect_stack(&stack[..]);
+}
+
+#[test]
+fn random_combinate_aux_2() {
+
+    let source = "
+        use.std::crypto::stark::random_combine
+
+        begin
+            # Store randomness [a0, a1, a0', a1']
+            mem_storew.1000
+            dropw
+
+            # Store OOD evaluation of column i at z and gz
+            mem_storew.2000
+            dropw
+
+            exec.random_combine::aux_2
+        end
+        ";
+
+    let b = 0_u64;
+    let a_addr = 1000_u64;
+    let z_addr = 2000_u64;
+    let x_addr = 3000_u64;
+
+    let r0: Felt = rand_value();
+    let r1: Felt = rand_value();
+    let p0: Felt = rand_value();
+    let p1: Felt = rand_value();
+
+    let t00: Felt = rand_value();
+    let t01: Felt = rand_value();
+    let t10: Felt = rand_value();
+    let t11: Felt = rand_value();
+    let t20: Felt = rand_value();
+    let t21: Felt = rand_value();
+    let t30: Felt = rand_value();
+    let t31: Felt = rand_value();
+    
+    let tz0: Felt = rand_value();
+    let tz1: Felt = rand_value();
+    let tgz0: Felt = rand_value();
+    let tgz1: Felt = rand_value();
+
+    let a00: Felt = rand_value();
+    let a01: Felt = rand_value();
+    let a10: Felt = rand_value();
+    let a11: Felt = rand_value();
+
+    // Compute the result of ɑ_i * (T_i(x) - T_i(z)). `random_combine::aux_1` uses the deepest of
+    // the two ɑ_i's while `random_combine::aux_2` uses the other one.
+    let r_new = QuadExt::new(r0, r1);
+    let alpha_1 = QuadExt::new(a10, a11);
+    let t_i_x = QuadExt::new(t00, t01);
+    let t_i_z = QuadExt::new(tz0, tz1);
+    let res_z = r_new + alpha_1 * (t_i_x - t_i_z);
+    let (res_z0, res_z1) = (res_z.base_element(0), res_z.base_element(1));
+
+    // Compute the result of ɑ_i * (T_i(x) - T_i(gz))
+    let p_new = QuadExt::new(p0, p1);
+    let t_i_x = QuadExt::new(t00, t01);
+    let t_i_gz = QuadExt::new(tgz0, tgz1);
+    let res_gz = p_new + alpha_1 * (t_i_x - t_i_gz);
+    let (res_gz0, res_gz1) = (res_gz.base_element(0), res_gz.base_element(1));
+
+    let mut stack = vec![];
+
+    stack.push(b);
+    stack.push(a_addr);
+    stack.push(z_addr);
+    stack.push(x_addr);
+    
+    stack.push(r0.as_int());
+    stack.push(r1.as_int());
+    stack.push(p0.as_int());
+    stack.push(p1.as_int());
+
+    stack.push(t00.as_int());
+    stack.push(t01.as_int());
+    stack.push(t10.as_int());
+    stack.push(t11.as_int());
+    stack.push(t20.as_int());
+    stack.push(t21.as_int());
+    stack.push(t30.as_int());
+    stack.push(t31.as_int());
+
+    stack.push(tz0.as_int());
+    stack.push(tz1.as_int());
+    stack.push(tgz0.as_int());
+    stack.push(tgz1.as_int());
+
+    stack.push(a00.as_int());
+    stack.push(a01.as_int());
+    stack.push(a10.as_int());
+    stack.push(a11.as_int());
+
+    let test = build_test!(source, &stack[..]);
+
+    let mut stack = vec![];
+
+    stack.push(1 - b);
+    stack.push(a_addr + b);
+    stack.push(z_addr + 1);
+    stack.push(x_addr);
+    stack.push(res_z0.as_int());
+    stack.push(res_z1.as_int());
+    stack.push(res_gz0.as_int());
+    stack.push(res_gz1.as_int());
+    stack.push(t10.as_int());
+    stack.push(t11.as_int());
+    stack.push(t20.as_int());
+    stack.push(t21.as_int());
+    stack.push(t30.as_int());
+    stack.push(t31.as_int());
+    stack.push(t00.as_int());
+    stack.push(t01.as_int());
+
+    stack.reverse();
+
+    test.expect_stack(&stack[..]);
+}
 
 #[test]
 fn stark_verifier_e2f4() {

--- a/stdlib/tests/crypto/stark/mod.rs
+++ b/stdlib/tests/crypto/stark/mod.rs
@@ -4,21 +4,21 @@ use verifier_recursive::{generate_advice_inputs, VerifierData};
 
 use crate::build_test;
 use assembly::Assembler;
-use miden_air::{FieldExtension, HashFunction, PublicInputs, Felt, StarkField, FieldElement};
+use miden_air::{Felt, FieldElement, FieldExtension, HashFunction, PublicInputs, StarkField};
 use test_utils::{
-    prove, AdviceInputs, MemAdviceProvider, ProgramInfo, ProofOptions, StackInputs, VerifierError, rand::rand_value,
+    prove, rand::rand_value, AdviceInputs, MemAdviceProvider, ProgramInfo, ProofOptions,
+    StackInputs, VerifierError,
 };
 
 use self::verifier_recursive::QuadExt;
 
 #[test]
-fn random_combinate_main_1() {
-
+fn random_combinate_main() {
     let source = "
         use.std::crypto::stark::random_combine
 
         begin
-            # Store randomness [a0, a1, a0', a1']
+            # Store randomness [a0, a1, 0, 0]
             mem_storew.1000
             dropw
 
@@ -26,11 +26,10 @@ fn random_combinate_main_1() {
             mem_storew.2000
             dropw
 
-            exec.random_combine::main_1
+            exec.random_combine::main
         end
         ";
 
-    let b = 0_u64;
     let a_addr = 1000_u64;
     let z_addr = 2000_u64;
     let x_addr = 3000_u64;
@@ -48,36 +47,33 @@ fn random_combinate_main_1() {
     let t5: Felt = rand_value();
     let t6: Felt = rand_value();
     let t7: Felt = rand_value();
-    
+
     let tz0: Felt = rand_value();
     let tz1: Felt = rand_value();
     let tgz0: Felt = rand_value();
     let tgz1: Felt = rand_value();
 
-    let a00: Felt = rand_value();
-    let a01: Felt = rand_value();
-    let a10: Felt = rand_value();
-    let a11: Felt = rand_value();
+    let a0: Felt = rand_value();
+    let a1: Felt = rand_value();
 
-    // Compute the result of ɑ_i * (T_i(x) - T_i(z)). `random_combine::main_1` uses the deepest of
-    // the two ɑ_i's while `random_combine::main_2` uses the other one.
+    // Compute the result of ɑ_i * (T_i(x) - T_i(z)).
     let r_new = QuadExt::new(r0, r1);
-    let alpha_0 = QuadExt::new(a00, a01);
+    let alpha = QuadExt::new(a0, a1);
     let t_i_x = QuadExt::new(t0, Felt::ZERO);
     let t_i_z = QuadExt::new(tz0, tz1);
-    let res_z = r_new + alpha_0 * (t_i_x - t_i_z);
+    let res_z = r_new + alpha * (t_i_x - t_i_z);
     let (res_z0, res_z1) = (res_z.base_element(0), res_z.base_element(1));
 
     // Compute the result of ɑ_i * (T_i(x) - T_i(gz))
     let p_new = QuadExt::new(p0, p1);
     let t_i_x = QuadExt::new(t0, Felt::ZERO);
     let t_i_gz = QuadExt::new(tgz0, tgz1);
-    let res_gz = p_new + alpha_0 * (t_i_x - t_i_gz);
+    let res_gz = p_new + alpha * (t_i_x - t_i_gz);
     let (res_gz0, res_gz1) = (res_gz.base_element(0), res_gz.base_element(1));
 
     let mut stack = vec![];
 
-    stack.push(b);
+    stack.push(0);
     stack.push(a_addr);
     stack.push(z_addr);
     stack.push(x_addr);
@@ -101,17 +97,17 @@ fn random_combinate_main_1() {
     stack.push(tgz0.as_int());
     stack.push(tgz1.as_int());
 
-    stack.push(a00.as_int());
-    stack.push(a01.as_int());
-    stack.push(a10.as_int());
-    stack.push(a11.as_int());
+    stack.push(a0.as_int());
+    stack.push(a1.as_int());
+    stack.push(0);
+    stack.push(0);
 
     let test = build_test!(source, &stack[..]);
 
     let mut stack = vec![];
 
-    stack.push(1 - b);
-    stack.push(a_addr + b);
+    stack.push(0);
+    stack.push(a_addr + 1);
     stack.push(z_addr + 1);
     stack.push(x_addr);
     stack.push(res_z0.as_int());
@@ -133,13 +129,12 @@ fn random_combinate_main_1() {
 }
 
 #[test]
-fn random_combinate_main_2() {
-
+fn random_combinate_aux() {
     let source = "
         use.std::crypto::stark::random_combine
 
         begin
-            # Store randomness [a0, a1, a0', a1']
+            # Store randomness [a0, a1, 0, 0]
             mem_storew.1000
             dropw
 
@@ -147,132 +142,10 @@ fn random_combinate_main_2() {
             mem_storew.2000
             dropw
 
-            exec.random_combine::main_2
+            exec.random_combine::aux
         end
         ";
 
-    let b = 1_u64;
-    let a_addr = 1000_u64;
-    let z_addr = 2000_u64;
-    let x_addr = 3000_u64;
-
-    let r0: Felt = rand_value();
-    let r1: Felt = rand_value();
-    let p0: Felt = rand_value();
-    let p1: Felt = rand_value();
-
-    let t0: Felt = rand_value();
-    let t1: Felt = rand_value();
-    let t2: Felt = rand_value();
-    let t3: Felt = rand_value();
-    let t4: Felt = rand_value();
-    let t5: Felt = rand_value();
-    let t6: Felt = rand_value();
-    let t7: Felt = rand_value();
-    
-    let tz0: Felt = rand_value();
-    let tz1: Felt = rand_value();
-    let tgz0: Felt = rand_value();
-    let tgz1: Felt = rand_value();
-
-    let a00: Felt = rand_value();
-    let a01: Felt = rand_value();
-    let a10: Felt = rand_value();
-    let a11: Felt = rand_value();
-
-    // Compute the result of ɑ_i * (T_i(x) - T_i(z)). `random_combine::main_1` uses the deepest of
-    // the two ɑ_i's while `random_combine::main_2` uses the other one.
-    let r_new = QuadExt::new(r0, r1);
-    let alpha_1 = QuadExt::new(a10, a11);
-    let t_i_x = QuadExt::new(t0, Felt::ZERO);
-    let t_i_z = QuadExt::new(tz0, tz1);
-    let res_z = r_new + alpha_1 * (t_i_x - t_i_z);
-    let (res_z0, res_z1) = (res_z.base_element(0), res_z.base_element(1));
-
-    // Compute the result of ɑ_i * (T_i(x) - T_i(gz))
-    let p_new = QuadExt::new(p0, p1);
-    let t_i_x = QuadExt::new(t0, Felt::ZERO);
-    let t_i_gz = QuadExt::new(tgz0, tgz1);
-    let res_gz = p_new + alpha_1 * (t_i_x - t_i_gz);
-    let (res_gz0, res_gz1) = (res_gz.base_element(0), res_gz.base_element(1));
-
-    let mut stack = vec![];
-
-    stack.push(b);
-    stack.push(a_addr);
-    stack.push(z_addr);
-    stack.push(x_addr);
-
-    stack.push(r0.as_int());
-    stack.push(r1.as_int());
-    stack.push(p0.as_int());
-    stack.push(p1.as_int());
-
-    stack.push(t0.as_int());
-    stack.push(t1.as_int());
-    stack.push(t2.as_int());
-    stack.push(t3.as_int());
-    stack.push(t4.as_int());
-    stack.push(t5.as_int());
-    stack.push(t6.as_int());
-    stack.push(t7.as_int());
-
-    stack.push(tz0.as_int());
-    stack.push(tz1.as_int());
-    stack.push(tgz0.as_int());
-    stack.push(tgz1.as_int());
-
-    stack.push(a00.as_int());
-    stack.push(a01.as_int());
-    stack.push(a10.as_int());
-    stack.push(a11.as_int());
-
-    let test = build_test!(source, &stack[..]);
-
-    let mut stack = vec![];
-
-    stack.push(1 - b);
-    stack.push(a_addr + b);
-    stack.push(z_addr + 1);
-    stack.push(x_addr);
-    stack.push(res_z0.as_int());
-    stack.push(res_z1.as_int());
-    stack.push(res_gz0.as_int());
-    stack.push(res_gz1.as_int());
-    stack.push(t1.as_int());
-    stack.push(t2.as_int());
-    stack.push(t3.as_int());
-    stack.push(t4.as_int());
-    stack.push(t5.as_int());
-    stack.push(t6.as_int());
-    stack.push(t7.as_int());
-    stack.push(t0.as_int());
-
-    stack.reverse();
-
-    test.expect_stack(&stack[..]);
-}
-
-#[test]
-fn random_combinate_aux_1() {
-
-    let source = "
-        use.std::crypto::stark::random_combine
-
-        begin
-            # Store randomness [a0, a1, a0', a1']
-            mem_storew.1000
-            dropw
-
-            # Store OOD evaluation of column i at z and gz
-            mem_storew.2000
-            dropw
-
-            exec.random_combine::aux_1
-        end
-        ";
-
-    let b = 0_u64;
     let a_addr = 1000_u64;
     let z_addr = 2000_u64;
     let x_addr = 3000_u64;
@@ -290,40 +163,37 @@ fn random_combinate_aux_1() {
     let t21: Felt = rand_value();
     let t30: Felt = rand_value();
     let t31: Felt = rand_value();
-    
+
     let tz0: Felt = rand_value();
     let tz1: Felt = rand_value();
     let tgz0: Felt = rand_value();
     let tgz1: Felt = rand_value();
 
-    let a00: Felt = rand_value();
-    let a01: Felt = rand_value();
-    let a10: Felt = rand_value();
-    let a11: Felt = rand_value();
+    let a0: Felt = rand_value();
+    let a1: Felt = rand_value();
 
-    // Compute the result of ɑ_i * (T_i(x) - T_i(z)). `random_combine::aux_1` uses the deepest of
-    // the two ɑ_i's while `random_combine::aux_2` uses the other one.
+    // Compute the result of ɑ_i * (T_i(x) - T_i(z)).
     let r_new = QuadExt::new(r0, r1);
-    let alpha_0 = QuadExt::new(a00, a01);
+    let alpha = QuadExt::new(a0, a1);
     let t_i_x = QuadExt::new(t00, t01);
     let t_i_z = QuadExt::new(tz0, tz1);
-    let res_z = r_new + alpha_0 * (t_i_x - t_i_z);
+    let res_z = r_new + alpha * (t_i_x - t_i_z);
     let (res_z0, res_z1) = (res_z.base_element(0), res_z.base_element(1));
 
     // Compute the result of ɑ_i * (T_i(x) - T_i(gz))
     let p_new = QuadExt::new(p0, p1);
     let t_i_x = QuadExt::new(t00, t01);
     let t_i_gz = QuadExt::new(tgz0, tgz1);
-    let res_gz = p_new + alpha_0 * (t_i_x - t_i_gz);
+    let res_gz = p_new + alpha * (t_i_x - t_i_gz);
     let (res_gz0, res_gz1) = (res_gz.base_element(0), res_gz.base_element(1));
 
     let mut stack = vec![];
 
-    stack.push(b);
+    stack.push(0);
     stack.push(a_addr);
     stack.push(z_addr);
     stack.push(x_addr);
-    
+
     stack.push(r0.as_int());
     stack.push(r1.as_int());
     stack.push(p0.as_int());
@@ -343,138 +213,17 @@ fn random_combinate_aux_1() {
     stack.push(tgz0.as_int());
     stack.push(tgz1.as_int());
 
-    stack.push(a00.as_int());
-    stack.push(a01.as_int());
-    stack.push(a10.as_int());
-    stack.push(a11.as_int());
+    stack.push(a0.as_int());
+    stack.push(a1.as_int());
+    stack.push(0);
+    stack.push(0);
 
     let test = build_test!(source, &stack[..]);
 
     let mut stack = vec![];
 
-    stack.push(1 - b);
-    stack.push(a_addr + b);
-    stack.push(z_addr + 1);
-    stack.push(x_addr);
-    stack.push(res_z0.as_int());
-    stack.push(res_z1.as_int());
-    stack.push(res_gz0.as_int());
-    stack.push(res_gz1.as_int());
-    stack.push(t10.as_int());
-    stack.push(t11.as_int());
-    stack.push(t20.as_int());
-    stack.push(t21.as_int());
-    stack.push(t30.as_int());
-    stack.push(t31.as_int());
-    stack.push(t00.as_int());
-    stack.push(t01.as_int());
-
-    stack.reverse();
-
-    test.expect_stack(&stack[..]);
-}
-
-#[test]
-fn random_combinate_aux_2() {
-
-    let source = "
-        use.std::crypto::stark::random_combine
-
-        begin
-            # Store randomness [a0, a1, a0', a1']
-            mem_storew.1000
-            dropw
-
-            # Store OOD evaluation of column i at z and gz
-            mem_storew.2000
-            dropw
-
-            exec.random_combine::aux_2
-        end
-        ";
-
-    let b = 0_u64;
-    let a_addr = 1000_u64;
-    let z_addr = 2000_u64;
-    let x_addr = 3000_u64;
-
-    let r0: Felt = rand_value();
-    let r1: Felt = rand_value();
-    let p0: Felt = rand_value();
-    let p1: Felt = rand_value();
-
-    let t00: Felt = rand_value();
-    let t01: Felt = rand_value();
-    let t10: Felt = rand_value();
-    let t11: Felt = rand_value();
-    let t20: Felt = rand_value();
-    let t21: Felt = rand_value();
-    let t30: Felt = rand_value();
-    let t31: Felt = rand_value();
-    
-    let tz0: Felt = rand_value();
-    let tz1: Felt = rand_value();
-    let tgz0: Felt = rand_value();
-    let tgz1: Felt = rand_value();
-
-    let a00: Felt = rand_value();
-    let a01: Felt = rand_value();
-    let a10: Felt = rand_value();
-    let a11: Felt = rand_value();
-
-    // Compute the result of ɑ_i * (T_i(x) - T_i(z)). `random_combine::aux_1` uses the deepest of
-    // the two ɑ_i's while `random_combine::aux_2` uses the other one.
-    let r_new = QuadExt::new(r0, r1);
-    let alpha_1 = QuadExt::new(a10, a11);
-    let t_i_x = QuadExt::new(t00, t01);
-    let t_i_z = QuadExt::new(tz0, tz1);
-    let res_z = r_new + alpha_1 * (t_i_x - t_i_z);
-    let (res_z0, res_z1) = (res_z.base_element(0), res_z.base_element(1));
-
-    // Compute the result of ɑ_i * (T_i(x) - T_i(gz))
-    let p_new = QuadExt::new(p0, p1);
-    let t_i_x = QuadExt::new(t00, t01);
-    let t_i_gz = QuadExt::new(tgz0, tgz1);
-    let res_gz = p_new + alpha_1 * (t_i_x - t_i_gz);
-    let (res_gz0, res_gz1) = (res_gz.base_element(0), res_gz.base_element(1));
-
-    let mut stack = vec![];
-
-    stack.push(b);
-    stack.push(a_addr);
-    stack.push(z_addr);
-    stack.push(x_addr);
-    
-    stack.push(r0.as_int());
-    stack.push(r1.as_int());
-    stack.push(p0.as_int());
-    stack.push(p1.as_int());
-
-    stack.push(t00.as_int());
-    stack.push(t01.as_int());
-    stack.push(t10.as_int());
-    stack.push(t11.as_int());
-    stack.push(t20.as_int());
-    stack.push(t21.as_int());
-    stack.push(t30.as_int());
-    stack.push(t31.as_int());
-
-    stack.push(tz0.as_int());
-    stack.push(tz1.as_int());
-    stack.push(tgz0.as_int());
-    stack.push(tgz1.as_int());
-
-    stack.push(a00.as_int());
-    stack.push(a01.as_int());
-    stack.push(a10.as_int());
-    stack.push(a11.as_int());
-
-    let test = build_test!(source, &stack[..]);
-
-    let mut stack = vec![];
-
-    stack.push(1 - b);
-    stack.push(a_addr + b);
+    stack.push(0);
+    stack.push(a_addr + 1);
     stack.push(z_addr + 1);
     stack.push(x_addr);
     stack.push(res_z0.as_int());


### PR DESCRIPTION
## Describe your changes
The following PR proposes two procedures mimicking the candidate new instructions proposed in #869. After #899 is addressed, we should be able to re-write the way we compute the random linear combinations in `deep_queries.masm` in a way that corresponds to how we want `RCOMB` to be used. See #869 .
~One thing that I could not manage to do is to use the flag `b` as proposed in the [comment](https://github.com/0xPolygonMiden/miden-vm/issues/869#issuecomment-1552544648) to select the appropriate randomness to use (using a `cdrop`). I opted instead to use two almost identical procedures to simulate the functioning of `b`. This is hacky but I didn't see an immediate way to use `b` and also I still need a confirmation that the logic for using `b` is sound in the first place.~
Edit: It seems that the flag idea for selecting between randomness' is not viable in our setting. We opted instead to use only one random element per memory address. This has being reflected in the current PR.

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
