### PR TITLE
Add more variants for `adv.push_mapval` instruction

### DIFF
--- a/assembly/src/ast/mod.rs
+++ b/assembly/src/ast/mod.rs
@@ -46,6 +46,9 @@ const MAX_BODY_LEN: usize = u16::MAX as usize;
 /// Maximum number of imported libraries in a module or a program
 const MAX_IMPORTS: usize = u16::MAX as usize;
 
+/// Maximum stack index at which a full word can start.
+const MAX_STACK_WORD_OFFSET: u8 = 12;
+
 // TYPE ALIASES
 // ================================================================================================
 type LocalProcMap = BTreeMap<String, (u16, ProcedureAst)>;

--- a/assembly/src/ast/nodes/advice.rs
+++ b/assembly/src/ast/nodes/advice.rs
@@ -1,4 +1,7 @@
-use super::super::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable};
+use super::super::{
+    ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable,
+    MAX_STACK_WORD_OFFSET,
+};
 use core::fmt;
 use vm_core::{AdviceInjector, Felt};
 
@@ -16,6 +19,9 @@ pub enum AdviceInjectorNode {
     PushExt2intt,
     PushSmtGet,
     PushMapVal,
+    PushMapValImm { offset: u8 },
+    PushMapValN,
+    PushMapValNImm { offset: u8 },
     PushMtNode,
     InsertMem,
     InsertHdword { domain: u8 },
@@ -23,14 +29,30 @@ pub enum AdviceInjectorNode {
 
 impl From<&AdviceInjectorNode> for AdviceInjector {
     fn from(value: &AdviceInjectorNode) -> Self {
+        use AdviceInjectorNode::*;
         match value {
-            AdviceInjectorNode::PushU64div => Self::DivU64,
-            AdviceInjectorNode::PushExt2intt => Self::Ext2Intt,
-            AdviceInjectorNode::PushSmtGet => Self::SmtGet,
-            AdviceInjectorNode::PushMapVal => Self::MapValueToStack,
-            AdviceInjectorNode::PushMtNode => Self::MerkleNodeToStack,
-            AdviceInjectorNode::InsertMem => Self::MemToMap,
-            AdviceInjectorNode::InsertHdword { domain } => Self::HdwordToMap {
+            PushU64div => Self::DivU64,
+            PushExt2intt => Self::Ext2Intt,
+            PushSmtGet => Self::SmtGet,
+            PushMapVal => Self::MapValueToStack {
+                include_len: false,
+                key_offset: 0,
+            },
+            PushMapValImm { offset } => Self::MapValueToStack {
+                include_len: false,
+                key_offset: (*offset) as usize,
+            },
+            PushMapValN => Self::MapValueToStack {
+                include_len: true,
+                key_offset: 0,
+            },
+            PushMapValNImm { offset } => Self::MapValueToStack {
+                include_len: true,
+                key_offset: (*offset) as usize,
+            },
+            PushMtNode => Self::MerkleNodeToStack,
+            InsertMem => Self::MemToMap,
+            InsertHdword { domain } => Self::HdwordToMap {
                 domain: Felt::from(*domain),
             },
         }
@@ -39,14 +61,18 @@ impl From<&AdviceInjectorNode> for AdviceInjector {
 
 impl fmt::Display for AdviceInjectorNode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use AdviceInjectorNode::*;
         match self {
-            AdviceInjectorNode::PushU64div => write!(f, "push_u64div"),
-            AdviceInjectorNode::PushExt2intt => write!(f, "push_ext2intt"),
-            AdviceInjectorNode::PushSmtGet => write!(f, "push_smtget"),
-            AdviceInjectorNode::PushMapVal => write!(f, "push_mapval"),
-            AdviceInjectorNode::PushMtNode => write!(f, "push_mtnode"),
-            AdviceInjectorNode::InsertMem => write!(f, "insert_mem"),
-            AdviceInjectorNode::InsertHdword { domain } => match domain {
+            PushU64div => write!(f, "push_u64div"),
+            PushExt2intt => write!(f, "push_ext2intt"),
+            PushSmtGet => write!(f, "push_smtget"),
+            PushMapVal => write!(f, "push_mapval"),
+            PushMapValImm { offset } => write!(f, "push_mapval.{offset}"),
+            PushMapValN => write!(f, "push_mapvaln"),
+            PushMapValNImm { offset } => write!(f, "push_mapvaln.{offset}"),
+            PushMtNode => write!(f, "push_mtnode"),
+            InsertMem => write!(f, "insert_mem"),
+            InsertHdword { domain } => match domain {
                 0 => write!(f, "insert_hdword"),
                 _ => write!(f, "insert_hdword.{domain}"),
             },
@@ -61,20 +87,33 @@ const PUSH_U64DIV: u8 = 0;
 const PUSH_EXT2INTT: u8 = 1;
 const PUSH_SMTGET: u8 = 2;
 const PUSH_MAPVAL: u8 = 3;
-const PUSH_MTNODE: u8 = 4;
-const INSERT_MEM: u8 = 5;
-const INSERT_HDWORD: u8 = 6;
+const PUSH_MAPVAL_IMM: u8 = 4;
+const PUSH_MAPVALN: u8 = 5;
+const PUSH_MAPVALN_IMM: u8 = 6;
+const PUSH_MTNODE: u8 = 7;
+const INSERT_MEM: u8 = 8;
+const INSERT_HDWORD: u8 = 9;
 
 impl Serializable for AdviceInjectorNode {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        use AdviceInjectorNode::*;
         match self {
-            AdviceInjectorNode::PushU64div => target.write_u8(PUSH_U64DIV),
-            AdviceInjectorNode::PushExt2intt => target.write_u8(PUSH_EXT2INTT),
-            AdviceInjectorNode::PushSmtGet => target.write_u8(PUSH_SMTGET),
-            AdviceInjectorNode::PushMapVal => target.write_u8(PUSH_MAPVAL),
-            AdviceInjectorNode::PushMtNode => target.write_u8(PUSH_MTNODE),
-            AdviceInjectorNode::InsertMem => target.write_u8(INSERT_MEM),
-            AdviceInjectorNode::InsertHdword { domain } => {
+            PushU64div => target.write_u8(PUSH_U64DIV),
+            PushExt2intt => target.write_u8(PUSH_EXT2INTT),
+            PushSmtGet => target.write_u8(PUSH_SMTGET),
+            PushMapVal => target.write_u8(PUSH_MAPVAL),
+            PushMapValImm { offset } => {
+                target.write_u8(PUSH_MAPVAL_IMM);
+                target.write_u8(*offset);
+            }
+            PushMapValN => target.write_u8(PUSH_MAPVALN),
+            PushMapValNImm { offset } => {
+                target.write_u8(PUSH_MAPVALN_IMM);
+                target.write_u8(*offset);
+            }
+            PushMtNode => target.write_u8(PUSH_MTNODE),
+            InsertMem => target.write_u8(INSERT_MEM),
+            InsertHdword { domain } => {
                 target.write_u8(INSERT_HDWORD);
                 target.write_u8(*domain);
             }
@@ -89,6 +128,21 @@ impl Deserializable for AdviceInjectorNode {
             PUSH_EXT2INTT => Ok(AdviceInjectorNode::PushExt2intt),
             PUSH_SMTGET => Ok(AdviceInjectorNode::PushSmtGet),
             PUSH_MAPVAL => Ok(AdviceInjectorNode::PushMapVal),
+            PUSH_MAPVAL_IMM => {
+                let offset = source.read_u8()?;
+                if offset > MAX_STACK_WORD_OFFSET {
+                    return Err(DeserializationError::InvalidValue("invalid offset".to_string()));
+                }
+                Ok(AdviceInjectorNode::PushMapValImm { offset })
+            }
+            PUSH_MAPVALN => Ok(AdviceInjectorNode::PushMapValN),
+            PUSH_MAPVALN_IMM => {
+                let offset = source.read_u8()?;
+                if offset > MAX_STACK_WORD_OFFSET {
+                    return Err(DeserializationError::InvalidValue("invalid offset".to_string()));
+                }
+                Ok(AdviceInjectorNode::PushMapValNImm { offset })
+            }
             PUSH_MTNODE => Ok(AdviceInjectorNode::PushMtNode),
             INSERT_MEM => Ok(AdviceInjectorNode::InsertMem),
             INSERT_HDWORD => {

--- a/assembly/src/ast/parsers/adv_ops.rs
+++ b/assembly/src/ast/parsers/adv_ops.rs
@@ -66,10 +66,14 @@ pub fn parse_adv_inject(op: &Token) -> Result<Node, ParsingError> {
             _ => return Err(ParsingError::extra_param(op)),
         },
         "insert_hdword" => match op.num_parts() {
-            2 => AdvInject(InsertHdword { domain: 0 }),
+            2 => AdvInject(InsertHdword),
             3 => {
                 let domain = parse_checked_param::<u8, _>(op, 2, 0..=u8::MAX)?;
-                AdvInject(InsertHdword { domain })
+                if domain == 0 {
+                    AdvInject(InsertHdword)
+                } else {
+                    AdvInject(InsertHdwordImm { domain })
+                }
             }
             _ => return Err(ParsingError::extra_param(op)),
         },

--- a/assembly/src/ast/parsers/adv_ops.rs
+++ b/assembly/src/ast/parsers/adv_ops.rs
@@ -3,7 +3,7 @@ use super::{
     AdviceInjectorNode::*,
     Instruction::AdvInject,
     Node::{self, Instruction},
-    ParsingError, Token,
+    ParsingError, Token, MAX_STACK_WORD_OFFSET,
 };
 
 // INSTRUCTION PARSERS
@@ -35,6 +35,26 @@ pub fn parse_adv_inject(op: &Token) -> Result<Node, ParsingError> {
         },
         "push_mapval" => match op.num_parts() {
             2 => AdvInject(PushMapVal),
+            3 => {
+                let offset = parse_checked_param::<u8, _>(op, 2, 0..=MAX_STACK_WORD_OFFSET)?;
+                if offset == 0 {
+                    AdvInject(PushMapVal)
+                } else {
+                    AdvInject(PushMapValImm { offset })
+                }
+            }
+            _ => return Err(ParsingError::extra_param(op)),
+        },
+        "push_mapvaln" => match op.num_parts() {
+            2 => AdvInject(PushMapValN),
+            3 => {
+                let offset = parse_checked_param::<u8, _>(op, 2, 0..=MAX_STACK_WORD_OFFSET)?;
+                if offset == 0 {
+                    AdvInject(PushMapValN)
+                } else {
+                    AdvInject(PushMapValNImm { offset })
+                }
+            }
             _ => return Err(ParsingError::extra_param(op)),
         },
         "push_mtnode" => match op.num_parts() {

--- a/assembly/src/ast/parsers/mod.rs
+++ b/assembly/src/ast/parsers/mod.rs
@@ -3,6 +3,7 @@ use super::{
     Instruction, InvocationTarget, LabelError, LibraryPath, LocalConstMap, LocalProcMap, Node,
     ParsingError, ProcedureAst, ProcedureId, RpoDigest, SliceReader, StarkField, Token,
     TokenStream, Vec, MAX_BODY_LEN, MAX_DOCS_LEN, MAX_IMPORTS, MAX_LABEL_LEN,
+    MAX_STACK_WORD_OFFSET,
 };
 use core::{fmt::Display, ops::RangeBounds};
 

--- a/core/src/operations/decorators/advice.rs
+++ b/core/src/operations/decorators/advice.rs
@@ -48,18 +48,29 @@ pub enum AdviceInjector {
     MerkleNodeToStack,
 
     /// Pushes a list of field elements onto the advice stack. The list is looked up in the advice
-    /// map using the top 4 elements (i.e. word) from the operand stack as the key.
+    /// map using the specified word from the operand stack as the key. If `include_len` is set to
+    /// true, the number of elements in the value is also pushed onto the advice stack.
     ///
     /// Inputs:
-    ///   Operand stack: [KEY, ...]
+    ///   Operand stack: [<key_offset>, KEY, ...]
     ///   Advice stack: [...]
     ///   Advice map: {KEY: values}
     ///
     /// Outputs:
-    ///   Operand stack: [KEY, ...]
-    ///   Advice stack: [values, ...]
+    ///   Operand stack: [<key_offset>, KEY, ...]
+    ///   Advice stack: [values_len?, values, ...]
     ///   Advice map: {KEY: values}
-    MapValueToStack,
+    ///
+    /// The `key_offset` value specifies the location of the `KEY` on the stack. For example,
+    /// offset value of 0 indicates that the top word on the stack should be used as the key, the
+    /// offset value of 4, indicates that the second word on the stack should be used as the key
+    /// etc.
+    ///
+    /// The valid values of `key_offset` are 0 through 12 (inclusive).
+    MapValueToStack {
+        include_len: bool,
+        key_offset: usize,
+    },
 
     /// Pushes the result of [u64] division (both the quotient and the remainder) onto the advice
     /// stack.
@@ -177,7 +188,16 @@ impl fmt::Display for AdviceInjector {
         match self {
             Self::MerkleNodeMerge => write!(f, "merkle_node_merge"),
             Self::MerkleNodeToStack => write!(f, "merkle_node_to_stack"),
-            Self::MapValueToStack => write!(f, "map_value_to_stack"),
+            Self::MapValueToStack {
+                include_len,
+                key_offset,
+            } => {
+                if *include_len {
+                    write!(f, "map_value_to_stack_with_len.{key_offset}")
+                } else {
+                    write!(f, "map_value_to_stack.{key_offset}")
+                }
+            }
             Self::DivU64 => write!(f, "div_u64"),
             Self::Ext2Inv => write!(f, "ext2_inv"),
             Self::Ext2Intt => write!(f, "ext2_intt"),

--- a/core/src/operations/decorators/advice.rs
+++ b/core/src/operations/decorators/advice.rs
@@ -52,12 +52,12 @@ pub enum AdviceInjector {
     /// true, the number of elements in the value is also pushed onto the advice stack.
     ///
     /// Inputs:
-    ///   Operand stack: [<key_offset>, KEY, ...]
+    ///   Operand stack: [..., KEY, ...]
     ///   Advice stack: [...]
     ///   Advice map: {KEY: values}
     ///
     /// Outputs:
-    ///   Operand stack: [<key_offset>, KEY, ...]
+    ///   Operand stack: [..., KEY, ...]
     ///   Advice stack: [values_len?, values, ...]
     ///   Advice map: {KEY: values}
     ///

--- a/docs/src/user_docs/assembly/io_operations.md
+++ b/docs/src/user_docs/assembly/io_operations.md
@@ -47,7 +47,8 @@ Advice injectors fall into two categories: (1) injectors which push new data ont
 
 | Instruction       | Stack_input | Stack_output | Notes                                      |
 | ----------------- | ----------- | ------------ | ------------------------------------------ |
-| adv.push_mapval   | [K, ... ]   | [K, ... ]    | Pushes a list of field elements onto the advice stack. The list is looked up in the advice map using workd $K$ as the key. |
+| adv.push_mapval <br> adv.push_mapval.*s* | [K, ... ]   | [K, ... ]    | Pushes a list of field elements onto the advice stack. The list is looked up in the advice map using word $K$ as the key. If offset $s$ is provided, the key is taken starting from item $s$ on the stack. |
+| adv.push_mapvaln <br> adv.push_mapvaln.*s* | [K, ... ]   | [K, ... ]    | Pushes a list of field elements together with the number of elements onto the advice stack. The list is looked up in the advice map using word $K$ as the key. If offset $s$ is provided, the key is taken starting from item $s$ on the stack. |
 | adv.push_mtnode   | [d, i, R, ... ] | [d, i, R, ... ] | Pushes a node of a Merkle tree with root $R$ at depth $d$ and index $i$ from Merkle store onto the advice stack. |
 | adv.push_u64div   | [b1, b0, a1, a0, ...] | [b1, b0, a1, a0, ...] | Pushes the result of `u64` division $a / b$ onto the advice stack. Both $a$ and $b$ are represented using 32-bit limbs. The result consists of both the quotient and the remainder. |
 | adv.push_ext2intt | [osize, isize, iptr, ... ] | [osize, isize, iptr, ... ] | Given evaluations of a polynomial over some specified domain, interpolates the evaluations into a polynomial in coefficient form and pushes the result into the advice stack. |

--- a/processor/src/advice/mem_provider.rs
+++ b/processor/src/advice/mem_provider.rs
@@ -67,12 +67,16 @@ impl AdviceProvider for MemAdviceProvider {
                 Ok(())
             }
 
-            AdviceSource::Map { key } => {
-                let map = self
+            AdviceSource::Map { key, include_len } => {
+                let values = self
                     .map
                     .get(&key.into_bytes())
                     .ok_or(ExecutionError::AdviceKeyNotFound(key))?;
-                self.stack.extend(map.iter().rev());
+
+                self.stack.extend(values.iter().rev());
+                if include_len {
+                    self.stack.push(Felt::from(values.len() as u64));
+                }
                 Ok(())
             }
         }

--- a/processor/src/advice/source.rs
+++ b/processor/src/advice/source.rs
@@ -12,15 +12,22 @@ pub enum AdviceSource {
     /// Fetches a list of elements under the specified key from the advice map and pushes them onto
     /// the advice stack.
     ///
+    /// If `include_len` is set to true, this also pushes the number of elements ont the advice
+    /// stack.
+    ///
     /// Note: this operation doesn't consume the map element so it can be called multiple times
     /// for the same key.
     ///
     /// # Example
-    /// Given an advice stack `[a, b, c, ...]`, and a map `x |-> [d, e, f]`, a call
-    /// `push_stack(AdviceSource::Map { key: x })` will result in  `[f, e, d, a, b, c, ...]` for
-    /// the advice stack, and will preserve `x |-> [d, e, f]` in the advice map.
+    /// Given an advice stack `[a, b, c, ...]`, and a map `x |-> [d, e, f]`:
+    ///
+    /// A call `push_stack(AdviceSource::Map { key: x, include_len: false })` will result in
+    /// advice stack: `[d, e, f, a, b, c, ...]`.
+    ///
+    /// A call `push_stack(AdviceSource::Map { key: x, include_len: true })` will result in
+    /// advice stack: `[3, d, e, f, a, b, c, ...]`.
     ///
     /// # Errors
     /// Returns an error if the key was not found in the key-value map.
-    Map { key: Word },
+    Map { key: Word, include_len: bool },
 }

--- a/processor/src/decorators/adv_stack_injectors.rs
+++ b/processor/src/decorators/adv_stack_injectors.rs
@@ -72,12 +72,12 @@ where
     /// true, the number of elements in the value is also pushed onto the advice stack.
     ///
     /// Inputs:
-    ///   Operand stack: [<key_offset>, KEY, ...]
+    ///   Operand stack: [..., KEY, ...]
     ///   Advice stack: [...]
     ///   Advice map: {KEY: values}
     ///
     /// Outputs:
-    ///   Operand stack: [<key_offset>, KEY, ...]
+    ///   Operand stack: [..., KEY, ...]
     ///   Advice stack: [values_len?, values, ...]
     ///   Advice map: {KEY: values}
     ///

--- a/processor/src/decorators/mod.rs
+++ b/processor/src/decorators/mod.rs
@@ -37,7 +37,10 @@ where
         match injector {
             AdviceInjector::MerkleNodeMerge => self.merge_merkle_nodes(),
             AdviceInjector::MerkleNodeToStack => self.copy_merkle_node_to_adv_stack(),
-            AdviceInjector::MapValueToStack => self.copy_map_value_to_adv_stack(),
+            AdviceInjector::MapValueToStack {
+                include_len,
+                key_offset,
+            } => self.copy_map_value_to_adv_stack(*include_len, *key_offset),
             AdviceInjector::DivU64 => self.push_u64_div_result(),
             AdviceInjector::Ext2Inv => self.push_ext2_inv_result(),
             AdviceInjector::Ext2Intt => self.push_ext2_intt_result(),

--- a/processor/src/errors.rs
+++ b/processor/src/errors.rs
@@ -27,6 +27,7 @@ pub enum ExecutionError {
     InvalidFriLayerFolding(QuadFelt, QuadFelt),
     InvalidMemoryRange { start_addr: u64, end_addr: u64 },
     InvalidStackDepthOnReturn(usize),
+    InvalidStackWordOffset(usize),
     InvalidTreeDepth { depth: Felt },
     InvalidTreeNodeIndex { depth: Felt, value: Felt },
     MemoryAddressOutOfBounds(u64),
@@ -80,6 +81,9 @@ impl Display for ExecutionError {
             }
             InvalidStackDepthOnReturn(depth) => {
                 write!(f, "When returning from a call, stack depth must be {STACK_TOP_SIZE}, but was {depth}")
+            }
+            InvalidStackWordOffset(offset) => {
+                write!(f, "Stack word offset cannot exceed 12, but was {offset}")
             }
             InvalidTreeDepth { depth } => {
                 write!(f, "The provided {depth} is out of bounds and cannot be represented as an unsigned 8-bits integer")


### PR DESCRIPTION
This PR addresses #835 and #880 but introducing additional variants of `adv.push_mapval` instruction. Specifically:

- We add `adv.push_mapvaln` instruction to enable pushing the number of elements in a value list onto the advice stack.
- We allow parameterization of both `adv.push_mapval` and `adv.push_mapvaln` to specify the offset of the key on the stack.

Tasks:

- [x] Implement `adv.push_mapvaln` instruction.
- [x] Add parameterization to `adv.push_mapval` and `adv.push_mapvaln` instructions.
- [x] Write tests.
- [x] Update docs.

