### PR TITLE
Advice injector refactoring

### DIFF
--- a/assembly/src/assembler/instruction/adv_ops.rs
+++ b/assembly/src/assembler/instruction/adv_ops.rs
@@ -1,5 +1,5 @@
 use super::{validate_param, AssemblyError, SpanBuilder};
-use crate::{ast::AdviceInjector, ADVICE_READ_LIMIT};
+use crate::{ast::AdviceInjectorNode, ADVICE_READ_LIMIT};
 use vm_core::{code_blocks::CodeBlock, Operation};
 
 // NON-DETERMINISTIC (ADVICE) INPUTS
@@ -24,15 +24,8 @@ pub fn adv_push(span: &mut SpanBuilder, n: u8) -> Result<Option<CodeBlock>, Asse
 /// Appends advice injector decorator to the span.
 pub fn adv_inject(
     span: &mut SpanBuilder,
-    injector: &AdviceInjector,
+    injector: &AdviceInjectorNode,
 ) -> Result<Option<CodeBlock>, AssemblyError> {
-    use super::AdviceInjector::*;
-    match injector {
-        AdviceInjector::PushU64div => span.push_advice_injector(DivU64),
-        AdviceInjector::PushExt2intt => span.push_advice_injector(Ext2Intt),
-        AdviceInjector::PushSmtGet => span.push_advice_injector(SmtGet),
-        AdviceInjector::PushMapVal => span.push_advice_injector(MapValueToStack),
-        AdviceInjector::InsertMem => span.push_advice_injector(MemToMap),
-    }
+    span.push_advice_injector(injector.into());
     Ok(None)
 }

--- a/assembly/src/assembler/instruction/adv_ops.rs
+++ b/assembly/src/assembler/instruction/adv_ops.rs
@@ -1,4 +1,4 @@
-use super::{validate_param, AssemblyError, Decorator, SpanBuilder};
+use super::{validate_param, AssemblyError, SpanBuilder};
 use crate::{ast::AdviceInjector, ADVICE_READ_LIMIT};
 use vm_core::{code_blocks::CodeBlock, Operation};
 
@@ -27,13 +27,12 @@ pub fn adv_inject(
     injector: &AdviceInjector,
 ) -> Result<Option<CodeBlock>, AssemblyError> {
     use super::AdviceInjector::*;
-
     match injector {
-        AdviceInjector::PushU64div => span.add_decorator(Decorator::Advice(DivU64)),
-        AdviceInjector::PushMapVal => span.add_decorator(Decorator::Advice(MapValueToStack)),
-        AdviceInjector::PushExt2inv => span.add_decorator(Decorator::Advice(Ext2Inv)),
-        AdviceInjector::PushExt2intt => span.add_decorator(Decorator::Advice(Ext2Intt)),
-        AdviceInjector::PushSmtGet => span.add_decorator(Decorator::Advice(SmtGet)),
-        AdviceInjector::InsertMem => span.add_decorator(Decorator::Advice(MemToMap)),
+        AdviceInjector::PushU64div => span.push_advice_injector(DivU64),
+        AdviceInjector::PushExt2intt => span.push_advice_injector(Ext2Intt),
+        AdviceInjector::PushSmtGet => span.push_advice_injector(SmtGet),
+        AdviceInjector::PushMapVal => span.push_advice_injector(MapValueToStack),
+        AdviceInjector::InsertMem => span.push_advice_injector(MemToMap),
     }
+    Ok(None)
 }

--- a/assembly/src/assembler/instruction/adv_ops.rs
+++ b/assembly/src/assembler/instruction/adv_ops.rs
@@ -29,11 +29,11 @@ pub fn adv_inject(
     use super::AdviceInjector::*;
 
     match injector {
-        AdviceInjector::PushU64div => span.add_decorator(Decorator::Advice(DivResultU64)),
-        AdviceInjector::PushMapVal => span.add_decorator(Decorator::Advice(MapValue)),
+        AdviceInjector::PushU64div => span.add_decorator(Decorator::Advice(DivU64)),
+        AdviceInjector::PushMapVal => span.add_decorator(Decorator::Advice(MapValueToStack)),
         AdviceInjector::PushExt2inv => span.add_decorator(Decorator::Advice(Ext2Inv)),
-        AdviceInjector::PushExt2intt => span.add_decorator(Decorator::Advice(Ext2INTT)),
+        AdviceInjector::PushExt2intt => span.add_decorator(Decorator::Advice(Ext2Intt)),
         AdviceInjector::PushSmtGet => span.add_decorator(Decorator::Advice(SmtGet)),
-        AdviceInjector::InsertMem => span.add_decorator(Decorator::Advice(Memory)),
+        AdviceInjector::InsertMem => span.add_decorator(Decorator::Advice(MemToMap)),
     }
 }

--- a/assembly/src/assembler/instruction/crypto_ops.rs
+++ b/assembly/src/assembler/instruction/crypto_ops.rs
@@ -1,5 +1,5 @@
 use super::{AssemblyError, CodeBlock, Operation::*, SpanBuilder};
-use vm_core::{AdviceInjector, Decorator};
+use vm_core::AdviceInjector;
 
 // HASHING
 // ================================================================================================
@@ -168,7 +168,7 @@ pub(super) fn mtree_merge(span: &mut SpanBuilder) -> Result<Option<CodeBlock>, A
 
     // invoke the advice provider function to merge 2 Merkle trees defined by the roots on the top
     // of the operand stack
-    span.push_decorator(Decorator::Advice(AdviceInjector::MerkleMerge));
+    span.push_advice_injector(AdviceInjector::MerkleTreeMerge);
 
     // perform the `hmerge`, updating the operand stack
     hmerge(span)
