### PR TITLE
Remove request side from bitwise chiplet bus constraint 

### DIFF
--- a/docs/src/design/chiplets/bitwise.md
+++ b/docs/src/design/chiplets/bitwise.md
@@ -131,8 +131,10 @@ $$
 To simplify the notation for describing bitwise constraints on the chiplet bus, we'll first define variable $u$, which represents how $a$, $b$, and $z$ in the execution trace are reduced to a single value. Denoting the random values received from the verifier as $\alpha_0, \alpha_1$, etc., this can be achieved as follows.
 
 $$
-u = \alpha_1 \cdot a + \alpha_2 \cdot b + \alpha_3 \cdot z
+u = \alpha_0 + \alpha_1 \cdot op_{bit} + \alpha_2 \cdot a + \alpha_3 \cdot b + \alpha_4 \cdot z
 $$
+
+Where, $op_{bit}$ is the unique [operation label](./main.md#operation-labels) of the bitwise operation.
 
 The request side constraint for the bitwise operation is described in the [stack bitwise operation section](../stack/u32_ops.md#u32and).
 
@@ -147,13 +149,13 @@ $$
 Then, setting $m = 1 - k_1$, we can compute the permutation product from the bitwise chiplet as follows:
 
 $$
-\prod_{i=0}^n ((\alpha_0 + v_i) \cdot m_i + 1 - m_i)
+\prod_{i=0}^n (v_i \cdot m_i + 1 - m_i)
 $$
 
-The above ensures that when $1 - k_1 = 0$ (which is true for all rows in the 8-row cycle except for the last one), the product does not change. Otherwise, $(\alpha_0 + v_i)$ gets included into the product.
+The above ensures that when $1 - k_1 = 0$ (which is true for all rows in the 8-row cycle except for the last one), the product does not change. Otherwise, $v_i$ gets included into the product.
 
 The response side of the bus communication can be enforced with the following constraint:
 
 > $$
-b'_{chip} = b_{chip} \cdot ((\alpha_0 + v_i) \cdot m_i + 1 - m_i) \text{ | degree} = 4
+b'_{chip} = b_{chip} \cdot (v_i \cdot m_i + 1 - m_i) \text{ | degree} = 4
 $$

--- a/docs/src/design/chiplets/bitwise.md
+++ b/docs/src/design/chiplets/bitwise.md
@@ -49,7 +49,7 @@ AIR constraints needed to ensure the correctness of the above table are describe
 
 ### Selectors
 
-The Bitwise chiplet supports three operations with the following operation selectors:
+The Bitwise chiplet supports two operations with the following operation selectors:
 
 - `U32AND`: $s = 0$
 - `U32XOR`: $s = 1$
@@ -134,11 +134,7 @@ $$
 u = \alpha_1 \cdot a + \alpha_2 \cdot b + \alpha_3 \cdot z
 $$
 
-To request a bitwise operation, the prover will provide the values of $a$, $b$, and $z$ non-deterministically to the [stack](../stack/u32_ops.md#u32and) (the component that makes bitwise requests). The lookup can then be performed by dividing $\left(\alpha_0 + u\right)$ out of the bus column:
-
-$$
-b'_{chip} \cdot \left(\alpha_0 + u\right) = b_{chip}
-$$
+The request side constraint for the bitwise operation is described in the [stack bitwise operation section](../stack/u32_ops.md#u32and).
 
 To provide the results of bitwise operations to the chiplets bus, we want to include values of $a$, $b$ and $z$ at the last row of the cycle.
 
@@ -156,8 +152,8 @@ $$
 
 The above ensures that when $1 - k_1 = 0$ (which is true for all rows in the 8-row cycle except for the last one), the product does not change. Otherwise, $(\alpha_0 + v_i)$ gets included into the product.
 
-The constraints for the two sides of the bus communication are combined as follows:
+The response side of the bus communication can be enforced with the following constraint:
 
 > $$
-b'_{chip} \cdot \left(\alpha_0 + u_i\right) = b_{chip} \cdot ((\alpha_0 + v_i) \cdot m_i + 1 - m_i) \text{ | degree} = 4
+b'_{chip} = b_{chip} \cdot ((\alpha_0 + v_i) \cdot m_i + 1 - m_i) \text{ | degree} = 4
 $$


### PR DESCRIPTION
This PR removes documentation about request side from the [bitwise chiplet bus constraint](https://0xpolygonmiden.github.io/miden-vm/design/chiplets/bitwise.html#bitwise-chiplet-bus-constraints). Now documentation redirects user to the stack u32 operations where request side is described. 
