### PR TITLE
Assembler: Introduce code block builder and refactor compile in context

### DIFF
--- a/assembly/src/ast/mod.rs
+++ b/assembly/src/ast/mod.rs
@@ -101,6 +101,16 @@ impl ProgramAst {
         iter::once(&self.start).chain(self.body.source_locations().iter())
     }
 
+    /// Returns a slice over the internal procedures of this program.
+    pub fn procedures(&self) -> &[ProcedureAst] {
+        &self.local_procs
+    }
+
+    /// Returns a reference to the body of this program.
+    pub fn body(&self) -> &CodeBody {
+        &self.body
+    }
+
     // PARSER
     // --------------------------------------------------------------------------------------------
     /// Parses the provided source into a [ProgramAst].

--- a/assembly/src/errors.rs
+++ b/assembly/src/errors.rs
@@ -13,6 +13,7 @@ use vm_core::utils::write_hex_bytes;
 pub enum AssemblyError {
     CallInKernel(String),
     CallerOutOKernel,
+    CallSetProcedureNotFound(ProcedureId),
     CircularModuleDependency(Vec<String>),
     DivisionByZero,
     DuplicateProcName(String, String),
@@ -122,6 +123,7 @@ impl fmt::Display for AssemblyError {
         match self {
             CallInKernel(proc_name) => write!(f, "call instruction used kernel procedure '{proc_name}'"),
             CallerOutOKernel => write!(f, "caller instruction used outside of kernel"),
+            CallSetProcedureNotFound(proc_id) => write!(f, "callset procedure not found in assembler cache for procedure  '{proc_id}'"),
             CircularModuleDependency(dep_chain) => write!(f, "circular module dependency in the following chain: {dep_chain:?}"),
             DivisionByZero => write!(f, "division by zero"),
             DuplicateProcName(proc_name, module_path) => write!(f, "duplicate proc name '{proc_name}' in module {module_path}"),

--- a/assembly/src/tests.rs
+++ b/assembly/src/tests.rs
@@ -141,14 +141,14 @@ fn simple_main_call() {
     let note_1 =
         ProgramAst::parse("use.context::account begin call.account::account_method_1 end").unwrap();
     let _note_1_root = assembler
-        .compile_in_context(note_1, &mut super::AssemblyContext::new(AssemblyContextType::Program))
+        .compile_in_context(&note_1, &mut super::AssemblyContext::new(AssemblyContextType::Program))
         .unwrap();
 
     // compile note 2 program
     let note_2 =
         ProgramAst::parse("use.context::account begin call.account::account_method_2 end").unwrap();
     let _note_2_root = assembler
-        .compile_in_context(note_2, &mut super::AssemblyContext::new(AssemblyContextType::Program))
+        .compile_in_context(&note_2, &mut super::AssemblyContext::new(AssemblyContextType::Program))
         .unwrap();
 }
 


### PR DESCRIPTION
## Describe your changes

This PR introduces the `build_cb_table(..)` method on the `Assembler` and modifies the signature of `compile_in_context(..)` such that it works with references of `ProgramAst`.