### PR TITLE
update kernel rom tests

### DIFF
--- a/processor/src/chiplets/bitwise/mod.rs
+++ b/processor/src/chiplets/bitwise/mod.rs
@@ -244,15 +244,16 @@ pub fn assert_u32(value: Felt) -> Result<Felt, ExecutionError> {
 // ================================================================================================
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct BitwiseLookup {
-    op_id: Felt,
+    // unique label identifying the bitwise operation
+    label: Felt,
     a: Felt,
     b: Felt,
     z: Felt,
 }
 
 impl BitwiseLookup {
-    pub fn new(op_id: Felt, a: Felt, b: Felt, z: Felt) -> Self {
-        Self { op_id, a, b, z }
+    pub fn new(label: Felt, a: Felt, b: Felt, z: Felt) -> Self {
+        Self { label, a, b, z }
     }
 }
 
@@ -265,7 +266,7 @@ impl LookupTableRow for BitwiseLookup {
         alphas: &[E],
     ) -> E {
         alphas[0]
-            + alphas[1].mul_base(self.op_id)
+            + alphas[1].mul_base(self.label)
             + alphas[2].mul_base(self.a)
             + alphas[3].mul_base(self.b)
             + alphas[4].mul_base(self.z)

--- a/processor/src/chiplets/kernel_rom/mod.rs
+++ b/processor/src/chiplets/kernel_rom/mod.rs
@@ -112,13 +112,12 @@ impl KernelRom {
 
             // write at least one row into the trace for each kernel procedure
             access_info.write_into_trace(trace, row, idx);
-            row += 1;
-
             // provide the kernel procedure to the chiplets bus, if it was accessed at least once
             let lookup = KernelProcLookup::new(access_info.proc_hash);
-            if access_info.num_accesses == 1 {
+            if access_info.num_accesses >= 1 {
                 chiplets_bus.provide_kernel_proc_call(lookup, (kernel_rom_start_row + row) as u32);
             }
+            row += 1;
 
             // if the procedure was accessed more than once, we need write a row and provide the
             // procedure to the bus per additional access

--- a/processor/src/trace/tests/chiplets/bitwise.rs
+++ b/processor/src/trace/tests/chiplets/bitwise.rs
@@ -7,7 +7,7 @@ use miden_air::trace::chiplets::{
     BITWISE_A_COL_IDX, BITWISE_B_COL_IDX, BITWISE_OUTPUT_COL_IDX, BITWISE_TRACE_OFFSET,
 };
 
-/// Tests the generation of the `b_aux` bus column when only bitwise lookups are included. It
+/// Tests the generation of the `b_chip` bus column when only bitwise lookups are included. It
 /// ensures that trace generation is correct when all of the following are true.
 ///
 /// - All possible bitwise operations are called by the stack.
@@ -18,7 +18,7 @@ use miden_air::trace::chiplets::{
 /// values are requested & provided.
 #[test]
 #[allow(clippy::needless_range_loop)]
-fn b_aux_trace_bitwise() {
+fn b_chip_trace_bitwise() {
     let a = rand_value::<u32>();
     let b = rand_value::<u32>();
     let stack = [a as u64, b as u64];
@@ -50,14 +50,14 @@ fn b_aux_trace_bitwise() {
 
     let rand_elements = rand_array::<Felt, AUX_TRACE_RAND_ELEMENTS>();
     let aux_columns = trace.build_aux_segment(&[], &rand_elements).unwrap();
-    let b_aux = aux_columns.get_column(CHIPLETS_AUX_TRACE_OFFSET);
+    let b_chip = aux_columns.get_column(CHIPLETS_AUX_TRACE_OFFSET);
 
-    assert_eq!(trace.length(), b_aux.len());
-    assert_eq!(ONE, b_aux[0]);
+    assert_eq!(trace.length(), b_chip.len());
+    assert_eq!(ONE, b_chip[0]);
 
     // At cycle 0 the span hash initialization is requested from the decoder and provided by the
     // hash chiplet, so the trace should still equal one.
-    assert_eq!(ONE, b_aux[1]);
+    assert_eq!(ONE, b_chip[1]);
 
     // The first bitwise request from the stack is sent when the `U32and` operation is executed at
     // cycle 1, so the request is included in the next row. (The trace begins by executing `span`).
@@ -69,11 +69,11 @@ fn b_aux_trace_bitwise() {
         Felt::from(a & b),
     );
     let mut expected = value.inv();
-    assert_eq!(expected, b_aux[2]);
+    assert_eq!(expected, b_chip[2]);
 
     // Nothing changes during user operations with no requests to the Chiplets.
     for row in 3..5 {
-        assert_eq!(expected, b_aux[row]);
+        assert_eq!(expected, b_chip[row]);
     }
 
     // The second bitwise request from the stack is sent when the `U32and` operation is executed at
@@ -86,22 +86,22 @@ fn b_aux_trace_bitwise() {
         Felt::from(a & b),
     );
     expected *= value.inv();
-    assert_eq!(expected, b_aux[5]);
+    assert_eq!(expected, b_chip[5]);
 
     // Nothing changes during user operations with no requests to the Chiplets.
     for row in 6..8 {
-        assert_eq!(expected, b_aux[row]);
+        assert_eq!(expected, b_chip[row]);
     }
 
     // At cycle 7 the hasher provides the result of the `SPAN` hash. Since this test is for changes
     // from bitwise lookups, just set it explicitly and save the multiplied-in value for later.
-    assert_ne!(expected, b_aux[8]);
-    let span_result = b_aux[8] * b_aux[7].inv();
-    expected = b_aux[8];
+    assert_ne!(expected, b_chip[8]);
+    let span_result = b_chip[8] * b_chip[7].inv();
+    expected = b_chip[8];
 
     // Nothing changes during user operations with no requests to the Chiplets.
     for row in 9..16 {
-        assert_eq!(expected, b_aux[row]);
+        assert_eq!(expected, b_chip[row]);
     }
 
     // Bitwise responses will be provided during the bitwise segment of the Chiplets trace,
@@ -122,42 +122,42 @@ fn b_aux_trace_bitwise() {
     );
     expected *= value.inv();
     expected *= build_expected_bitwise_from_trace(&trace, &rand_elements, response_1_row - 1);
-    assert_eq!(expected, b_aux[response_1_row]);
+    assert_eq!(expected, b_chip[response_1_row]);
 
     // Nothing changes until the decoder requests the result of the `SPAN` hash at cycle 21.
     for row in response_1_row..21 {
-        assert_eq!(expected, b_aux[row]);
+        assert_eq!(expected, b_chip[row]);
     }
 
     // At cycle 21 the decoder requests the span hash. We set this as the inverse of the previously
     // identified `span_result`, since this test is for consistency of the bitwise lookups.
-    assert_ne!(expected, b_aux[22]);
+    assert_ne!(expected, b_chip[22]);
     expected *= span_result.inv();
-    assert_eq!(expected, b_aux[22]);
+    assert_eq!(expected, b_chip[22]);
 
     // Nothing changes until the next time the Bitwise chiplet responds.
     for row in 23..response_2_row {
-        assert_eq!(expected, b_aux[row]);
+        assert_eq!(expected, b_chip[row]);
     }
 
     // At the end of the next bitwise cycle, the response for `U32and` is provided by the Bitwise
     // chiplet.
     expected *= build_expected_bitwise_from_trace(&trace, &rand_elements, response_2_row - 1);
-    assert_eq!(expected, b_aux[response_2_row]);
+    assert_eq!(expected, b_chip[response_2_row]);
 
     // Nothing changes until the next time the Bitwise chiplet responds.
     for row in response_2_row..response_3_row {
-        assert_eq!(expected, b_aux[row]);
+        assert_eq!(expected, b_chip[row]);
     }
 
     // At the end of the next bitwise cycle, the response for `U32and` is provided by the Bitwise
     // chiplet.
     expected *= build_expected_bitwise_from_trace(&trace, &rand_elements, response_3_row - 1);
-    assert_eq!(expected, b_aux[response_3_row]);
+    assert_eq!(expected, b_chip[response_3_row]);
 
-    // The value in b_aux should be ONE now and for the rest of the trace.
+    // The value in b_chip should be ONE now and for the rest of the trace.
     for row in response_3_row..trace.length() - NUM_RAND_ROWS {
-        assert_eq!(ONE, b_aux[row]);
+        assert_eq!(ONE, b_chip[row]);
     }
 }
 

--- a/processor/src/trace/tests/chiplets/memory.rs
+++ b/processor/src/trace/tests/chiplets/memory.rs
@@ -8,7 +8,7 @@ use miden_air::trace::chiplets::{
     MEMORY_V_COL_RANGE,
 };
 
-/// Tests the generation of the `b_aux` bus column when only memory lookups are included. It ensures
+/// Tests the generation of the `b_chip` bus column when only memory lookups are included. It ensures
 /// that trace generation is correct when all of the following are true.
 ///
 /// - All possible memory operations are called by the stack.
@@ -20,7 +20,7 @@ use miden_air::trace::chiplets::{
 /// values are requested & provided.
 #[test]
 #[allow(clippy::needless_range_loop)]
-fn b_aux_trace_mem() {
+fn b_chip_trace_mem() {
     let stack = [1, 2, 3, 4, 0];
     let word = [ONE, Felt::new(2), Felt::new(3), Felt::new(4)];
     let operations = vec![
@@ -42,24 +42,24 @@ fn b_aux_trace_mem() {
 
     let rand_elements = rand_array::<Felt, AUX_TRACE_RAND_ELEMENTS>();
     let aux_columns = trace.build_aux_segment(&[], &rand_elements).unwrap();
-    let b_aux = aux_columns.get_column(CHIPLETS_AUX_TRACE_OFFSET);
+    let b_chip = aux_columns.get_column(CHIPLETS_AUX_TRACE_OFFSET);
 
-    assert_eq!(trace.length(), b_aux.len());
-    assert_eq!(ONE, b_aux[0]);
+    assert_eq!(trace.length(), b_chip.len());
+    assert_eq!(ONE, b_chip[0]);
 
     // At cycle 0 the span hash initialization is requested from the decoder and provided by the
     // hash chiplet, so the trace should still equal one.
-    assert_eq!(ONE, b_aux[1]);
+    assert_eq!(ONE, b_chip[1]);
 
     // The first memory request from the stack is sent when the `MStoreW` operation is executed, at
     // cycle 1, so the request is included in the next row. (The trace begins by executing `span`).
     let value = build_expected_memory(&rand_elements, MEMORY_WRITE_LABEL, ZERO, ZERO, ONE, word);
     let mut expected = value.inv();
-    assert_eq!(expected, b_aux[2]);
+    assert_eq!(expected, b_chip[2]);
 
     // Nothing changes after user operations that don't make requests to the Chiplets.
     for row in 3..7 {
-        assert_eq!(expected, b_aux[row]);
+        assert_eq!(expected, b_chip[row]);
     }
 
     // The next memory request from the stack is sent when `MLoad` is executed at cycle 6 and
@@ -67,13 +67,13 @@ fn b_aux_trace_mem() {
     let value =
         build_expected_memory(&rand_elements, MEMORY_READ_LABEL, ZERO, ZERO, Felt::new(6), word);
     expected *= value.inv();
-    assert_eq!(expected, b_aux[7]);
+    assert_eq!(expected, b_chip[7]);
 
     // At cycle 7 the hasher provides the result of the `SPAN` hash. Since this test is for changes
     // from memory lookups, just set it explicitly and save the multiplied-in value for later.
-    assert_ne!(expected, b_aux[8]);
-    let span_result = b_aux[8] * b_aux[7].inv();
-    expected = b_aux[8];
+    assert_ne!(expected, b_chip[8]);
+    let span_result = b_chip[8] * b_chip[7].inv();
+    expected = b_chip[8];
 
     // Memory responses will be provided during the memory segment of the Chiplets trace,
     // which starts after the hash for the span block at row 8. There will be 6 rows, corresponding
@@ -84,15 +84,15 @@ fn b_aux_trace_mem() {
         build_expected_memory(&rand_elements, MEMORY_READ_LABEL, ZERO, ZERO, Felt::new(8), word);
     expected *= value.inv();
     expected *= build_expected_memory_from_trace(&trace, &rand_elements, 8);
-    assert_eq!(expected, b_aux[9]);
+    assert_eq!(expected, b_chip[9]);
 
     // At cycle 9, `MLoad` is provided by memory.
     expected *= build_expected_memory_from_trace(&trace, &rand_elements, 9);
-    assert_eq!(expected, b_aux[10]);
+    assert_eq!(expected, b_chip[10]);
 
     // At cycle 10,  `MLoadW` is provided by memory.
     expected *= build_expected_memory_from_trace(&trace, &rand_elements, 10);
-    assert_eq!(expected, b_aux[11]);
+    assert_eq!(expected, b_chip[11]);
 
     // At cycle 11, `MStore` is requested by the stack and the first read of `MStream` is provided
     // by the memory.
@@ -106,11 +106,11 @@ fn b_aux_trace_mem() {
     );
     expected *= value.inv();
     expected *= build_expected_memory_from_trace(&trace, &rand_elements, 11);
-    assert_eq!(expected, b_aux[12]);
+    assert_eq!(expected, b_chip[12]);
 
     // At cycle 12, `MStore` is provided by the memory
     expected *= build_expected_memory_from_trace(&trace, &rand_elements, 12);
-    assert_eq!(expected, b_aux[13]);
+    assert_eq!(expected, b_chip[13]);
 
     // At cycle 13, `MStream` is requested by the stack, and the second read of `MStream` is
     // provided by the memory.
@@ -126,17 +126,17 @@ fn b_aux_trace_mem() {
     );
     expected *= (value1 * value2).inv();
     expected *= build_expected_memory_from_trace(&trace, &rand_elements, 13);
-    assert_eq!(expected, b_aux[14]);
+    assert_eq!(expected, b_chip[14]);
 
     // At cycle 14 the decoder requests the span hash. We set this as the inverse of the previously
     // identified `span_result`, since this test is for consistency of the memory lookups.
-    assert_ne!(expected, b_aux[15]);
+    assert_ne!(expected, b_chip[15]);
     expected *= span_result.inv();
-    assert_eq!(expected, b_aux[15]);
+    assert_eq!(expected, b_chip[15]);
 
-    // The value in b_aux should be ONE now and for the rest of the trace.
+    // The value in b_chip should be ONE now and for the rest of the trace.
     for row in 15..trace.length() - NUM_RAND_ROWS {
-        assert_eq!(ONE, b_aux[row]);
+        assert_eq!(ONE, b_chip[row]);
     }
 }
 


### PR DESCRIPTION
This PR updates the kernel rom tests to check the chiplets bus communications. It also includes a fix for an error found during testing and some minor renaming for terminological consistency between chiplets