@@ -216,7 +216,7 @@ fn read_mtree_node(span: &mut SpanBuilder) {
     // new node value post the tree root: [d, i, R, V_new]
     //
     // pops the value of the node we are looking for from the advice stack
-    span.push_decorator(Decorator::Advice(AdviceInjector::MerkleNode));
+    span.push_advice_injector(AdviceInjector::MerkleNodeToStack);
 
     // pops the old node value from advice the stack => MPVERIFY: [V_old, d, i, R, ...]
     // MRUPDATE: [V_old, d, i, R, V_new, ...]

--- a/assembly/src/assembler/instruction/crypto_ops.rs
+++ b/assembly/src/assembler/instruction/crypto_ops.rs
@@ -168,7 +168,7 @@ pub(super) fn mtree_merge(span: &mut SpanBuilder) -> Result<Option<CodeBlock>, A
 
     // invoke the advice provider function to merge 2 Merkle trees defined by the roots on the top
     // of the operand stack
-    span.push_advice_injector(AdviceInjector::MerkleTreeMerge);
+    span.push_advice_injector(AdviceInjector::MerkleNodeMerge);
 
     // perform the `hmerge`, updating the operand stack
     hmerge(span)

--- a/assembly/src/assembler/instruction/ext2_ops.rs
+++ b/assembly/src/assembler/instruction/ext2_ops.rs
@@ -1,5 +1,5 @@
 use super::{AssemblyError, CodeBlock, Operation::*, SpanBuilder};
-use vm_core::{AdviceInjector::Ext2Inv, Decorator};
+use vm_core::AdviceInjector::Ext2Inv;
 
 /// Given a stack in the following initial configuration [b1, b0, a1, a0, ...] where a = (a0, a1)
 /// and b = (b0, b1) represent elements in the extension field of degree 2, this series of
@@ -52,7 +52,7 @@ pub fn ext2_mul(span: &mut SpanBuilder) -> Result<Option<CodeBlock>, AssemblyErr
 ///
 /// This operation takes 11 VM cycles.
 pub fn ext2_div(span: &mut SpanBuilder) -> Result<Option<CodeBlock>, AssemblyError> {
-    span.add_decorator(Decorator::Advice(Ext2Inv))?;
+    span.push_advice_injector(Ext2Inv);
     #[rustfmt::skip]
     let ops = [
         AdvPop,      // [b0', b1, b0, a1, a0, ...]
@@ -112,7 +112,7 @@ pub fn ext2_neg(span: &mut SpanBuilder) -> Result<Option<CodeBlock>, AssemblyErr
 ///
 /// This operation takes 8 VM cycles.
 pub fn ext2_inv(span: &mut SpanBuilder) -> Result<Option<CodeBlock>, AssemblyError> {
-    span.add_decorator(Decorator::Advice(Ext2Inv))?;
+    span.push_advice_injector(Ext2Inv);
     #[rustfmt::skip]
     let ops = [
         AdvPop,   // [a0', a1, a0, ...]

--- a/assembly/src/assembler/instruction/mod.rs
+++ b/assembly/src/assembler/instruction/mod.rs
@@ -1,5 +1,5 @@
 use super::{
-    Assembler, AssemblyContext, AssemblyError, CodeBlock, Decorator, Felt, Instruction, Operation,
+    Assembler, AssemblyContext, AssemblyError, CodeBlock, Felt, Instruction, Operation,
     ProcedureId, RpoDigest, SpanBuilder, ONE, ZERO,
 };
 use crate::utils::bound_into_included_u64;

--- a/assembly/src/assembler/instruction/mod.rs
+++ b/assembly/src/assembler/instruction/mod.rs
@@ -4,7 +4,7 @@ use super::{
 };
 use crate::utils::bound_into_included_u64;
 use core::ops::RangeBounds;
-use vm_core::{AdviceInjector, FieldElement, StarkField};
+use vm_core::{FieldElement, StarkField};
 
 mod adv_ops;
 mod crypto_ops;

--- a/assembly/src/assembler/span_builder.rs
+++ b/assembly/src/assembler/span_builder.rs
@@ -94,15 +94,6 @@ impl SpanBuilder {
         self.push_decorator(Decorator::Advice(injector));
     }
 
-    /// Adds the specified decorator to the list of span decorators and returns Ok(None).
-    pub fn add_decorator(
-        &mut self,
-        decorator: Decorator,
-    ) -> Result<Option<CodeBlock>, AssemblyError> {
-        self.push_decorator(decorator);
-        Ok(None)
-    }
-
     /// Adds an AsmOp decorator to the list of span decorators.
     ///
     /// This indicates that the provided instruction should be tracked and the cycle count for

--- a/assembly/src/assembler/span_builder.rs
+++ b/assembly/src/assembler/span_builder.rs
@@ -2,7 +2,7 @@ use super::{
     AssemblyContext, AssemblyError, BodyWrapper, Borrow, CodeBlock, Decorator, DecoratorList,
     Instruction, Operation, ToString, Vec,
 };
-use vm_core::AssemblyOp;
+use vm_core::{AdviceInjector, AssemblyOp};
 
 // SPAN BUILDER
 // ================================================================================================
@@ -87,6 +87,11 @@ impl SpanBuilder {
     /// Add ths specified decorator to the list of span decorators.
     pub fn push_decorator(&mut self, decorator: Decorator) {
         self.decorators.push((self.ops.len(), decorator));
+    }
+
+    /// Adds the specified advice injector to the list of span decorators.
+    pub fn push_advice_injector(&mut self, injector: AdviceInjector) {
+        self.push_decorator(Decorator::Advice(injector));
     }
 
     /// Adds the specified decorator to the list of span decorators and returns Ok(None).

--- a/assembly/src/ast/mod.rs
+++ b/assembly/src/ast/mod.rs
@@ -15,7 +15,7 @@ use vm_core::utils::bound_into_included_u64;
 pub use super::tokens::SourceLocation;
 
 mod nodes;
-pub use nodes::{AdviceInjector, Instruction, Node};
+pub use nodes::{AdviceInjectorNode, Instruction, Node};
 
 mod code_body;
 pub use code_body::CodeBody;

--- a/assembly/src/ast/nodes/advice.rs
+++ b/assembly/src/ast/nodes/advice.rs
@@ -1,5 +1,6 @@
 use super::super::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable};
 use core::fmt;
+use vm_core::{AdviceInjector, Felt};
 
 // ADVICE INJECTORS
 // ================================================================================================
@@ -9,48 +10,92 @@ use core::fmt;
 /// These instructions can be used to perform two broad sets of operations:
 /// - Push new data onto the advice stack.
 /// - Insert new data into the advice map.
-#[derive(Clone, PartialEq, Eq, Debug)]
-pub enum AdviceInjector {
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum AdviceInjectorNode {
     PushU64div,
     PushExt2intt,
     PushSmtGet,
     PushMapVal,
+    PushMtNode,
     InsertMem,
+    InsertHdword { domain: u8 },
 }
 
-impl Serializable for AdviceInjector {
-    fn write_into<W: ByteWriter>(&self, target: &mut W) {
-        match self {
-            AdviceInjector::PushU64div => target.write_u8(0),
-            AdviceInjector::PushExt2intt => target.write_u8(3),
-            AdviceInjector::PushSmtGet => target.write_u8(4),
-            AdviceInjector::PushMapVal => target.write_u8(1),
-            AdviceInjector::InsertMem => target.write_u8(5),
+impl From<&AdviceInjectorNode> for AdviceInjector {
+    fn from(value: &AdviceInjectorNode) -> Self {
+        match value {
+            AdviceInjectorNode::PushU64div => Self::DivU64,
+            AdviceInjectorNode::PushExt2intt => Self::Ext2Intt,
+            AdviceInjectorNode::PushSmtGet => Self::SmtGet,
+            AdviceInjectorNode::PushMapVal => Self::MapValueToStack,
+            AdviceInjectorNode::PushMtNode => Self::MerkleNodeToStack,
+            AdviceInjectorNode::InsertMem => Self::MemToMap,
+            AdviceInjectorNode::InsertHdword { domain } => Self::HdwordToMap {
+                domain: Felt::from(*domain),
+            },
         }
     }
 }
 
-impl Deserializable for AdviceInjector {
-    fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
-        match source.read_u8()? {
-            0 => Ok(AdviceInjector::PushU64div),
-            3 => Ok(AdviceInjector::PushExt2intt),
-            4 => Ok(AdviceInjector::PushSmtGet),
-            1 => Ok(AdviceInjector::PushMapVal),
-            5 => Ok(AdviceInjector::InsertMem),
-            val => Err(DeserializationError::InvalidValue(val.to_string())),
-        }
-    }
-}
-
-impl fmt::Display for AdviceInjector {
+impl fmt::Display for AdviceInjectorNode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            AdviceInjector::PushU64div => write!(f, "push_u64div"),
-            AdviceInjector::PushExt2intt => write!(f, "push_ext2intt"),
-            AdviceInjector::PushSmtGet => write!(f, "push_smtget"),
-            AdviceInjector::PushMapVal => write!(f, "push_mapval"),
-            AdviceInjector::InsertMem => write!(f, "insert_mem"),
+            AdviceInjectorNode::PushU64div => write!(f, "push_u64div"),
+            AdviceInjectorNode::PushExt2intt => write!(f, "push_ext2intt"),
+            AdviceInjectorNode::PushSmtGet => write!(f, "push_smtget"),
+            AdviceInjectorNode::PushMapVal => write!(f, "push_mapval"),
+            AdviceInjectorNode::PushMtNode => write!(f, "push_mtnode"),
+            AdviceInjectorNode::InsertMem => write!(f, "insert_mem"),
+            AdviceInjectorNode::InsertHdword { domain } => match domain {
+                0 => write!(f, "insert_hdword"),
+                _ => write!(f, "insert_hdword.{domain}"),
+            },
+        }
+    }
+}
+
+// SERIALIZATION / DESERIALIZATION
+// ================================================================================================
+
+const PUSH_U64DIV: u8 = 0;
+const PUSH_EXT2INTT: u8 = 1;
+const PUSH_SMTGET: u8 = 2;
+const PUSH_MAPVAL: u8 = 3;
+const PUSH_MTNODE: u8 = 4;
+const INSERT_MEM: u8 = 5;
+const INSERT_HDWORD: u8 = 6;
+
+impl Serializable for AdviceInjectorNode {
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        match self {
+            AdviceInjectorNode::PushU64div => target.write_u8(PUSH_U64DIV),
+            AdviceInjectorNode::PushExt2intt => target.write_u8(PUSH_EXT2INTT),
+            AdviceInjectorNode::PushSmtGet => target.write_u8(PUSH_SMTGET),
+            AdviceInjectorNode::PushMapVal => target.write_u8(PUSH_MAPVAL),
+            AdviceInjectorNode::PushMtNode => target.write_u8(PUSH_MTNODE),
+            AdviceInjectorNode::InsertMem => target.write_u8(INSERT_MEM),
+            AdviceInjectorNode::InsertHdword { domain } => {
+                target.write_u8(INSERT_HDWORD);
+                target.write_u8(*domain);
+            }
+        }
+    }
+}
+
+impl Deserializable for AdviceInjectorNode {
+    fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
+        match source.read_u8()? {
+            PUSH_U64DIV => Ok(AdviceInjectorNode::PushU64div),
+            PUSH_EXT2INTT => Ok(AdviceInjectorNode::PushExt2intt),
+            PUSH_SMTGET => Ok(AdviceInjectorNode::PushSmtGet),
+            PUSH_MAPVAL => Ok(AdviceInjectorNode::PushMapVal),
+            PUSH_MTNODE => Ok(AdviceInjectorNode::PushMtNode),
+            INSERT_MEM => Ok(AdviceInjectorNode::InsertMem),
+            INSERT_HDWORD => {
+                let domain = source.read_u8()?;
+                Ok(AdviceInjectorNode::InsertHdword { domain })
+            }
+            val => Err(DeserializationError::InvalidValue(val.to_string())),
         }
     }
 }

--- a/assembly/src/ast/nodes/advice.rs
+++ b/assembly/src/ast/nodes/advice.rs
@@ -12,10 +12,9 @@ use core::fmt;
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub enum AdviceInjector {
     PushU64div,
-    PushMapVal,
-    PushExt2inv,
     PushExt2intt,
     PushSmtGet,
+    PushMapVal,
     InsertMem,
 }
 
@@ -23,10 +22,9 @@ impl Serializable for AdviceInjector {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
         match self {
             AdviceInjector::PushU64div => target.write_u8(0),
-            AdviceInjector::PushMapVal => target.write_u8(1),
-            AdviceInjector::PushExt2inv => target.write_u8(2),
             AdviceInjector::PushExt2intt => target.write_u8(3),
             AdviceInjector::PushSmtGet => target.write_u8(4),
+            AdviceInjector::PushMapVal => target.write_u8(1),
             AdviceInjector::InsertMem => target.write_u8(5),
         }
     }
@@ -36,10 +34,9 @@ impl Deserializable for AdviceInjector {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
         match source.read_u8()? {
             0 => Ok(AdviceInjector::PushU64div),
-            1 => Ok(AdviceInjector::PushMapVal),
-            2 => Ok(AdviceInjector::PushExt2inv),
             3 => Ok(AdviceInjector::PushExt2intt),
             4 => Ok(AdviceInjector::PushSmtGet),
+            1 => Ok(AdviceInjector::PushMapVal),
             5 => Ok(AdviceInjector::InsertMem),
             val => Err(DeserializationError::InvalidValue(val.to_string())),
         }
@@ -49,12 +46,11 @@ impl Deserializable for AdviceInjector {
 impl fmt::Display for AdviceInjector {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            AdviceInjector::PushU64div => write!(f, "u64div"), // push_u64div
-            AdviceInjector::PushMapVal => write!(f, "keyval"), // push_mapval
-            AdviceInjector::PushExt2inv => write!(f, "ext2inv"), // push_ext2inv
-            AdviceInjector::PushExt2intt => write!(f, "ext2intt"), // push_ext2intt
-            AdviceInjector::PushSmtGet => write!(f, "smtget"), // push_smtget
-            AdviceInjector::InsertMem => write!(f, "mem"),     // inert_mem
+            AdviceInjector::PushU64div => write!(f, "push_u64div"),
+            AdviceInjector::PushExt2intt => write!(f, "push_ext2intt"),
+            AdviceInjector::PushSmtGet => write!(f, "push_smtget"),
+            AdviceInjector::PushMapVal => write!(f, "push_mapval"),
+            AdviceInjector::InsertMem => write!(f, "insert_mem"),
         }
     }
 }

--- a/assembly/src/ast/nodes/mod.rs
+++ b/assembly/src/ast/nodes/mod.rs
@@ -2,7 +2,7 @@ use super::{CodeBody, Felt, ProcedureId, RpoDigest, Vec};
 use core::fmt;
 
 mod advice;
-pub use advice::AdviceInjector;
+pub use advice::AdviceInjectorNode;
 
 mod serde;
 
@@ -268,7 +268,7 @@ pub enum Instruction {
     AdvPush(u8),
     AdvLoadW,
 
-    AdvInject(AdviceInjector),
+    AdvInject(AdviceInjectorNode),
 
     // ----- cryptographic operations -------------------------------------------------------------
     Hash,

--- a/assembly/src/ast/nodes/serde/deserialization.rs
+++ b/assembly/src/ast/nodes/serde/deserialization.rs
@@ -1,5 +1,5 @@
 use super::{
-    super::AdviceInjector, ByteReader, CodeBody, Deserializable, DeserializationError, Felt,
+    super::AdviceInjectorNode, ByteReader, CodeBody, Deserializable, DeserializationError, Felt,
     Instruction, Node, OpCode, ProcedureId, RpoDigest, MAX_PUSH_INPUTS,
 };
 
@@ -333,7 +333,7 @@ impl Deserializable for Instruction {
             OpCode::AdvPush => Ok(Instruction::AdvPush(source.read_u8()?)),
             OpCode::AdvLoadW => Ok(Instruction::AdvLoadW),
 
-            OpCode::AdvInject => Ok(Instruction::AdvInject(AdviceInjector::read_from(source)?)),
+            OpCode::AdvInject => Ok(Instruction::AdvInject(AdviceInjectorNode::read_from(source)?)),
 
             // ----- cryptographic operations -----------------------------------------------------
             OpCode::Hash => Ok(Instruction::Hash),

--- a/assembly/src/ast/parsers/adv_ops.rs
+++ b/assembly/src/ast/parsers/adv_ops.rs
@@ -8,8 +8,7 @@ use super::{
 // INSTRUCTION PARSERS
 // ================================================================================================
 
-/// Returns `AdvU64Div`, `AdvKeyval`, `AdvMem`, `AdvExt2Inv`, `AdvExt2INTT`, or `AdvSmtGet`
-/// instruction node.
+/// Returns `AdvInject` instruction node with an appropriate internal advice injector variant.
 ///
 /// # Errors
 /// Returns an error if:
@@ -21,41 +20,35 @@ pub fn parse_adv_inject(op: &Token) -> Result<Node, ParsingError> {
     }
 
     let injector = match op.parts()[1] {
-        "u64div" => {
+        "push_u64div" => {
             if op.num_parts() > 2 {
                 return Err(ParsingError::extra_param(op));
             }
             AdvInject(PushU64div)
         }
-        "keyval" => {
-            if op.num_parts() > 2 {
-                return Err(ParsingError::extra_param(op));
-            }
-            AdvInject(PushMapVal)
-        }
-        "mem" => {
-            if op.num_parts() > 2 {
-                return Err(ParsingError::extra_param(op));
-            }
-            AdvInject(InsertMem)
-        }
-        "ext2inv" => {
-            if op.num_parts() > 2 {
-                return Err(ParsingError::extra_param(op));
-            }
-            AdvInject(PushExt2inv)
-        }
-        "ext2intt" => {
+        "push_ext2intt" => {
             if op.num_parts() > 2 {
                 return Err(ParsingError::extra_param(op));
             }
             AdvInject(PushExt2intt)
         }
-        "smtget" => {
+        "push_smtget" => {
             if op.num_parts() > 2 {
                 return Err(ParsingError::extra_param(op));
             }
             AdvInject(PushSmtGet)
+        }
+        "push_mapval" => {
+            if op.num_parts() > 2 {
+                return Err(ParsingError::extra_param(op));
+            }
+            AdvInject(PushMapVal)
+        }
+        "insert_mem" => {
+            if op.num_parts() > 2 {
+                return Err(ParsingError::extra_param(op));
+            }
+            AdvInject(InsertMem)
         }
         _ => return Err(ParsingError::invalid_op(op)),
     };

--- a/assembly/src/ast/parsers/adv_ops.rs
+++ b/assembly/src/ast/parsers/adv_ops.rs
@@ -1,5 +1,6 @@
 use super::{
-    AdviceInjector::*,
+    parse_checked_param,
+    AdviceInjectorNode::*,
     Instruction::AdvInject,
     Node::{self, Instruction},
     ParsingError, Token,
@@ -11,8 +12,8 @@ use super::{
 /// Returns `AdvInject` instruction node with an appropriate internal advice injector variant.
 ///
 /// # Errors
-/// Returns an error if:
-/// - Any of the instructions have a wrong number of parameters.
+/// Returns an error if parsing of the internal advice injector variant fails due to wrong number
+/// of parameters or invalid parameter values.
 pub fn parse_adv_inject(op: &Token) -> Result<Node, ParsingError> {
     debug_assert_eq!(op.parts()[0], "adv");
     if op.num_parts() < 2 {
@@ -20,36 +21,38 @@ pub fn parse_adv_inject(op: &Token) -> Result<Node, ParsingError> {
     }
 
     let injector = match op.parts()[1] {
-        "push_u64div" => {
-            if op.num_parts() > 2 {
-                return Err(ParsingError::extra_param(op));
+        "push_u64div" => match op.num_parts() {
+            2 => AdvInject(PushU64div),
+            _ => return Err(ParsingError::extra_param(op)),
+        },
+        "push_ext2intt" => match op.num_parts() {
+            2 => AdvInject(PushExt2intt),
+            _ => return Err(ParsingError::extra_param(op)),
+        },
+        "push_smtget" => match op.num_parts() {
+            2 => AdvInject(PushSmtGet),
+            _ => return Err(ParsingError::extra_param(op)),
+        },
+        "push_mapval" => match op.num_parts() {
+            2 => AdvInject(PushMapVal),
+            _ => return Err(ParsingError::extra_param(op)),
+        },
+        "push_mtnode" => match op.num_parts() {
+            2 => AdvInject(PushMtNode),
+            _ => return Err(ParsingError::extra_param(op)),
+        },
+        "insert_mem" => match op.num_parts() {
+            2 => AdvInject(InsertMem),
+            _ => return Err(ParsingError::extra_param(op)),
+        },
+        "insert_hdword" => match op.num_parts() {
+            2 => AdvInject(InsertHdword { domain: 0 }),
+            3 => {
+                let domain = parse_checked_param::<u8, _>(op, 2, 0..=u8::MAX)?;
+                AdvInject(InsertHdword { domain })
             }
-            AdvInject(PushU64div)
-        }
-        "push_ext2intt" => {
-            if op.num_parts() > 2 {
-                return Err(ParsingError::extra_param(op));
-            }
-            AdvInject(PushExt2intt)
-        }
-        "push_smtget" => {
-            if op.num_parts() > 2 {
-                return Err(ParsingError::extra_param(op));
-            }
-            AdvInject(PushSmtGet)
-        }
-        "push_mapval" => {
-            if op.num_parts() > 2 {
-                return Err(ParsingError::extra_param(op));
-            }
-            AdvInject(PushMapVal)
-        }
-        "insert_mem" => {
-            if op.num_parts() > 2 {
-                return Err(ParsingError::extra_param(op));
-            }
-            AdvInject(InsertMem)
-        }
+            _ => return Err(ParsingError::extra_param(op)),
+        },
         _ => return Err(ParsingError::invalid_op(op)),
     };
 

--- a/assembly/src/ast/parsers/mod.rs
+++ b/assembly/src/ast/parsers/mod.rs
@@ -1,8 +1,8 @@
 use super::{
-    bound_into_included_u64, AdviceInjector, BTreeMap, CodeBody, Deserializable, Felt, Instruction,
-    InvocationTarget, LabelError, LibraryPath, LocalConstMap, LocalProcMap, Node, ParsingError,
-    ProcedureAst, ProcedureId, RpoDigest, SliceReader, StarkField, Token, TokenStream, Vec,
-    MAX_DOCS_LEN, MAX_LABEL_LEN,
+    bound_into_included_u64, AdviceInjectorNode, BTreeMap, CodeBody, Deserializable, Felt,
+    Instruction, InvocationTarget, LabelError, LibraryPath, LocalConstMap, LocalProcMap, Node,
+    ParsingError, ProcedureAst, ProcedureId, RpoDigest, SliceReader, StarkField, Token,
+    TokenStream, Vec, MAX_DOCS_LEN, MAX_LABEL_LEN,
 };
 use core::{fmt::Display, ops::RangeBounds};
 

--- a/assembly/src/ast/tests.rs
+++ b/assembly/src/ast/tests.rs
@@ -193,7 +193,7 @@ fn test_ast_parsing_adv_ops() {
 
 #[test]
 fn test_ast_parsing_adv_injection() {
-    use super::AdviceInjector::*;
+    use super::AdviceInjectorNode::*;
     use Instruction::AdvInject;
 
     let source = "begin adv.push_u64div adv.push_mapval adv.push_smtget adv.insert_mem end";

--- a/assembly/src/ast/tests.rs
+++ b/assembly/src/ast/tests.rs
@@ -196,7 +196,7 @@ fn test_ast_parsing_adv_injection() {
     use super::AdviceInjector::*;
     use Instruction::AdvInject;
 
-    let source = "begin adv.u64div adv.keyval adv.smtget adv.mem end";
+    let source = "begin adv.push_u64div adv.push_mapval adv.push_smtget adv.insert_mem end";
     let nodes: Vec<Node> = vec![
         Node::Instruction(AdvInject(PushU64div)),
         Node::Instruction(AdvInject(PushMapVal)),

--- a/core/src/operations/decorators/advice.rs
+++ b/core/src/operations/decorators/advice.rs
@@ -16,42 +16,52 @@ pub enum AdviceInjector {
     // MERKLE STORE INJECTORS
     // --------------------------------------------------------------------------------------------
     /// Creates a new Merkle tree in the advice provider by combining Merkle trees with the
-    /// specified roots. The root of the new tree is defined as `Hash(left_root, right_root)`.
+    /// specified roots. The root of the new tree is defined as `Hash(LEFT_ROOT, RIGHT_ROOT)`.
     ///
     /// The operand stack is expected to be arranged as follows:
-    /// - root of the right tree, 4 elements.
-    /// - root of the left tree, 4 elements.
+    ///
+    /// [RIGHT_ROOT, LEFT_ROOT, ...]
     ///
     /// After the operation, both the original trees and the new tree remains in the advice
     /// provider (i.e., the input trees are not removed).
-    MerkleMerge,
+    MerkleTreeMerge,
 
     // ADVICE STACK INJECTORS
     // --------------------------------------------------------------------------------------------
     /// Pushes a node of the Merkle tree specified by the values on the top of the operand stack
-    /// onto the advice stack. The operand stack is expected to be arranged as follows (from the
-    /// top):
-    /// - depth of the node, 1 element
-    /// - index of the node, 1 element
-    /// - root of the tree, 4 elements
-    MerkleNode,
+    /// onto the advice stack.
+    ///
+    /// The operand stack is expected to be arranged as follows:
+    ///
+    /// [depth, index, TREE_ROOT, ...]
+    MerkleNodeToStack,
 
     /// Pushes a list of field elements onto the advice stack. The list is looked up in the
     /// key-value map maintained by the advice provider using the top 4 elements of the operand
     /// stack as key.
-    MapValue,
+    MapValueToStack,
 
     /// Pushes the result of [u64] division (both the quotient and the remainder) onto the advice
-    /// stack. The operand stack is expected to be arranged as follows (from the top):
+    /// stack.
+    ///
+    /// The operand stack is expected to be arranged as follows (from the top):
     /// - divisor split into two 32-bit elements
     /// - dividend split into two 32-bit elements
     ///
     /// The result is pushed onto the advice stack as follows: first the remainder is pushed,
     /// then the quotient.
-    DivResultU64,
+    DivU64,
 
-    /// Given an element of quadratic extension field, it computes multiplicative inverse and
-    /// push the result into the advice stack.
+    /// Given an element in a quadratic extension field on the top of the stack (i.e., a0, b1),
+    /// computes its multiplicative inverse and push the result onto the advice stack.
+    ///
+    /// The operand stack is expected to be arranged as follows:
+    ///
+    /// [a1, a0, ...]
+    ///
+    /// The result (i.e., b0, b1) is pushed onto the advice stack as follows: first b1 is pushed,
+    /// then b0 is pushed. Thus, when the VM reads data from the advice stack, it will first read
+    /// b0, and then b1.
     Ext2Inv,
 
     /// Given evaluations of a polynomial over some specified domain, this routine interpolates
@@ -59,18 +69,32 @@ pub enum AdviceInjector {
     /// stack.
     ///
     /// The interpolation is performed using the iNTT algorithm. The evaluations are expected to be
-    /// in the quadratic extension field of the VM's base field.
-    Ext2INTT,
+    /// in the quadratic extension.
+    ///
+    /// The operand stack is expected to be arranged as follows:
+    ///
+    /// [output_size, input_size, input_start_ptr, ...]
+    ///
+    /// - `input_size` is the number of evaluations (each evaluation is 2 base field elements).
+    ///   Must be a power of 2 and greater 1.
+    /// - `output_size` is the number of coefficients in the interpolated polynomial (each
+    ///   coefficient is 2 base field elements). Must be smaller than or equal to the number of
+    ///   input evaluations.
+    /// - Memory address of the first evaluation.
+    ///
+    /// The result is pushed onto the advice stack such that the high-degree coefficients are
+    /// pushed first, and the zero-degree coefficient is pushed last.
+    Ext2Intt,
 
-    /// Pushes the value and depth flags of a leaf indexed by `key` on a Sparse Merkle tree with
-    /// the provided `root`.
+    /// Pushes the value and depth flags of a leaf indexed by `KEY` on a Sparse Merkle tree with
+    /// the provided `ROOT`.
     ///
     /// The Sparse Merkle tree is tiered, meaning it will have leaf depths in `{16, 32, 48, 64}`.
     /// The depth flags define the tier on which the leaf is located.
     ///
-    /// The operand stack is expected to be arranged as follows (from the top):
-    /// - key, 4 elements.
-    /// - root of the Sparse Merkle tree, 4 elements.
+    /// The operand stack is expected to be arranged as follows:
+    ///
+    /// [KEY, ROOT, ...]
     ///
     /// After a successful operation, the advice stack will look as follows:
     /// - boolean flag set to `1` if the depth is `16` or `48`.
@@ -85,21 +109,23 @@ pub enum AdviceInjector {
     /// Reads words from memory range `start_addr .. end_addr` and insert into the advice map
     /// under the key `KEY`.
     ///
-    /// Expects the operand stack to be [KEY, start_addr, end_addr, ...].
-    Memory,
+    /// The operand stack is expected to be arranged as follows:
+    ///
+    /// [KEY, start_addr, end_addr, ...]
+    MemToMap,
 }
 
 impl fmt::Display for AdviceInjector {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::MerkleMerge => write!(f, "merkle_merge"),
-            Self::MerkleNode => write!(f, "merkle_node"),
-            Self::DivResultU64 => write!(f, "div_result_u64"),
-            Self::MapValue => write!(f, "map_value"),
+            Self::MerkleTreeMerge => write!(f, "merkle_tree_merge"),
+            Self::MerkleNodeToStack => write!(f, "merkle_node_to_stack"),
+            Self::MapValueToStack => write!(f, "map_value_to_stack"),
+            Self::DivU64 => write!(f, "div_u64"),
             Self::Ext2Inv => write!(f, "ext2_inv"),
-            Self::Ext2INTT => write!(f, "ext2_intt"),
+            Self::Ext2Intt => write!(f, "ext2_intt"),
             Self::SmtGet => write!(f, "smt_get"),
-            Self::Memory => write!(f, "mem"),
+            Self::MemToMap => write!(f, "mem_to_map"),
         }
     }
 }

--- a/docs/src/user_docs/assembly/io_operations.md
+++ b/docs/src/user_docs/assembly/io_operations.md
@@ -38,7 +38,7 @@ In both case the values must still encode valid field elements.
 | adv_push.*n* <br> - *(n cycles)*   | [ ... ]         | [a, ... ]    | $a \leftarrow stack.pop()$ <br> Pops $n$ values from the advice stack and pushes them onto the operand stack. Valid for $n \in \{1, ..., 16\}$. <br> Fails if the advice stack has fewer than $n$ values. |
 | adv_loadw <br> - *(1 cycle)*     | [0, 0, 0, 0, ... ] | [A, ... ] | $A \leftarrow stack.pop(4)$ <br> Pop the next word (4 elements) from the advice stack and overwrites the first word of the operand stack (4 elements) with them. <br> Fails if the advice stack has fewer than $4$ values. |
 | adv_pipe <br> - *(1 cycle)*     | [C, B, A, a, ... ] | [E, D, A, a', ... ] | $[D, E] \leftarrow [adv_stack.pop(4), adv_stack.pop(4)]$ <br> $a' \leftarrow a + 2$ <br> Pops the next two words from the advice stack, overwrites the top of the operand stack with them and also writes these words into memory at address $a$ and $a + 1$.<br> Fails if the advice stack has fewer than $8$ values. |
-| adv.mem <br> - *(0 cycles)*     | [W, b, a, ... ] | [W, b, a, ... ] | Reads words $data \leftarrow mem[b] .. mem[b + a]$ from memory, and save the data $advice_map[W] \leftarrow data$. |
+| adv.insert_mem <br> - *(0 cycles)*     | [W, b, a, ... ] | [W, b, a, ... ] | Reads words $data \leftarrow mem[b] .. mem[b + a]$ from memory, and save the data $advice_map[W] \leftarrow data$. |
 
 > **Note**: The opcodes above always push data onto the operand stack so that the first element is placed deepest in the stack. For example, if the data on the stack is `a,b,c,d` and you use the opcode `adv_push.4`, the data will be `d,c,b,a` on your stack. This is also the behavior of the other opcodes.
 

--- a/miden/tests/integration/operations/decorators/advice.rs
+++ b/miden/tests/integration/operations/decorators/advice.rs
@@ -6,7 +6,7 @@ use test_utils::{build_test, rand::rand_value};
 #[test]
 fn advice_inject_u64div() {
     // push a/b onto the advice stack and then move these values onto the operand stack.
-    let source = "begin adv.u64div adv_push.4 end";
+    let source = "begin adv.push_u64div adv_push.4 end";
 
     // get two random 64-bit integers and split them into 32-bit limbs
     let a = rand_value::<u64>();
@@ -42,7 +42,7 @@ fn advice_inject_u64div_repeat() {
     // Finally the first 2 elements of the stack are removed
     let source = "begin
         repeat.7
-            adv.u64div
+            adv.push_u64div
             drop drop
             adv_push.2
             push.2
@@ -78,7 +78,7 @@ fn advice_inject_u64div_repeat() {
 #[test]
 fn advice_inject_u64div_local_procedure() {
     // push a/b onto the advice stack and then move these values onto the operand stack.
-    let source = "proc.foo adv.u64div adv_push.4 end begin exec.foo end";
+    let source = "proc.foo adv.push_u64div adv_push.4 end begin exec.foo end";
 
     // get two random 64-bit integers and split them into 32-bit limbs
     let a = rand_value::<u64>();
@@ -106,7 +106,7 @@ fn advice_inject_u64div_local_procedure() {
 
 #[test]
 fn advice_inject_u64div_conditional_execution() {
-    let source = "begin eq if.true adv.u64div adv_push.4 else padw end end";
+    let source = "begin eq if.true adv.push_u64div adv_push.4 else padw end end";
 
     // if branch
     let test = build_test!(source, &[8, 0, 4, 0, 1, 1]);
@@ -134,12 +134,12 @@ fn advice_inject_mem() {
     # the key used is in the reverse order of the field elements in the word at the top of the
     # stack.
     push.2.4 movdn.4 movdn.4
-    adv.mem
+    adv.insert_mem
     # State Transition:
     # advice_map: k: [8, 7, 6, 5], v: [4, 3, 2, 1, 8, 7, 6, 5]
 
     # copy from advice map to advice stack
-    adv.keyval dropw
+    adv.push_mapval dropw
     # State Transition:
     # stack: [0, 0, 0, 0]
     # advice_stack: [4, 3, 2, 1, 8, 7, 6, 5]

--- a/miden/tests/integration/operations/io_ops/mem_ops.rs
+++ b/miden/tests/integration/operations/io_ops/mem_ops.rs
@@ -28,10 +28,10 @@ fn mem_load() {
 #[test]
 fn mem_store() {
     let asm_op = "mem_store";
-    let addr = 0;
+    let addr = 0_u32;
 
     // --- address provided via the stack ---------------------------------------------------------
-    let test = build_op_test!(asm_op, &[1, 2, 3, 4, addr]);
+    let test = build_op_test!(asm_op, &[1, 2, 3, 4, addr as u64]);
     test.expect_stack_and_memory(&[3, 2, 1], addr, &[4, 0, 0, 0]);
 
     // --- address provided as a parameter --------------------------------------------------------
@@ -70,10 +70,10 @@ fn mem_loadw() {
 #[test]
 fn mem_storew() {
     let asm_op = "mem_storew";
-    let addr = 0;
+    let addr = 0_u32;
 
     // --- address provided via the stack ---------------------------------------------------------
-    let test = build_op_test!(asm_op, &[1, 2, 3, 4, addr]);
+    let test = build_op_test!(asm_op, &[1, 2, 3, 4, addr as u64]);
     test.expect_stack_and_memory(&[4, 3, 2, 1], addr, &[1, 2, 3, 4]);
 
     // --- address provided as a parameter --------------------------------------------------------

--- a/processor/src/advice/mem_provider.rs
+++ b/processor/src/advice/mem_provider.rs
@@ -93,7 +93,7 @@ impl AdviceProvider for MemAdviceProvider {
         index: &Felt,
     ) -> Result<Word, ExecutionError> {
         let index = NodeIndex::from_elements(depth, index).map_err(|_| {
-            ExecutionError::InvalidNodeIndex {
+            ExecutionError::InvalidTreeNodeIndex {
                 depth: *depth,
                 value: *index,
             }
@@ -110,7 +110,7 @@ impl AdviceProvider for MemAdviceProvider {
         index: &Felt,
     ) -> Result<MerklePath, ExecutionError> {
         let index = NodeIndex::from_elements(depth, index).map_err(|_| {
-            ExecutionError::InvalidNodeIndex {
+            ExecutionError::InvalidTreeNodeIndex {
                 depth: *depth,
                 value: *index,
             }
@@ -142,7 +142,7 @@ impl AdviceProvider for MemAdviceProvider {
         value: Word,
     ) -> Result<MerklePath, ExecutionError> {
         let node_index = NodeIndex::from_elements(depth, index).map_err(|_| {
-            ExecutionError::InvalidNodeIndex {
+            ExecutionError::InvalidTreeNodeIndex {
                 depth: *depth,
                 value: *index,
             }

--- a/processor/src/advice/mod.rs
+++ b/processor/src/advice/mod.rs
@@ -83,6 +83,9 @@ pub trait AdviceProvider {
     fn pop_stack_dword(&mut self) -> Result<[Word; 2], ExecutionError>;
 
     /// Pushes the value(s) specified by the source onto the advice stack.
+    ///
+    /// # Errors
+    /// Returns an error if the value specified by the advice source cannot be obtained.
     fn push_stack(&mut self, source: AdviceSource) -> Result<(), ExecutionError>;
 
     /// Inserts the provided value into the advice map under the specified key.
@@ -90,8 +93,8 @@ pub trait AdviceProvider {
     /// The values in the advice map can be moved onto the advice stack by invoking
     /// [AdviceProvider::push_stack()] method.
     ///
-    /// # Errors
-    /// Returns an error if the key is already present in the advice map.
+    /// If the specified key is already present in the advice map, the values under the key
+    /// are replaced with the specified values.
     fn insert_into_map(&mut self, key: Word, values: Vec<Felt>) -> Result<(), ExecutionError>;
 
     // ADVISE SETS

--- a/processor/src/chiplets/mod.rs
+++ b/processor/src/chiplets/mod.rs
@@ -428,8 +428,8 @@ impl Chiplets {
     ///
     /// Unlike mem_read() which modifies the memory access trace, this method returns the value at
     /// the specified address (if one exists) without altering the memory access trace.
-    pub fn get_mem_value(&self, ctx: u32, addr: u64) -> Option<Word> {
-        self.memory.get_value(ctx, addr)
+    pub fn get_mem_value(&self, ctx: u32, addr: u32) -> Option<Word> {
+        self.memory.get_value(ctx, addr as u64)
     }
 
     /// Returns the entire memory state for the specified execution context at the specified cycle.

--- a/processor/src/decorators/adv_map_injectors.rs
+++ b/processor/src/decorators/adv_map_injectors.rs
@@ -1,0 +1,58 @@
+use super::{AdviceProvider, ExecutionError, Process};
+use vm_core::{StarkField, WORD_SIZE, ZERO};
+
+// ADVICE INJECTORS
+// ================================================================================================
+
+impl<A> Process<A>
+where
+    A: AdviceProvider,
+{
+    /// Reads the specified number of words from the memory starting at the given start address and
+    /// writes the vector of field elements to the advice map with the top 4 elements on the stack
+    /// as the key. This operation does not affect the state of the Memory chiplet and the VM in
+    /// general.
+    ///
+    /// # Errors
+    /// Returns an error if the key is already present in the advice map.
+    pub(super) fn inject_mem_values(&mut self) -> Result<(), ExecutionError> {
+        let (start_addr, end_addr) = self.get_mem_addr_range();
+        let len = end_addr - start_addr;
+        let ctx = self.system.ctx();
+        let mut values = Vec::with_capacity((len as usize) * WORD_SIZE);
+        for i in 0u64..len {
+            let mem_value =
+                self.chiplets.get_mem_value(ctx, start_addr + i).unwrap_or([ZERO; WORD_SIZE]);
+            values.extend_from_slice(&mem_value);
+        }
+        let top_word = self.stack.get_word(0);
+        self.advice_provider.insert_into_map(top_word, values)?;
+
+        Ok(())
+    }
+
+    //pub(super) fn inject_stack_dword(&mut self, domain: Felt) -> Result<(), ExecutionError> {
+    //    // get the top two words from the stack and hash them to compute the key value
+    //    let word1 = self.stack.get_word(1);
+    //    let word2 = self.stack.get_word(0);
+    //    let key = Rpo256::merge_in_domain(&[word1.into(), word2.into()], domain);
+
+    //    // build a vector of values from the two word and insert into the advice map under the
+    //    // computed key
+    //    let mut values = Vec::with_capacity(2 * WORD_SIZE);
+    //    values.extend_from_slice(&word1);
+    //    values.extend_from_slice(&word2);
+    //    self.advice_provider.insert_into_map(key.into(), values)
+    //}
+
+    // HELPER METHODS
+    // --------------------------------------------------------------------------------------------
+
+    ///
+    fn get_mem_addr_range(&self) -> (u64, u64) {
+        let start_addr = self.stack.get(4).as_int();
+        let end_addr = self.stack.get(5).as_int();
+
+        (start_addr, end_addr)
+    }
+}

--- a/processor/src/decorators/adv_map_injectors.rs
+++ b/processor/src/decorators/adv_map_injectors.rs
@@ -1,5 +1,5 @@
 use super::{AdviceProvider, ExecutionError, Process};
-use vm_core::{utils::collections::Vec, StarkField, WORD_SIZE, ZERO};
+use vm_core::{crypto::hash::Rpo256, utils::collections::Vec, Felt, StarkField, WORD_SIZE, ZERO};
 
 // ADVICE INJECTORS
 // ================================================================================================
@@ -8,12 +8,18 @@ impl<A> Process<A>
 where
     A: AdviceProvider,
 {
-    /// Inserts values from memory between the specified start and end addresses into the advice
-    /// map using the word at the top of the stack as the key.
+    /// Reads words from memory at the specified range and inserts them into the advice map under
+    /// the key `KEY` located at the top of the stack.
     ///
-    /// The operand stack is expected to be arranged as follows:
+    /// Inputs:
+    ///   Operand stack: [KEY, start_addr, end_addr, ...]
+    ///   Advice map: {...}
     ///
-    /// [KEY, start_addr, end_addr, ...]
+    /// Outputs:
+    ///   Operand stack: [KEY, start_addr, end_addr, ...]
+    ///   Advice map: {KEY: values}
+    ///
+    /// Where `values` are the elements located in memory[start_addr..end_addr].
     ///
     /// # Errors
     /// Returns an error:
@@ -36,19 +42,35 @@ where
         Ok(())
     }
 
-    //pub(super) fn inject_stack_dword(&mut self, domain: Felt) -> Result<(), ExecutionError> {
-    //    // get the top two words from the stack and hash them to compute the key value
-    //    let word1 = self.stack.get_word(1);
-    //    let word2 = self.stack.get_word(0);
-    //    let key = Rpo256::merge_in_domain(&[word1.into(), word2.into()], domain);
+    /// Reads two word from the operand stack and inserts them into the advice map under the key
+    /// defined by the hash of these words.
+    ///
+    /// Inputs:
+    ///   Operand stack: [B, A, ...]
+    ///   Advice map: {...}
+    ///
+    /// Outputs:
+    ///   Operand stack: [B, A, ...]
+    ///   Advice map: {KEY: [a0, a1, a2, a3, b0, b1, b2, b3]}
+    ///
+    /// Where KEY is computed as hash(A || B, domain), where domain is provided via the immediate
+    /// value.
+    pub(super) fn insert_hdword_into_adv_map(
+        &mut self,
+        domain: Felt,
+    ) -> Result<(), ExecutionError> {
+        // get the top two words from the stack and hash them to compute the key value
+        let word0 = self.stack.get_word(0);
+        let word1 = self.stack.get_word(1);
+        let key = Rpo256::merge_in_domain(&[word1.into(), word0.into()], domain);
 
-    //    // build a vector of values from the two word and insert into the advice map under the
-    //    // computed key
-    //    let mut values = Vec::with_capacity(2 * WORD_SIZE);
-    //    values.extend_from_slice(&word1);
-    //    values.extend_from_slice(&word2);
-    //    self.advice_provider.insert_into_map(key.into(), values)
-    //}
+        // build a vector of values from the two word and insert it into the advice map under the
+        // computed key
+        let mut values = Vec::with_capacity(2 * WORD_SIZE);
+        values.extend_from_slice(&word1);
+        values.extend_from_slice(&word0);
+        self.advice_provider.insert_into_map(key.into(), values)
+    }
 
     // HELPER METHODS
     // --------------------------------------------------------------------------------------------

--- a/processor/src/decorators/adv_stack_injectors.rs
+++ b/processor/src/decorators/adv_stack_injectors.rs
@@ -1,0 +1,287 @@
+use super::{AdviceProvider, AdviceSource, ExecutionError, Process};
+use vm_core::{
+    crypto::merkle::EmptySubtreeRoots, utils::collections::Vec, Felt, FieldElement, QuadExtension,
+    StarkField, Word, ONE, ZERO,
+};
+use winter_prover::math::fft;
+
+// TYPE ALIASES
+// ================================================================================================
+type QuadFelt = QuadExtension<Felt>;
+
+// CONSTANTS
+// ================================================================================================
+
+/// Maximum depth of a Sparse Merkle tree
+const SMT_MAX_TREE_DEPTH: Felt = Felt::new(64);
+
+/// Lookup table for Sparse Merkle tree depth normalization
+const SMT_NORMALIZED_DEPTHS: [u8; 65] = [
+    16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 32, 32, 32, 32, 32, 32, 32,
+    32, 32, 32, 32, 32, 32, 32, 32, 32, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48,
+    48, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+];
+
+// ADVICE INJECTORS
+// ================================================================================================
+
+impl<A> Process<A>
+where
+    A: AdviceProvider,
+{
+    /// Pushes a node of the Merkle tree specified by the word on the top of the operand stack onto
+    /// the advice stack. The operand stack is expected to be arranged as follows (from the top):
+    /// - depth of the node, 1 element
+    /// - index of the node, 1 element
+    /// - root of the tree, 4 elements
+    ///
+    /// # Errors
+    /// Returns an error if:
+    /// - Merkle tree for the specified root cannot be found in the advice provider.
+    /// - The specified depth is either zero or greater than the depth of the Merkle tree
+    ///   identified by the specified root.
+    /// - Value of the node at the specified depth and index is not known to the advice provider.
+    pub(super) fn inject_merkle_node(&mut self) -> Result<(), ExecutionError> {
+        // read node depth, node index, and tree root from the stack
+        let depth = self.stack.get(0);
+        let index = self.stack.get(1);
+        let root = [self.stack.get(5), self.stack.get(4), self.stack.get(3), self.stack.get(2)];
+
+        // look up the node in the advice provider
+        let node = self.advice_provider.get_tree_node(root, &depth, &index)?;
+
+        // push the node onto the advice stack with the first element pushed last so that it can
+        // be popped first (i.e. stack behavior for word)
+        self.advice_provider.push_stack(AdviceSource::Value(node[3]))?;
+        self.advice_provider.push_stack(AdviceSource::Value(node[2]))?;
+        self.advice_provider.push_stack(AdviceSource::Value(node[1]))?;
+        self.advice_provider.push_stack(AdviceSource::Value(node[0]))?;
+
+        Ok(())
+    }
+
+    /// Pushes the result of [u64] division (both the quotient and the remainder) onto the advice
+    /// stack. The operand stack is expected to be arranged as follows (from the top):
+    /// - divisor split into two 32-bit elements
+    /// - dividend split into two 32-bit elements
+    ///
+    /// The result is pushed onto the advice stack as follows: the remainder is pushed first, then
+    /// the quotient is pushed. This guarantees that when popping values from the advice stack, the
+    /// quotient will be returned first, and the remainder will be returned next.
+    ///
+    /// # Errors
+    /// Returns an error if the divisor is ZERO.
+    pub(super) fn inject_div_result_u64(&mut self) -> Result<(), ExecutionError> {
+        let divisor_hi = self.stack.get(0).as_int();
+        let divisor_lo = self.stack.get(1).as_int();
+        let divisor = (divisor_hi << 32) + divisor_lo;
+
+        if divisor == 0 {
+            return Err(ExecutionError::DivideByZero(self.system.clk()));
+        }
+
+        let dividend_hi = self.stack.get(2).as_int();
+        let dividend_lo = self.stack.get(3).as_int();
+        let dividend = (dividend_hi << 32) + dividend_lo;
+
+        let quotient = dividend / divisor;
+        let remainder = dividend - quotient * divisor;
+
+        let (q_hi, q_lo) = u64_to_u32_elements(quotient);
+        let (r_hi, r_lo) = u64_to_u32_elements(remainder);
+
+        self.advice_provider.push_stack(AdviceSource::Value(r_hi))?;
+        self.advice_provider.push_stack(AdviceSource::Value(r_lo))?;
+        self.advice_provider.push_stack(AdviceSource::Value(q_hi))?;
+        self.advice_provider.push_stack(AdviceSource::Value(q_lo))?;
+
+        Ok(())
+    }
+
+    /// Pushes a list of field elements onto the advice stack. The list is looked up in the advice
+    /// map using the top 4 elements (i.e. word) from the operand stack as the key.
+    ///
+    /// # Errors
+    /// Returns an error if the required key was not found in the key-value map.
+    pub(super) fn inject_map_value(&mut self) -> Result<(), ExecutionError> {
+        let top_word = self.stack.get_word(0);
+        self.advice_provider.push_stack(AdviceSource::Map { key: top_word })?;
+
+        Ok(())
+    }
+
+    /// Given a quadratic extension field element ( say a ) on stack top, this routine computes
+    /// multiplicative inverse of that element ( say b ) s.t.
+    ///
+    /// a * b = 1 ( mod P ) | b = a ^ -1, P = irreducible polynomial x^2 - x + 2 over F_q, q = 2^64 - 2^32 + 1
+    ///
+    /// Input on stack expected in following order
+    ///
+    /// [coeff_1, coeff_0, ...]
+    ///
+    /// While computed multiplicative inverse is put on advice provider in following order
+    ///
+    /// [coeff'_0, coeff'_1, ...]
+    ///
+    /// Meaning when a Miden program is going to read it from advice stack, it'll see
+    /// coefficient_0 first and then coefficient_1.
+    ///
+    /// Note, in case input operand is zero, division by zero error is returned, because
+    /// that's a non-invertible element of extension field.
+    pub(super) fn inject_ext2_inv_result(&mut self) -> Result<(), ExecutionError> {
+        let coef0 = self.stack.get(1);
+        let coef1 = self.stack.get(0);
+
+        let elm = QuadFelt::new(coef0, coef1);
+        if elm == QuadFelt::ZERO {
+            return Err(ExecutionError::DivideByZero(self.system.clk()));
+        }
+        let coeffs = elm.inv().to_base_elements();
+
+        self.advice_provider.push_stack(AdviceSource::Value(coeffs[1]))?;
+        self.advice_provider.push_stack(AdviceSource::Value(coeffs[0]))?;
+
+        Ok(())
+    }
+
+    /// Given evaluations of a polynomial over some specified domain, this routine interpolates the
+    /// evaluations into a polynomial in coefficient form, and pushes the results onto the advice
+    /// stack.
+    ///
+    /// The interpolation is performed using the iNTT algorithm. The evaluations are expected to be
+    /// in the quadratic extension field | q = 2^64 - 2^32 + 1.
+    ///
+    /// Input stack state should look like
+    ///
+    /// `[output_poly_len, input_eval_len, input_eval_begin_address, ...]`
+    ///
+    /// - `input_eval_len` must be a power of 2 and > 1.
+    /// - `output_poly_len <= input_eval_len`
+    /// - Only starting memory address of evaluations ( of length `input_eval_len` ) is
+    /// provided on the stack, consecutive memory addresses are expected to be holding
+    /// remaining `input_eval_len - 2` many evaluations.
+    /// - Each memory address holds two evaluations of the polynomial at adjacent points
+    ///
+    /// Final advice stack should look like
+    ///
+    /// `[coeff_0, coeff_1, ..., coeff_{n-1}, ...]` | n = output_poly_len
+    ///
+    /// Program which is requesting this non-deterministic computation should read `coeff0`
+    /// first i.e. `coeff{n-1}` should be seen at the very end.
+    pub(super) fn inject_ext2_intt_result(&mut self) -> Result<(), ExecutionError> {
+        let out_poly_len = self.stack.get(0).as_int() as usize;
+        let in_evaluations_len = self.stack.get(1).as_int() as usize;
+        let in_evaluations_addr = self.stack.get(2).as_int();
+
+        if in_evaluations_len <= 1 {
+            return Err(ExecutionError::NttDomainSizeTooSmall(in_evaluations_len as u64));
+        }
+        if !in_evaluations_len.is_power_of_two() {
+            return Err(ExecutionError::NttDomainSizeNotPowerOf2(in_evaluations_len as u64));
+        }
+        if out_poly_len > in_evaluations_len {
+            return Err(ExecutionError::InterpolationResultSizeTooBig(
+                out_poly_len,
+                in_evaluations_len,
+            ));
+        }
+
+        let mut poly = Vec::with_capacity(in_evaluations_len);
+        for i in 0..(in_evaluations_len >> 1) {
+            let word = self
+                .get_memory_value(self.system.ctx(), in_evaluations_addr + i as u64)
+                .ok_or_else(|| {
+                    ExecutionError::UninitializedMemoryAddress(in_evaluations_addr + i as u64)
+                })?;
+
+            poly.push(QuadFelt::new(word[0], word[1]));
+            poly.push(QuadFelt::new(word[2], word[3]));
+        }
+
+        let twiddles = fft::get_inv_twiddles::<Felt>(in_evaluations_len);
+        fft::interpolate_poly::<Felt, QuadFelt>(&mut poly, &twiddles);
+
+        for i in QuadFelt::slice_as_base_elements(&poly[..out_poly_len]).iter().rev().copied() {
+            self.advice_provider.push_stack(AdviceSource::Value(i))?;
+        }
+
+        Ok(())
+    }
+
+    /// Pushes the value and depth flags of a leaf indexed by `key` on a Sparse Merkle tree with
+    /// the provided `root`.
+    ///
+    /// The Sparse Merkle tree is tiered, meaning it will have leaf depths in `{16, 32, 48, 64}`.
+    /// The depth flags define the tier on which the leaf is located.
+    ///
+    /// The operand stack is expected to be arranged as follows:
+    /// - key, 4 elements.
+    /// - root of the Sparse Merkle tree, 4 elements.
+    ///
+    /// After a successful operation, the advice stack will look as follows (from the top):
+    /// - boolean flag set to `1` if the depth is `16` or `48`.
+    /// - boolean flag set to `1` if the depth is `16` or `32`.
+    /// - remaining key word; will be zeroed if the tree don't contain a mapped value for the key.
+    /// - value word; will be zeroed if the tree don't contain a mapped value for the key.
+    /// - boolean flag set to `1` if a remaining key is not zero.
+    ///
+    /// # Errors
+    /// Will return an error if:
+    /// - The provided Merkle root doesn't exist on the advice provider
+    ///
+    /// # Panics
+    /// Will panic as unimplemented if the target depth is `64`.
+    pub(super) fn inject_smtget(&mut self) -> Result<(), ExecutionError> {
+        // fetch the arguments from the operand stack
+        let key = [self.stack.get(3), self.stack.get(2), self.stack.get(1), self.stack.get(0)];
+        let root = [self.stack.get(7), self.stack.get(6), self.stack.get(5), self.stack.get(4)];
+
+        let index = &key[3];
+        let depth = self.advice_provider.get_leaf_depth(root, &SMT_MAX_TREE_DEPTH, index)?;
+        debug_assert!(depth < 65);
+
+        // normalize the depth into one of the tiers. this is not a simple `next_power_of_two`
+        // because of `48`. using a lookup table is far more efficient than if/else if/else.
+        let depth = SMT_NORMALIZED_DEPTHS[depth as usize];
+        if depth == 64 {
+            unimplemented!("the functionality is unimplemented for depth 64 as the bottom tier will have a special treatment to embed multiple key/value pairs onto a single node");
+        }
+
+        // fetch the node value
+        let index = index.as_int() >> (64 - depth);
+        let index = Felt::new(index);
+        let node = self.advice_provider.get_tree_node(root, &Felt::new(depth as u64), &index)?;
+
+        // set the node value; zeroed if empty sub-tree
+        let empty = EmptySubtreeRoots::empty_hashes(64);
+        if Word::from(empty[depth as usize]) == node {
+            // push zeroes for remaining key, value & empty remaining key flag
+            for _ in 0..9 {
+                self.advice_provider.push_stack(AdviceSource::Value(ZERO))?;
+            }
+        } else {
+            // push a flag indicating that a remaining key exists
+            self.advice_provider.push_stack(AdviceSource::Value(ONE))?;
+
+            // map is expected to contain `node |-> {K', V}`
+            self.advice_provider.push_stack(AdviceSource::Map { key: node })?;
+        }
+
+        // set the flags
+        let is_16_or_32 = if depth == 16 || depth == 32 { ONE } else { ZERO };
+        let is_16_or_48 = if depth == 16 || depth == 48 { ONE } else { ZERO };
+        self.advice_provider.push_stack(AdviceSource::Value(is_16_or_32))?;
+        self.advice_provider.push_stack(AdviceSource::Value(is_16_or_48))?;
+
+        Ok(())
+    }
+}
+
+// HELPER FUNCTIONS
+// ================================================================================================
+
+fn u64_to_u32_elements(value: u64) -> (Felt, Felt) {
+    let hi = Felt::new(value >> 32);
+    let lo = Felt::new((value as u32) as u64);
+    (hi, lo)
+}

--- a/processor/src/decorators/adv_stack_injectors.rs
+++ b/processor/src/decorators/adv_stack_injectors.rs
@@ -1,4 +1,4 @@
-use super::{AdviceProvider, AdviceSource, ExecutionError, Process};
+use super::{super::Ext2InttError, AdviceProvider, AdviceSource, ExecutionError, Process};
 use vm_core::{
     crypto::merkle::EmptySubtreeRoots, utils::collections::Vec, Felt, FieldElement, QuadExtension,
     StarkField, Word, ONE, ZERO,
@@ -30,10 +30,11 @@ where
     A: AdviceProvider,
 {
     /// Pushes a node of the Merkle tree specified by the word on the top of the operand stack onto
-    /// the advice stack. The operand stack is expected to be arranged as follows (from the top):
-    /// - depth of the node, 1 element
-    /// - index of the node, 1 element
-    /// - root of the tree, 4 elements
+    /// the advice stack.
+    ///
+    /// The operand stack is expected to be arranged as follows:
+    ///
+    /// [depth, index, TREE_ROOT, ...]
     ///
     /// # Errors
     /// Returns an error if:
@@ -41,7 +42,7 @@ where
     /// - The specified depth is either zero or greater than the depth of the Merkle tree
     ///   identified by the specified root.
     /// - Value of the node at the specified depth and index is not known to the advice provider.
-    pub(super) fn inject_merkle_node(&mut self) -> Result<(), ExecutionError> {
+    pub(super) fn copy_merkle_node_to_adv_stack(&mut self) -> Result<(), ExecutionError> {
         // read node depth, node index, and tree root from the stack
         let depth = self.stack.get(0);
         let index = self.stack.get(1);
@@ -60,8 +61,20 @@ where
         Ok(())
     }
 
+    /// Pushes a list of field elements onto the advice stack. The list is looked up in the advice
+    /// map using the top 4 elements (i.e. word) from the operand stack as the key.
+    ///
+    /// # Errors
+    /// Returns an error if the required key was not found in the key-value map.
+    pub(super) fn copy_map_value_to_adv_stack(&mut self) -> Result<(), ExecutionError> {
+        let key = self.stack.get_word(0);
+        self.advice_provider.push_stack(AdviceSource::Map { key })
+    }
+
     /// Pushes the result of [u64] division (both the quotient and the remainder) onto the advice
-    /// stack. The operand stack is expected to be arranged as follows (from the top):
+    /// stack.
+    ///
+    /// The operand stack is expected to be arranged as follows (from the top):
     /// - divisor split into two 32-bit elements
     /// - dividend split into two 32-bit elements
     ///
@@ -71,7 +84,7 @@ where
     ///
     /// # Errors
     /// Returns an error if the divisor is ZERO.
-    pub(super) fn inject_div_result_u64(&mut self) -> Result<(), ExecutionError> {
+    pub(super) fn push_u64_div_result(&mut self) -> Result<(), ExecutionError> {
         let divisor_hi = self.stack.get(0).as_int();
         let divisor_lo = self.stack.get(1).as_int();
         let divisor = (divisor_hi << 32) + divisor_lo;
@@ -98,48 +111,31 @@ where
         Ok(())
     }
 
-    /// Pushes a list of field elements onto the advice stack. The list is looked up in the advice
-    /// map using the top 4 elements (i.e. word) from the operand stack as the key.
+    /// Given an element in a quadratic extension field on the top of the stack (i.e., a0, b1),
+    /// computes its multiplicative inverse and push the result onto the advice stack.
+    ///
+    /// The operand stack is expected to be arranged as follows:
+    ///
+    /// [a1, a0, ...]
+    ///
+    /// The result (i.e., b0, b1) is pushed onto the advice stack as follows: first b1 is pushed,
+    /// then b0 is pushed. Thus, when the VM reads data from the advice stack, it will first read
+    /// b0, and then b1.
     ///
     /// # Errors
-    /// Returns an error if the required key was not found in the key-value map.
-    pub(super) fn inject_map_value(&mut self) -> Result<(), ExecutionError> {
-        let top_word = self.stack.get_word(0);
-        self.advice_provider.push_stack(AdviceSource::Map { key: top_word })?;
-
-        Ok(())
-    }
-
-    /// Given a quadratic extension field element ( say a ) on stack top, this routine computes
-    /// multiplicative inverse of that element ( say b ) s.t.
-    ///
-    /// a * b = 1 ( mod P ) | b = a ^ -1, P = irreducible polynomial x^2 - x + 2 over F_q, q = 2^64 - 2^32 + 1
-    ///
-    /// Input on stack expected in following order
-    ///
-    /// [coeff_1, coeff_0, ...]
-    ///
-    /// While computed multiplicative inverse is put on advice provider in following order
-    ///
-    /// [coeff'_0, coeff'_1, ...]
-    ///
-    /// Meaning when a Miden program is going to read it from advice stack, it'll see
-    /// coefficient_0 first and then coefficient_1.
-    ///
-    /// Note, in case input operand is zero, division by zero error is returned, because
-    /// that's a non-invertible element of extension field.
-    pub(super) fn inject_ext2_inv_result(&mut self) -> Result<(), ExecutionError> {
+    /// Returns an error if the input is a zero element in the extension field.
+    pub(super) fn push_ext2_inv_result(&mut self) -> Result<(), ExecutionError> {
         let coef0 = self.stack.get(1);
         let coef1 = self.stack.get(0);
 
-        let elm = QuadFelt::new(coef0, coef1);
-        if elm == QuadFelt::ZERO {
+        let element = QuadFelt::new(coef0, coef1);
+        if element == QuadFelt::ZERO {
             return Err(ExecutionError::DivideByZero(self.system.clk()));
         }
-        let coeffs = elm.inv().to_base_elements();
+        let result = element.inv().to_base_elements();
 
-        self.advice_provider.push_stack(AdviceSource::Value(coeffs[1]))?;
-        self.advice_provider.push_stack(AdviceSource::Value(coeffs[0]))?;
+        self.advice_provider.push_stack(AdviceSource::Value(result[1]))?;
+        self.advice_provider.push_stack(AdviceSource::Value(result[0]))?;
 
         Ok(())
     }
@@ -149,74 +145,87 @@ where
     /// stack.
     ///
     /// The interpolation is performed using the iNTT algorithm. The evaluations are expected to be
-    /// in the quadratic extension field | q = 2^64 - 2^32 + 1.
+    /// in the quadratic extension.
     ///
-    /// Input stack state should look like
+    /// The operand stack is expected to be arranged as follows:
     ///
-    /// `[output_poly_len, input_eval_len, input_eval_begin_address, ...]`
+    /// [output_size, input_size, input_ptr, ...]
     ///
-    /// - `input_eval_len` must be a power of 2 and > 1.
-    /// - `output_poly_len <= input_eval_len`
-    /// - Only starting memory address of evaluations ( of length `input_eval_len` ) is
-    /// provided on the stack, consecutive memory addresses are expected to be holding
-    /// remaining `input_eval_len - 2` many evaluations.
-    /// - Each memory address holds two evaluations of the polynomial at adjacent points
+    /// - `input_size` is the number of evaluations (each evaluation is 2 base field elements).
+    ///   Must be a power of 2 and greater 1.
+    /// - `output_size` is the number of coefficients in the interpolated polynomial (each
+    ///   coefficient is 2 base field elements). Must be smaller than or equal to the number of
+    ///   input evaluations.
+    /// - `input_ptr` is the memory address of the first evaluation.
     ///
-    /// Final advice stack should look like
+    /// The result is pushed onto the advice stack such that the high-degree coefficients are
+    /// pushed first, and the zero-degree coefficient is pushed last.
     ///
-    /// `[coeff_0, coeff_1, ..., coeff_{n-1}, ...]` | n = output_poly_len
-    ///
-    /// Program which is requesting this non-deterministic computation should read `coeff0`
-    /// first i.e. `coeff{n-1}` should be seen at the very end.
-    pub(super) fn inject_ext2_intt_result(&mut self) -> Result<(), ExecutionError> {
-        let out_poly_len = self.stack.get(0).as_int() as usize;
-        let in_evaluations_len = self.stack.get(1).as_int() as usize;
-        let in_evaluations_addr = self.stack.get(2).as_int();
+    /// # Errors
+    /// Returns an error if:
+    /// - `input_size` less than or equal to 1, or is not a power of 2.
+    /// - `output_size` is 0 or is greater than the `input_size`.
+    /// - `input_ptr` is greater than 2^32.
+    /// - `input_ptr + input_size / 2` is greater than 2^32.
+    pub(super) fn push_ext2_intt_result(&mut self) -> Result<(), ExecutionError> {
+        let output_size = self.stack.get(0).as_int() as usize;
+        let input_size = self.stack.get(1).as_int() as usize;
+        let input_start_ptr = self.stack.get(2).as_int();
 
-        if in_evaluations_len <= 1 {
-            return Err(ExecutionError::NttDomainSizeTooSmall(in_evaluations_len as u64));
+        if input_size <= 1 {
+            return Err(Ext2InttError::DomainSizeTooSmall(input_size as u64).into());
         }
-        if !in_evaluations_len.is_power_of_two() {
-            return Err(ExecutionError::NttDomainSizeNotPowerOf2(in_evaluations_len as u64));
+        if !input_size.is_power_of_two() {
+            return Err(Ext2InttError::DomainSizeNotPowerOf2(input_size as u64).into());
         }
-        if out_poly_len > in_evaluations_len {
-            return Err(ExecutionError::InterpolationResultSizeTooBig(
-                out_poly_len,
-                in_evaluations_len,
-            ));
+        if input_start_ptr >= u32::MAX as u64 {
+            return Err(Ext2InttError::InputStartAddressTooBig(input_start_ptr).into());
+        }
+        if input_size > u32::MAX as usize {
+            return Err(Ext2InttError::InputSizeTooBig(input_size as u64).into());
         }
 
-        let mut poly = Vec::with_capacity(in_evaluations_len);
-        for i in 0..(in_evaluations_len >> 1) {
+        let input_end_ptr = input_start_ptr + (input_size / 2) as u64;
+        if input_end_ptr > u32::MAX as u64 {
+            return Err(Ext2InttError::InputEndAddressTooBig(input_end_ptr).into());
+        }
+
+        if output_size == 0 {
+            return Err(Ext2InttError::OutputSizeIsZero.into());
+        }
+        if output_size > input_size {
+            return Err(Ext2InttError::OutputSizeTooBig(output_size, input_size).into());
+        }
+
+        let mut poly = Vec::with_capacity(input_size);
+        for addr in (input_start_ptr as u32)..(input_end_ptr as u32) {
             let word = self
-                .get_memory_value(self.system.ctx(), in_evaluations_addr + i as u64)
-                .ok_or_else(|| {
-                    ExecutionError::UninitializedMemoryAddress(in_evaluations_addr + i as u64)
-                })?;
+                .get_memory_value(self.system.ctx(), addr)
+                .ok_or(Ext2InttError::UninitializedMemoryAddress(addr))?;
 
             poly.push(QuadFelt::new(word[0], word[1]));
             poly.push(QuadFelt::new(word[2], word[3]));
         }
 
-        let twiddles = fft::get_inv_twiddles::<Felt>(in_evaluations_len);
+        let twiddles = fft::get_inv_twiddles::<Felt>(input_size);
         fft::interpolate_poly::<Felt, QuadFelt>(&mut poly, &twiddles);
 
-        for i in QuadFelt::slice_as_base_elements(&poly[..out_poly_len]).iter().rev().copied() {
-            self.advice_provider.push_stack(AdviceSource::Value(i))?;
+        for element in QuadFelt::slice_as_base_elements(&poly[..output_size]).iter().rev() {
+            self.advice_provider.push_stack(AdviceSource::Value(*element))?;
         }
 
         Ok(())
     }
 
-    /// Pushes the value and depth flags of a leaf indexed by `key` on a Sparse Merkle tree with
-    /// the provided `root`.
+    /// Pushes the value and depth flags of a leaf indexed by `KEY` on a Sparse Merkle tree with
+    /// the provided `ROOT`.
     ///
     /// The Sparse Merkle tree is tiered, meaning it will have leaf depths in `{16, 32, 48, 64}`.
     /// The depth flags define the tier on which the leaf is located.
     ///
     /// The operand stack is expected to be arranged as follows:
-    /// - key, 4 elements.
-    /// - root of the Sparse Merkle tree, 4 elements.
+    ///
+    /// [KEY, ROOT, ...]
     ///
     /// After a successful operation, the advice stack will look as follows (from the top):
     /// - boolean flag set to `1` if the depth is `16` or `48`.
@@ -231,10 +240,10 @@ where
     ///
     /// # Panics
     /// Will panic as unimplemented if the target depth is `64`.
-    pub(super) fn inject_smtget(&mut self) -> Result<(), ExecutionError> {
+    pub(super) fn push_smtget_inputs(&mut self) -> Result<(), ExecutionError> {
         // fetch the arguments from the operand stack
-        let key = [self.stack.get(3), self.stack.get(2), self.stack.get(1), self.stack.get(0)];
-        let root = [self.stack.get(7), self.stack.get(6), self.stack.get(5), self.stack.get(4)];
+        let key = self.stack.get_word(0);
+        let root = self.stack.get_word(1);
 
         let index = &key[3];
         let depth = self.advice_provider.get_leaf_depth(root, &SMT_MAX_TREE_DEPTH, index)?;

--- a/processor/src/decorators/mod.rs
+++ b/processor/src/decorators/mod.rs
@@ -1,32 +1,10 @@
-use super::{
-    AdviceInjector, AdviceProvider, AdviceSource, Decorator, ExecutionError, Felt, Process,
-    StarkField, Word,
-};
-use vm_core::{
-    crypto::merkle::EmptySubtreeRoots, utils::collections::Vec, FieldElement, QuadExtension, ONE,
-    WORD_SIZE, ZERO,
-};
-use winter_prover::math::fft;
+use super::{AdviceInjector, AdviceProvider, AdviceSource, Decorator, ExecutionError, Process};
+
+mod adv_map_injectors;
+mod adv_stack_injectors;
 
 #[cfg(test)]
 mod tests;
-
-// TYPE ALIASES
-// ================================================================================================
-type QuadFelt = QuadExtension<Felt>;
-
-// CONSTANTS
-// ================================================================================================
-
-/// Maximum depth of a Sparse Merkle tree
-const SMT_MAX_TREE_DEPTH: Felt = Felt::new(64);
-
-/// Lookup table for Sparse Merkle tree depth normalization
-const SMT_NORMALIZED_DEPTHS: [u8; 65] = [
-    16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 32, 32, 32, 32, 32, 32, 32,
-    32, 32, 32, 32, 32, 32, 32, 32, 32, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48,
-    48, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
-];
 
 // DECORATORS
 // ================================================================================================
@@ -61,46 +39,15 @@ where
             AdviceInjector::MerkleMerge => self.inject_merkle_merge(),
             AdviceInjector::DivResultU64 => self.inject_div_result_u64(),
             AdviceInjector::MapValue => self.inject_map_value(),
-            AdviceInjector::Memory => self.inject_mem_values(),
             AdviceInjector::Ext2Inv => self.inject_ext2_inv_result(),
             AdviceInjector::Ext2INTT => self.inject_ext2_intt_result(),
             AdviceInjector::SmtGet => self.inject_smtget(),
+            AdviceInjector::Memory => self.inject_mem_values(),
         }
     }
 
     // INJECTOR HELPERS
     // --------------------------------------------------------------------------------------------
-
-    /// Pushes a node of the Merkle tree specified by the word on the top of the operand stack onto
-    /// the advice stack. The operand stack is expected to be arranged as follows (from the top):
-    /// - depth of the node, 1 element
-    /// - index of the node, 1 element
-    /// - root of the tree, 4 elements
-    ///
-    /// # Errors
-    /// Returns an error if:
-    /// - Merkle tree for the specified root cannot be found in the advice provider.
-    /// - The specified depth is either zero or greater than the depth of the Merkle tree
-    ///   identified by the specified root.
-    /// - Value of the node at the specified depth and index is not known to the advice provider.
-    fn inject_merkle_node(&mut self) -> Result<(), ExecutionError> {
-        // read node depth, node index, and tree root from the stack
-        let depth = self.stack.get(0);
-        let index = self.stack.get(1);
-        let root = [self.stack.get(5), self.stack.get(4), self.stack.get(3), self.stack.get(2)];
-
-        // look up the node in the advice provider
-        let node = self.advice_provider.get_tree_node(root, &depth, &index)?;
-
-        // push the node onto the advice stack with the first element pushed last so that it can
-        // be popped first (i.e. stack behavior for word)
-        self.advice_provider.push_stack(AdviceSource::Value(node[3]))?;
-        self.advice_provider.push_stack(AdviceSource::Value(node[2]))?;
-        self.advice_provider.push_stack(AdviceSource::Value(node[1]))?;
-        self.advice_provider.push_stack(AdviceSource::Value(node[0]))?;
-
-        Ok(())
-    }
 
     /// Creates a new Merkle tree in the advice provider by combining Merkle trees with the
     /// specified roots. The root of the new tree is defined as `hash(left_root, right_root)`.
@@ -117,261 +64,12 @@ where
     /// advice provider.
     fn inject_merkle_merge(&mut self) -> Result<(), ExecutionError> {
         // fetch the arguments from the stack
-        let lhs = [self.stack.get(7), self.stack.get(6), self.stack.get(5), self.stack.get(4)];
-        let rhs = [self.stack.get(3), self.stack.get(2), self.stack.get(1), self.stack.get(0)];
+        let lhs = self.stack.get_word(1);
+        let rhs = self.stack.get_word(0);
 
         // perform the merge
         self.advice_provider.merge_roots(lhs, rhs)?;
 
         Ok(())
     }
-
-    /// Pushes the result of [u64] division (both the quotient and the remainder) onto the advice
-    /// stack. The operand stack is expected to be arranged as follows (from the top):
-    /// - divisor split into two 32-bit elements
-    /// - dividend split into two 32-bit elements
-    ///
-    /// The result is pushed onto the advice stack as follows: the remainder is pushed first, then
-    /// the quotient is pushed. This guarantees that when popping values from the advice stack, the
-    /// quotient will be returned first, and the remainder will be returned next.
-    ///
-    /// # Errors
-    /// Returns an error if the divisor is ZERO.
-    fn inject_div_result_u64(&mut self) -> Result<(), ExecutionError> {
-        let divisor_hi = self.stack.get(0).as_int();
-        let divisor_lo = self.stack.get(1).as_int();
-        let divisor = (divisor_hi << 32) + divisor_lo;
-
-        if divisor == 0 {
-            return Err(ExecutionError::DivideByZero(self.system.clk()));
-        }
-
-        let dividend_hi = self.stack.get(2).as_int();
-        let dividend_lo = self.stack.get(3).as_int();
-        let dividend = (dividend_hi << 32) + dividend_lo;
-
-        let quotient = dividend / divisor;
-        let remainder = dividend - quotient * divisor;
-
-        let (q_hi, q_lo) = u64_to_u32_elements(quotient);
-        let (r_hi, r_lo) = u64_to_u32_elements(remainder);
-
-        self.advice_provider.push_stack(AdviceSource::Value(r_hi))?;
-        self.advice_provider.push_stack(AdviceSource::Value(r_lo))?;
-        self.advice_provider.push_stack(AdviceSource::Value(q_hi))?;
-        self.advice_provider.push_stack(AdviceSource::Value(q_lo))?;
-
-        Ok(())
-    }
-
-    /// Pushes a list of field elements onto the advice stack. The list is looked up in the advice
-    /// map using the top 4 elements (i.e. word) from the operand stack as the key.
-    ///
-    /// # Errors
-    /// Returns an error if the required key was not found in the key-value map.
-    fn inject_map_value(&mut self) -> Result<(), ExecutionError> {
-        let top_word = self.stack.get_word(0);
-        self.advice_provider.push_stack(AdviceSource::Map { key: top_word })?;
-
-        Ok(())
-    }
-
-    /// Reads the specfied number of words from the memory starting at the given start address and
-    /// writes the vector of field elements to the advice map with the top 4 elements on the stack
-    /// as the key. This operation does not affect the state of the Memory chiplet and the VM in
-    /// general.
-    ///
-    /// # Errors
-    /// Returns an error if the key is already present in the advice map.
-    fn inject_mem_values(&mut self) -> Result<(), ExecutionError> {
-        let start_addr = self.stack.get(4).as_int();
-        let end_addr = self.stack.get(5).as_int();
-        let len = end_addr - start_addr;
-        let ctx = self.system.ctx();
-        let mut values = Vec::with_capacity((len as usize) * WORD_SIZE);
-        for i in 0u64..len {
-            let mem_value =
-                self.chiplets.get_mem_value(ctx, start_addr + i).unwrap_or([ZERO; WORD_SIZE]);
-            values.extend_from_slice(&mem_value);
-        }
-        let top_word = self.stack.get_word(0);
-        self.advice_provider.insert_into_map(top_word, values)?;
-
-        Ok(())
-    }
-
-    /// Given a quadratic extension field element ( say a ) on stack top, this routine computes
-    /// multiplicative inverse of that element ( say b ) s.t.
-    ///
-    /// a * b = 1 ( mod P ) | b = a ^ -1, P = irreducible polynomial x^2 - x + 2 over F_q, q = 2^64 - 2^32 + 1
-    ///
-    /// Input on stack expected in following order
-    ///
-    /// [coeff_1, coeff_0, ...]
-    ///
-    /// While computed multiplicative inverse is put on advice provider in following order
-    ///
-    /// [coeff'_0, coeff'_1, ...]
-    ///
-    /// Meaning when a Miden program is going to read it from advice stack, it'll see
-    /// coefficient_0 first and then coefficient_1.
-    ///
-    /// Note, in case input operand is zero, division by zero error is returned, because
-    /// that's a non-invertible element of extension field.
-    fn inject_ext2_inv_result(&mut self) -> Result<(), ExecutionError> {
-        let coef0 = self.stack.get(1);
-        let coef1 = self.stack.get(0);
-
-        let elm = QuadFelt::new(coef0, coef1);
-        if elm == QuadFelt::ZERO {
-            return Err(ExecutionError::DivideByZero(self.system.clk()));
-        }
-        let coeffs = elm.inv().to_base_elements();
-
-        self.advice_provider.push_stack(AdviceSource::Value(coeffs[1]))?;
-        self.advice_provider.push_stack(AdviceSource::Value(coeffs[0]))?;
-
-        Ok(())
-    }
-
-    /// Given evaluations of a polynomial over some specified domain, this routine interpolates the
-    /// evaluations into a polynomial in coefficient form, and pushes the results onto the advice
-    /// stack.
-    ///
-    /// The interpolation is performed using the iNTT algorithm. The evaluations are expected to be
-    /// in the quadratic extension field | q = 2^64 - 2^32 + 1.
-    ///
-    /// Input stack state should look like
-    ///
-    /// `[output_poly_len, input_eval_len, input_eval_begin_address, ...]`
-    ///
-    /// - `input_eval_len` must be a power of 2 and > 1.
-    /// - `output_poly_len <= input_eval_len`
-    /// - Only starting memory address of evaluations ( of length `input_eval_len` ) is
-    /// provided on the stack, consecutive memory addresses are expected to be holding
-    /// remaining `input_eval_len - 2` many evaluations.
-    /// - Each memory address holds two evaluations of the polynomial at adjacent points
-    ///
-    /// Final advice stack should look like
-    ///
-    /// `[coeff_0, coeff_1, ..., coeff_{n-1}, ...]` | n = output_poly_len
-    ///
-    /// Program which is requesting this non-deterministic computation should read `coeff0`
-    /// first i.e. `coeff{n-1}` should be seen at the very end.
-    fn inject_ext2_intt_result(&mut self) -> Result<(), ExecutionError> {
-        let out_poly_len = self.stack.get(0).as_int() as usize;
-        let in_evaluations_len = self.stack.get(1).as_int() as usize;
-        let in_evaluations_addr = self.stack.get(2).as_int();
-
-        if in_evaluations_len <= 1 {
-            return Err(ExecutionError::NttDomainSizeTooSmall(in_evaluations_len as u64));
-        }
-        if !in_evaluations_len.is_power_of_two() {
-            return Err(ExecutionError::NttDomainSizeNotPowerOf2(in_evaluations_len as u64));
-        }
-        if out_poly_len > in_evaluations_len {
-            return Err(ExecutionError::InterpolationResultSizeTooBig(
-                out_poly_len,
-                in_evaluations_len,
-            ));
-        }
-
-        let mut poly = Vec::with_capacity(in_evaluations_len);
-        for i in 0..(in_evaluations_len >> 1) {
-            let word = self
-                .get_memory_value(self.system.ctx(), in_evaluations_addr + i as u64)
-                .ok_or_else(|| {
-                    ExecutionError::UninitializedMemoryAddress(in_evaluations_addr + i as u64)
-                })?;
-
-            poly.push(QuadFelt::new(word[0], word[1]));
-            poly.push(QuadFelt::new(word[2], word[3]));
-        }
-
-        let twiddles = fft::get_inv_twiddles::<Felt>(in_evaluations_len);
-        fft::interpolate_poly::<Felt, QuadFelt>(&mut poly, &twiddles);
-
-        for i in QuadFelt::slice_as_base_elements(&poly[..out_poly_len]).iter().rev().copied() {
-            self.advice_provider.push_stack(AdviceSource::Value(i))?;
-        }
-
-        Ok(())
-    }
-
-    /// Pushes the value and depth flags of a leaf indexed by `key` on a Sparse Merkle tree with
-    /// the provided `root`.
-    ///
-    /// The Sparse Merkle tree is tiered, meaning it will have leaf depths in `{16, 32, 48, 64}`.
-    /// The depth flags define the tier on which the leaf is located.
-    ///
-    /// The operand stack is expected to be arranged as follows:
-    /// - key, 4 elements.
-    /// - root of the Sparse Merkle tree, 4 elements.
-    ///
-    /// After a successful operation, the advice stack will look as follows (from the top):
-    /// - boolean flag set to `1` if the depth is `16` or `48`.
-    /// - boolean flag set to `1` if the depth is `16` or `32`.
-    /// - remaining key word; will be zeroed if the tree don't contain a mapped value for the key.
-    /// - value word; will be zeroed if the tree don't contain a mapped value for the key.
-    /// - boolean flag set to `1` if a remaining key is not zero.
-    ///
-    /// # Errors
-    /// Will return an error if:
-    /// - The provided Merkle root doesn't exist on the advice provider
-    ///
-    /// # Panics
-    /// Will panic as unimplemented if the target depth is `64`.
-    fn inject_smtget(&mut self) -> Result<(), ExecutionError> {
-        // fetch the arguments from the operand stack
-        let key = [self.stack.get(3), self.stack.get(2), self.stack.get(1), self.stack.get(0)];
-        let root = [self.stack.get(7), self.stack.get(6), self.stack.get(5), self.stack.get(4)];
-
-        let index = &key[3];
-        let depth = self.advice_provider.get_leaf_depth(root, &SMT_MAX_TREE_DEPTH, index)?;
-        debug_assert!(depth < 65);
-
-        // normalize the depth into one of the tiers. this is not a simple `next_power_of_two`
-        // because of `48`. using a lookup table is far more efficient than if/else if/else.
-        let depth = SMT_NORMALIZED_DEPTHS[depth as usize];
-        if depth == 64 {
-            unimplemented!("the functionality is unimplemented for depth 64 as the bottom tier will have a special treatment to embed multiple key/value pairs onto a single node");
-        }
-
-        // fetch the node value
-        let index = index.as_int() >> (64 - depth);
-        let index = Felt::new(index);
-        let node = self.advice_provider.get_tree_node(root, &Felt::new(depth as u64), &index)?;
-
-        // set the node value; zeroed if empty sub-tree
-        let empty = EmptySubtreeRoots::empty_hashes(64);
-        if Word::from(empty[depth as usize]) == node {
-            // push zeroes for remaining key, value & empty remaining key flag
-            for _ in 0..9 {
-                self.advice_provider.push_stack(AdviceSource::Value(ZERO))?;
-            }
-        } else {
-            // push a flag indicating that a remaining key exists
-            self.advice_provider.push_stack(AdviceSource::Value(ONE))?;
-
-            // map is expected to contain `node |-> {K', V}`
-            self.advice_provider.push_stack(AdviceSource::Map { key: node })?;
-        }
-
-        // set the flags
-        let is_16_or_32 = if depth == 16 || depth == 32 { ONE } else { ZERO };
-        let is_16_or_48 = if depth == 16 || depth == 48 { ONE } else { ZERO };
-        self.advice_provider.push_stack(AdviceSource::Value(is_16_or_32))?;
-        self.advice_provider.push_stack(AdviceSource::Value(is_16_or_48))?;
-
-        Ok(())
-    }
-}
-
-// HELPER FUNCTIONS
-// ================================================================================================
-
-fn u64_to_u32_elements(value: u64) -> (Felt, Felt) {
-    let hi = Felt::new(value >> 32);
-    let lo = Felt::new((value as u32) as u64);
-    (hi, lo)
 }

--- a/processor/src/decorators/mod.rs
+++ b/processor/src/decorators/mod.rs
@@ -35,14 +35,14 @@ where
     /// Process the specified advice injector.
     pub fn dec_advice(&mut self, injector: &AdviceInjector) -> Result<(), ExecutionError> {
         match injector {
-            AdviceInjector::MerkleNode => self.inject_merkle_node(),
-            AdviceInjector::MerkleMerge => self.inject_merkle_merge(),
-            AdviceInjector::DivResultU64 => self.inject_div_result_u64(),
-            AdviceInjector::MapValue => self.inject_map_value(),
-            AdviceInjector::Ext2Inv => self.inject_ext2_inv_result(),
-            AdviceInjector::Ext2INTT => self.inject_ext2_intt_result(),
-            AdviceInjector::SmtGet => self.inject_smtget(),
-            AdviceInjector::Memory => self.inject_mem_values(),
+            AdviceInjector::MerkleTreeMerge => self.merge_merkle_trees(),
+            AdviceInjector::MerkleNodeToStack => self.copy_merkle_node_to_adv_stack(),
+            AdviceInjector::MapValueToStack => self.copy_map_value_to_adv_stack(),
+            AdviceInjector::DivU64 => self.push_u64_div_result(),
+            AdviceInjector::Ext2Inv => self.push_ext2_inv_result(),
+            AdviceInjector::Ext2Intt => self.push_ext2_intt_result(),
+            AdviceInjector::SmtGet => self.push_smtget_inputs(),
+            AdviceInjector::MemToMap => self.insert_mem_values_into_adv_map(),
         }
     }
 
@@ -50,11 +50,11 @@ where
     // --------------------------------------------------------------------------------------------
 
     /// Creates a new Merkle tree in the advice provider by combining Merkle trees with the
-    /// specified roots. The root of the new tree is defined as `hash(left_root, right_root)`.
+    /// specified roots. The root of the new tree is defined as `Hash(LEFT_ROOT, RIGHT_ROOT)`.
     ///
     /// The operand stack is expected to be arranged as follows:
-    /// - root of the right tree, 4 elements
-    /// - root of the left tree, 4 elements
+    ///
+    /// [RIGHT_ROOT, LEFT_ROOT, ...]
     ///
     /// After the operation, both the original trees and the new tree remains in the advice
     /// provider (i.e., the input trees are not removed).
@@ -62,7 +62,7 @@ where
     /// # Errors
     /// Return an error if a Merkle tree for either of the specified roots cannot be found in this
     /// advice provider.
-    fn inject_merkle_merge(&mut self) -> Result<(), ExecutionError> {
+    fn merge_merkle_trees(&mut self) -> Result<(), ExecutionError> {
         // fetch the arguments from the stack
         let lhs = self.stack.get_word(1);
         let rhs = self.stack.get_word(0);

--- a/processor/src/decorators/tests.rs
+++ b/processor/src/decorators/tests.rs
@@ -35,7 +35,7 @@ fn inject_merkle_node() {
 
     // push the node onto the advice stack
     process
-        .execute_decorator(&Decorator::Advice(AdviceInjector::MerkleNode))
+        .execute_decorator(&Decorator::Advice(AdviceInjector::MerkleNodeToStack))
         .unwrap();
 
     // pop the node from the advice stack and push it onto the operand stack

--- a/processor/src/decorators/tests.rs
+++ b/processor/src/decorators/tests.rs
@@ -1,6 +1,6 @@
 use super::{
     super::{AdviceInputs, Felt, FieldElement, Kernel, Operation, StarkField},
-    Process, ZERO,
+    Process,
 };
 use crate::{MemAdviceProvider, StackInputs, Word};
 use test_utils::{crypto::get_smt_remaining_key, rand::seeded_word};
@@ -10,7 +10,7 @@ use vm_core::{
         merkle::{EmptySubtreeRoots, MerkleStore, MerkleTree, NodeIndex},
     },
     utils::IntoBytes,
-    AdviceInjector, Decorator, ONE,
+    AdviceInjector, Decorator, ONE, ZERO,
 };
 
 #[test]

--- a/processor/src/decorators/tests.rs
+++ b/processor/src/decorators/tests.rs
@@ -14,7 +14,7 @@ use vm_core::{
 };
 
 #[test]
-fn inject_merkle_node() {
+fn push_merkle_node() {
     let leaves = [init_leaf(1), init_leaf(2), init_leaf(3), init_leaf(4)];
     let tree = MerkleTree::new(leaves.to_vec()).unwrap();
     let store = MerkleStore::from(&tree);
@@ -60,7 +60,7 @@ fn inject_merkle_node() {
 }
 
 #[test]
-fn inject_smtget() {
+fn push_smtget() {
     // setup the test
     let empty = EmptySubtreeRoots::empty_hashes(64);
     let initial_root = Word::from(empty[0]);

--- a/processor/src/errors.rs
+++ b/processor/src/errors.rs
@@ -17,24 +17,22 @@ use std::error::Error;
 pub enum ExecutionError {
     AdviceKeyNotFound(Word),
     AdviceStackReadFailed(u32),
-    InvalidNodeIndex { depth: Felt, value: Felt },
-    InvalidTreeDepth { depth: Felt },
-    MerkleUpdateInPlace,
-    MerkleStoreLookupFailed(MerkleError),
-    MerkleStoreUpdateFailed(MerkleError),
-    MerkleStoreMergeFailed(MerkleError),
-    CodeBlockNotFound(Digest),
     CallerNotInSyscall,
+    CodeBlockNotFound(Digest),
     DivideByZero(u32),
+    Ext2InttError(Ext2InttError),
     FailedAssertion(u32),
-    UninitializedMemoryAddress(u64),
     InvalidFmpValue(Felt, Felt),
     InvalidFriDomainSegment(u64),
     InvalidFriLayerFolding(QuadFelt, QuadFelt),
+    InvalidMemoryRange { start_addr: u64, end_addr: u64 },
     InvalidStackDepthOnReturn(usize),
-    NttDomainSizeTooSmall(u64),
-    NttDomainSizeNotPowerOf2(u64),
-    InterpolationResultSizeTooBig(usize, usize),
+    InvalidTreeDepth { depth: Felt },
+    InvalidTreeNodeIndex { depth: Felt, value: Felt },
+    MemoryAddressOutOfBounds(u64),
+    MerkleStoreMergeFailed(MerkleError),
+    MerkleStoreLookupFailed(MerkleError),
+    MerkleStoreUpdateFailed(MerkleError),
     NotBinaryValue(Felt),
     NotU32Value(Felt),
     ProverError(ProverError),
@@ -43,90 +41,77 @@ pub enum ExecutionError {
 }
 
 impl Display for ExecutionError {
-    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), core::fmt::Error> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), core::fmt::Error> {
         use ExecutionError::*;
 
         match self {
             AdviceKeyNotFound(key) => {
                 let hex = to_hex(Felt::elements_as_bytes(key))?;
-                write!(fmt, "Can't push values onto the advice stack: value for key {hex} not present in the advice map.")
+                write!(f, "Can't push values onto the advice stack: value for key {hex} not present in the advice map.")
             }
-            InvalidNodeIndex { depth, value } => write!(
-                fmt,
-                "The provided index {value} is out of bounds for a node at depth {depth}"
-            ),
-            InvalidTreeDepth { depth } => {
-                write!(fmt, "The provided {depth} is out of bounds and cannot be represented as an unsigned 8-bits integer")
+            AdviceStackReadFailed(step) => write!(f, "Advice stack read failed at step {step}"),
+            CallerNotInSyscall => {
+                write!(f, "Instruction `caller` used outside of kernel context")
             }
-            MerkleUpdateInPlace => write!(fmt, "Update in place is not supported"),
-            MerkleStoreLookupFailed(reason) => {
-                write!(fmt, "Advice provider Merkle store backend lookup failed: {reason}")
-            }
-            MerkleStoreUpdateFailed(reason) => {
-                write!(fmt, "Advice provider Merkle store backend update failed: {reason}")
-            }
-            MerkleStoreMergeFailed(reason) => {
-                write!(fmt, "Advice provider Merkle store backend merge failed: {reason}")
-            }
-            AdviceStackReadFailed(step) => write!(fmt, "Advice stack read failed at step {step}"),
             CodeBlockNotFound(digest) => {
                 let hex = to_hex(&digest.as_bytes())?;
                 write!(
-                    fmt,
+                    f,
                     "Failed to execute code block with root {hex}; the block could not be found"
                 )
             }
-            CallerNotInSyscall => {
-                write!(
-                    fmt,
-                    "Instruction `caller` used outside of kernel context, this is not supported"
-                )
-            }
-            DivideByZero(clk) => write!(fmt, "Division by zero at clock cycle {clk}"),
-            FailedAssertion(clk) => write!(fmt, "Assertion failed at clock cycle {clk}"),
-            UninitializedMemoryAddress(address) => {
-                write!(fmt, "Ext2INTT referenced unintialized memory at address {address}")
-            }
+            DivideByZero(clk) => write!(f, "Division by zero at clock cycle {clk}"),
+            Ext2InttError(err) => write!(f, "Failed to execute Ext2Intt operation: {err}"),
+            FailedAssertion(clk) => write!(f, "Assertion failed at clock cycle {clk}"),
             InvalidFmpValue(old, new) => {
-                write!(fmt, "Updating FMP register from {old} to {new} failed because {new} is outside of {FMP_MIN}..{FMP_MAX}")
+                write!(f, "Updating FMP register from {old} to {new} failed because {new} is outside of {FMP_MIN}..{FMP_MAX}")
             }
             InvalidFriDomainSegment(value) => {
-                write!(fmt, "FRI domain segment value cannot exceed 3, but was {value}")
+                write!(f, "FRI domain segment value cannot exceed 3, but was {value}")
             }
             InvalidFriLayerFolding(expected, actual) => {
-                write!(fmt, "Degree-respecting projection is inconsistent: expected {expected} but was {actual}")
+                write!(f, "Degree-respecting projection is inconsistent: expected {expected} but was {actual}")
             }
-            NttDomainSizeTooSmall(v) => {
-                write!(fmt, "Input NTT domain size ({v} elements) is too small")
-            }
-            NttDomainSizeNotPowerOf2(v) => {
-                write!(fmt, "Input NTT domain size must be a power of two, but was {v}")
+            InvalidMemoryRange {
+                start_addr,
+                end_addr,
+            } => {
+                write!(f, "Memory range start address cannot exceed end address, but was ({start_addr}, {end_addr})")
             }
             InvalidStackDepthOnReturn(depth) => {
-                write!(fmt, "When returning from a call, stack depth must be {STACK_TOP_SIZE}, but was {depth}")
+                write!(f, "When returning from a call, stack depth must be {STACK_TOP_SIZE}, but was {depth}")
             }
-            InterpolationResultSizeTooBig(output_len, input_len) => {
-                write!(
-                    fmt,
-                    "Interpolation output length ({output_len}) cannot be greater than the input length ({input_len})"
-                )
+            InvalidTreeDepth { depth } => {
+                write!(f, "The provided {depth} is out of bounds and cannot be represented as an unsigned 8-bits integer")
+            }
+            InvalidTreeNodeIndex { depth, value } => {
+                write!(f, "The provided index {value} is out of bounds for a node at depth {depth}")
+            }
+            MemoryAddressOutOfBounds(addr) => {
+                write!(f, "Memory address cannot exceed 2^32 but was {addr}")
+            }
+            MerkleStoreLookupFailed(reason) => {
+                write!(f, "Advice provider Merkle store backend lookup failed: {reason}")
+            }
+            MerkleStoreMergeFailed(reason) => {
+                write!(f, "Advice provider Merkle store backend merge failed: {reason}")
+            }
+            MerkleStoreUpdateFailed(reason) => {
+                write!(f, "Advice provider Merkle store backend update failed: {reason}")
             }
             NotBinaryValue(v) => {
-                write!(
-                    fmt,
-                    "Execution failed: an operation expected a binary value, but received {v}"
-                )
+                write!(f, "An operation expected a binary value, but received {v}")
             }
             NotU32Value(v) => {
-                write!(fmt, "Execution failed: an operation expected a u32 value, but received {v}")
+                write!(f, "An operation expected a u32 value, but received {v}")
             }
-            ProverError(error) => write!(fmt, "Proof generation failed: {error}"),
+            ProverError(error) => write!(f, "Proof generation failed: {error}"),
             SyscallTargetNotInKernel(proc) => {
                 let hex = to_hex(&proc.as_bytes())?;
-                write!(fmt, "Syscall failed: procedure with root {hex} was not found in the kernel")
+                write!(f, "Syscall failed: procedure with root {hex} was not found in the kernel")
             }
             UnexecutableCodeBlock(block) => {
-                write!(fmt, "Execution reached unexecutable code block {block:?}")
+                write!(f, "Execution reached unexecutable code block {block:?}")
             }
         }
     }
@@ -134,3 +119,64 @@ impl Display for ExecutionError {
 
 #[cfg(feature = "std")]
 impl Error for ExecutionError {}
+
+impl From<Ext2InttError> for ExecutionError {
+    fn from(value: Ext2InttError) -> Self {
+        Self::Ext2InttError(value)
+    }
+}
+
+// EXT2INTT ERROR
+// ================================================================================================
+
+#[derive(Debug)]
+pub enum Ext2InttError {
+    DomainSizeNotPowerOf2(u64),
+    DomainSizeTooSmall(u64),
+    InputEndAddressTooBig(u64),
+    InputSizeTooBig(u64),
+    InputStartAddressTooBig(u64),
+    OutputSizeTooBig(usize, usize),
+    OutputSizeIsZero,
+    UninitializedMemoryAddress(u32),
+}
+
+impl Display for Ext2InttError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), core::fmt::Error> {
+        use Ext2InttError::*;
+
+        match self {
+            DomainSizeNotPowerOf2(v) => {
+                write!(f, "input domain size must be a power of two, but was {v}")
+            }
+            DomainSizeTooSmall(v) => {
+                write!(f, "input domain size ({v} elements) is too small")
+            }
+            InputEndAddressTooBig(addr) => {
+                write!(f, "address of the last input must be smaller than 2^32, but was {addr}")
+            }
+            InputSizeTooBig(size) => {
+                write!(f, "input size must be smaller than 2^32, but was {size}")
+            }
+            InputStartAddressTooBig(addr) => {
+                write!(f, "address of the first input must be smaller than 2^32, but was {addr}")
+            }
+            OutputSizeIsZero => {
+                write!(f, "output size must be greater than 0")
+            }
+            OutputSizeTooBig(output_size, input_size) => {
+                write!(
+                    f,
+                    "output size ({output_size}) cannot be greater than the input size ({input_size})"
+                )
+            }
+
+            UninitializedMemoryAddress(address) => {
+                write!(f, "uninitialized memory at address {address}")
+            }
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl Error for Ext2InttError {}

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -50,7 +50,7 @@ pub use trace::ExecutionTrace;
 use trace::TraceFragment;
 
 mod errors;
-pub use errors::ExecutionError;
+pub use errors::{ExecutionError, Ext2InttError};
 
 pub mod utils;
 
@@ -439,7 +439,7 @@ where
         self.chiplets.kernel()
     }
 
-    pub fn get_memory_value(&self, ctx: u32, addr: u64) -> Option<Word> {
+    pub fn get_memory_value(&self, ctx: u32, addr: u32) -> Option<Word> {
         self.chiplets.get_mem_value(ctx, addr)
     }
 

--- a/stdlib/asm/collections/mmr.masm
+++ b/stdlib/asm/collections/mmr.masm
@@ -222,7 +222,7 @@ end
 #!    16, i.e. `round_up((num_of_peaks - 16) / 2)`
 export.unpack
   # load the num_leaves and peaks to the advice_stack (0 cycles)
-  adv.keyval
+  adv.push_mapval
   # operand_stack => [HASH, mmr_ptr, ...]
   # advice_stack => [NUM_LEAVES, peaks*, ...]
 
@@ -300,12 +300,12 @@ export.pack
   exec.native::state_to_digest
   # => [HASH, peaks_end, peaks_end, mmr_ptr, ...]
 
-  # prepare stack for adv.mem (4 cycles)
+  # prepare stack for adv.insert_mem (4 cycles)
   movup.4 drop movup.4 movdn.5
   # => [HASH, mmr_ptr, peaks_end, ...]
 
   # copy the data to advice map
-  adv.mem
+  adv.insert_mem
 
   # drop the extra addresses (4 cycles)
   movup.4 drop movup.4 drop

--- a/stdlib/asm/collections/smt.masm
+++ b/stdlib/asm/collections/smt.masm
@@ -283,7 +283,7 @@ end
 #! Depth 48: 93 cycles
 export.get
     # invoke adv and fetch target depth flags
-    adv.smtget adv_push.2
+    adv.push_smtget adv_push.2
     # => [d ∈ {16, 32}, d ∈ {16, 48}, K, R, ...]
 
     # call the inner procedure depending on the depth

--- a/stdlib/asm/crypto/fri/ext2fri.masm
+++ b/stdlib/asm/crypto/fri/ext2fri.masm
@@ -22,7 +22,7 @@
 proc.compute_tau_64
     push.64
     push.8
-    adv.ext2intt # interpolate polynomial p, using advice provider
+    adv.push_ext2intt # interpolate polynomial p, using advice provider
 
     drop
     drop
@@ -81,7 +81,7 @@ end
 proc.compute_tau_32
     push.32
     push.4
-    adv.ext2intt # interpolate polynomial p, using advice provider
+    adv.push_ext2intt # interpolate polynomial p, using advice provider
 
     drop
     drop

--- a/stdlib/asm/crypto/fri/frie2f4.masm
+++ b/stdlib/asm/crypto/fri/frie2f4.masm
@@ -115,7 +115,7 @@ export.verify_query_layer.3
     dup.5
     movup.5             # [t_depth, f_pos, C, f_pos, d_seg, poe, e1, e0, a1, a0, layer_ptr, rem_ptr, ...]
     mtree_get           # [V, C, f_pos, d_seg, poe, e1, e0, a1, a0, layer_ptr, rem_ptr, ...]
-    adv.keyval
+    adv.push_mapval
     swapw
     # => [V, C, f_pos, d_seg, poe, e1, e0, a1, a0, layer_ptr, rem_ptr, ...]
     # where f_pos = p % d_size and d_seg = p / 4

--- a/stdlib/asm/crypto/stark/deep_queries.masm
+++ b/stdlib/asm/crypto/stark/deep_queries.masm
@@ -273,7 +273,7 @@ proc.load_query_row
     dup.5 dup.5
     mtree_get
     exec.constants::tmp3 mem_storew
-    adv.keyval
+    adv.push_mapval
     #=>[V, R, depth, index, query_ptr, ...]
     drop
     exec.constants::current_trace_row_ptr
@@ -328,7 +328,7 @@ proc.load_query_row
     dup.9
     mtree_get
     exec.constants::tmp3 mem_storew
-    adv.keyval
+    adv.push_mapval
     #=> [L, R, ptr, y, y, y, depth, index, query_ptr, ...]
 
     ## adv_pipe aux trace portion
@@ -380,7 +380,7 @@ proc.load_query_row
     dup.9
     mtree_get
     exec.constants::tmp3 mem_storew
-    adv.keyval
+    adv.push_mapval
     #=>[L, R, ptr, y, y, y, depth, index, query_ptr, ...]
     padw
     exec.constants::zero_word mem_loadw

--- a/stdlib/asm/math/poly512.masm
+++ b/stdlib/asm/math/poly512.masm
@@ -78,7 +78,7 @@ export.mod_12289
     u32split
     push.12289.0
 
-    adv.u64div
+    adv.push_u64div
 
     adv_push.2
     u32assert.2

--- a/stdlib/asm/math/u64.masm
+++ b/stdlib/asm/math/u64.masm
@@ -427,7 +427,7 @@ end
 #! Stack transition looks as follows:
 #! [b_hi, b_lo, a_hi, a_lo, ...] -> [c_hi, c_lo, ...], where c = a // b
 export.unchecked_div
-    adv.u64div          # push the quotient and the remainder onto the advice stack
+    adv.push_u64div     # push the quotient and the remainder onto the advice stack
 
     adv_push.2          # pop the quotient from the advice stack and assert it consists of
     u32assert.2         # 32-bit limbs
@@ -492,7 +492,7 @@ end
 #! Stack transition looks as follows:
 #! [b_hi, b_lo, a_hi, a_lo, ...] -> [c_hi, c_lo, ...], where c = a % b
 export.unchecked_mod
-    adv.u64div          # push the quotient and the remainder onto the advice stack
+    adv.push_u64div     # push the quotient and the remainder onto the advice stack
 
     adv_push.2          # pop the quotient from the advice stack and assert it consists of
     u32assert.2         # 32-bit limbs
@@ -557,7 +557,7 @@ end
 #! Stack transition looks as follows:
 #! [b_hi, b_lo, a_hi, a_lo, ...] -> [r_hi, r_lo, q_hi, q_lo ...], where r = a % b, q = a / b
 export.unchecked_divmod
-    adv.u64div          # push the quotient and the remainder onto the advice stack
+    adv.push_u64div     # push the quotient and the remainder onto the advice stack
 
     adv_push.2          # pop the quotient from the advice stack and assert it consists of
     u32assert.2         # 32-bit limbs

--- a/stdlib/docs/constants_stark.md
+++ b/stdlib/docs/constants_stark.md
@@ -1,0 +1,4 @@
+
+## std::crypto::stark::constants
+| Procedure | Description |
+| ----------- | ------------- |

--- a/stdlib/tests/collections/mmr.rs
+++ b/stdlib/tests/collections/mmr.rs
@@ -366,8 +366,8 @@ fn test_mmr_unpack() {
 
     // Set up the VM stack with the MMR hash, and its target address
     let mut stack = stack_to_ints(&*hash);
-    let mmr_ptr = 1000;
-    stack.insert(0, mmr_ptr);
+    let mmr_ptr = 1000_u32;
+    stack.insert(0, mmr_ptr as u64);
 
     // both the advice stack and merkle store start empty (data is available in
     // the map and pushed to the advice stack by the MASM code)
@@ -490,8 +490,8 @@ fn test_mmr_unpack_large_mmr() {
 
     // Set up the VM stack with the MMR hash, and its target address
     let mut stack = stack_to_ints(&*hash);
-    let mmr_ptr = 1000;
-    stack.insert(0, mmr_ptr);
+    let mmr_ptr = 1000_u32;
+    stack.insert(0, mmr_ptr as u64);
 
     // both the advice stack and merkle store start empty (data is available in
     // the map and pushed to the advice stack by the MASM code)
@@ -735,7 +735,7 @@ fn test_mmr_large() {
 
 #[test]
 fn test_mmr_large_add_roundtrip() {
-    let mmr_ptr = 1000;
+    let mmr_ptr = 1000_u32;
 
     let mut mmr: Mmr = Mmr::from([
         [Felt::new(0), Felt::new(0), Felt::new(0), Felt::new(1)],
@@ -752,7 +752,7 @@ fn test_mmr_large_add_roundtrip() {
 
     // Set up the VM stack with the MMR hash, and its target address
     let mut stack = stack_to_ints(&hash);
-    stack.insert(0, mmr_ptr);
+    stack.insert(0, mmr_ptr as u64);
 
     // both the advice stack and merkle store start empty (data is available in
     // the map and pushed to the advice stack by the MASM code)

--- a/stdlib/tests/crypto/fri/remainder.rs
+++ b/stdlib/tests/crypto/fri/remainder.rs
@@ -37,7 +37,7 @@ fn test_decorator_ext2intt(in_poly_len: usize, blowup: usize) {
         push.{}
         push.{}
 
-        adv.ext2intt
+        adv.push_ext2intt
 
         push.0
         dropw

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -155,7 +155,7 @@ impl Test {
     pub fn expect_stack_and_memory(
         &self,
         final_stack: &[u64],
-        mut mem_start_addr: u64,
+        mut mem_start_addr: u32,
         expected_mem: &[u64],
     ) {
         // compile the program


### PR DESCRIPTION
This PR refactors advice injector names, handling logic, and introduces a couple new advice injectors. Specifically:

- [x] Split advice injector handlers int the processor into multiple files.
- [x] Cleaned up `ExecutionError` enum a bit (i.e., broke out `Ext2InttError` into a separate sub-enum).
- [x] Renamed advice instructions to have the form `adv.push_xxx` for instructions which push data onto the advice stack and `adv.insert_xxx` for instructions which insert data into the advice map.
- [x] Added 2 new advice injectors and removed one injector which does not need to be exposed to the user (see detailed list below).
- [x] Update user docs.

Instruction set updates (some of these are breaking changes):
- Renamed instructions:
  - `adv.u64div` -> `adv.push_u64div`.
  - `adv.ext2intt` -> `adv.push_ext2intt`.
  - `adv.smtget` -> `adv.push_smtget`.
  - `adv.keyval` -> `adv.push_mapval`.
  - `adv.mem` -> `adv.insert_mem`.
- Removed instructions:
  - `adv.ext2inv`.
- Added instructions:
  - `adv.push_mtnode` for non-deterministically getting a value of a Merkle tree node.
  - `adv.insert_hdword` for inserting top two words from the stack into the advice map.