### PR TITLE
Add code block builder method to Assembler

### DIFF
--- a/assembly/src/assembler/context.rs
+++ b/assembly/src/assembler/context.rs
@@ -228,7 +228,10 @@ impl AssemblyContext {
     /// - If this module is not an executable module.
     /// - If any of the procedures in the module's callset cannot be found in the specified
     ///   procedure cache or the local procedure set of the module.
-    pub fn into_cb_table(mut self, proc_cache: &ProcedureCache) -> CodeBlockTable {
+    pub fn into_cb_table(
+        mut self,
+        proc_cache: &ProcedureCache,
+    ) -> Result<CodeBlockTable, AssemblyError> {
         // get the last module off the module stack
         assert_eq!(self.module_stack.len(), 1, "module stack must contain exactly one module");
         let mut main_module_context = self.module_stack.pop().unwrap();
@@ -244,12 +247,12 @@ impl AssemblyContext {
             let proc = proc_cache
                 .get_by_id(proc_id)
                 .or_else(|| main_module_context.find_local_proc(proc_id))
-                .expect("callset procedure not found");
+                .ok_or(AssemblyError::CallSetProcedureNotFound(*proc_id))?;
 
             cb_table.insert(proc.code_root().clone());
         }
 
-        cb_table
+        Ok(cb_table)
     }
 
     // HELPER METHODS

--- a/assembly/src/assembler/mod.rs
+++ b/assembly/src/assembler/mod.rs
@@ -134,7 +134,7 @@ impl Assembler {
         let program_root = self.compile_in_context(program, &mut context)?;
 
         // convert the context into a call block table for the program
-        let cb_table = context.into_cb_table(&self.proc_cache.borrow());
+        let cb_table = context.into_cb_table(&self.proc_cache.borrow())?;
 
         // build and return the program
         Ok(Program::with_kernel(program_root, self.kernel.clone(), cb_table))
@@ -361,6 +361,19 @@ impl Assembler {
         }
 
         Ok(())
+    }
+
+    // CODE BLOCK BUILDER
+    // --------------------------------------------------------------------------------------------
+    /// Returns the [CodeBlockTable] associated with the [AssemblyContext].
+    ///
+    /// # Errors
+    /// Retuns an error if a required procedure is not found in the [Assembler] prodedure cache.
+    pub fn build_cb_table(
+        &self,
+        context: AssemblyContext,
+    ) -> Result<CodeBlockTable, AssemblyError> {
+        context.into_cb_table(&self.proc_cache.borrow())
     }
 }
 

--- a/assembly/src/errors.rs
+++ b/assembly/src/errors.rs
@@ -11,6 +11,7 @@ use core::fmt;
 pub enum AssemblyError {
     CallInKernel(String),
     CallerOutOKernel,
+    CallSetProcedureNotFound(ProcedureId),
     CircularModuleDependency(Vec<String>),
     DivisionByZero,
     DuplicateProcName(String, String),
@@ -120,6 +121,7 @@ impl fmt::Display for AssemblyError {
         match self {
             CallInKernel(proc_name) => write!(f, "call instruction used kernel procedure '{proc_name}'"),
             CallerOutOKernel => write!(f, "caller instruction used outside of kernel"),
+            CallSetProcedureNotFound(proc_id) => write!(f, "callset procedure not found in assembler cache for procedure  '{proc_id}'"),
             CircularModuleDependency(dep_chain) => write!(f, "circular module dependency in the following chain: {dep_chain:?}"),
             DivisionByZero => write!(f, "division by zero"),
             DuplicateProcName(proc_name, module_path) => write!(f, "duplicate proc name '{proc_name}' in module {module_path}"),


### PR DESCRIPTION
This PR introduces the `build_cb_table(..)` method on the `Assembler` which allows the user to convert an `AssemblyContext` into a `CodeBlockTable`.  This support the implementation of the [`TransactionCompiler`](https://github.com/0xPolygonMiden/miden-base/issues/130). 
