### PR TITLE
Update miden-crypto dependency to the latest version

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -21,7 +21,7 @@ std = ["math/std", "winter-utils/std"]
 
 [dependencies]
 math = { package = "winter-math", version = "0.6", default-features = false }
-crypto = { package = "miden-crypto", version = "0.5", default-features = false }
+crypto = { package = "miden-crypto", version = "0.6", default-features = false }
 winter-crypto = { package = "winter-crypto", version = "0.6", default-features = false }
 winter-utils = { package = "winter-utils", version = "0.6", default-features = false }
 

--- a/miden/tests/integration/air/chiplets/hasher.rs
+++ b/miden/tests/integration/air/chiplets/hasher.rs
@@ -88,7 +88,8 @@ fn mtree_merge() {
     let root_b = tree_b.root();
     let root_merged = Rpo256::merge(&[root_a.into(), root_b.into()]);
     let mut store = MerkleStore::default();
-    store.extend(tree_a.inner_nodes()).extend(tree_b.inner_nodes());
+    store.extend(tree_a.inner_nodes());
+    store.extend(tree_b.inner_nodes());
 
     let stack_inputs = vec![
         0xbeef,

--- a/processor/src/advice/mem_provider.rs
+++ b/processor/src/advice/mem_provider.rs
@@ -103,7 +103,8 @@ impl AdviceProvider for MemAdviceProvider {
             }
         })?;
         self.store
-            .get_node(root, index)
+            .get_node(root.into(), index)
+            .map(|v| v.into())
             .map_err(ExecutionError::MerkleStoreLookupFailed)
     }
 
@@ -120,7 +121,7 @@ impl AdviceProvider for MemAdviceProvider {
             }
         })?;
         self.store
-            .get_path(root, index)
+            .get_path(root.into(), index)
             .map(|value| value.path)
             .map_err(ExecutionError::MerkleStoreLookupFailed)
     }
@@ -134,7 +135,7 @@ impl AdviceProvider for MemAdviceProvider {
         let tree_depth = u8::try_from(tree_depth.as_int())
             .map_err(|_| ExecutionError::InvalidTreeDepth { depth: *tree_depth })?;
         self.store
-            .get_leaf_depth(root, tree_depth, index.as_int())
+            .get_leaf_depth(root.into(), tree_depth, index.as_int())
             .map_err(ExecutionError::MerkleStoreLookupFailed)
     }
 
@@ -152,13 +153,16 @@ impl AdviceProvider for MemAdviceProvider {
             }
         })?;
         self.store
-            .set_node(root, node_index, value)
+            .set_node(root.into(), node_index, value.into())
             .map(|root| root.path)
             .map_err(ExecutionError::MerkleStoreUpdateFailed)
     }
 
     fn merge_roots(&mut self, lhs: Word, rhs: Word) -> Result<Word, ExecutionError> {
-        self.store.merge_roots(lhs, rhs).map_err(ExecutionError::MerkleStoreMergeFailed)
+        self.store
+            .merge_roots(lhs.into(), rhs.into())
+            .map(|v| v.into())
+            .map_err(ExecutionError::MerkleStoreMergeFailed)
     }
 
     // CONTEXT MANAGEMENT
@@ -175,7 +179,7 @@ impl MemAdviceProvider {
 
     /// Returns true if the Merkle root exists for the advice provider Merkle store.
     #[cfg(test)]
-    pub fn has_merkle_root(&self, root: Word) -> bool {
+    pub fn has_merkle_root(&self, root: crate::crypto::RpoDigest) -> bool {
         self.store.get_node(root, NodeIndex::root()).is_ok()
     }
 }

--- a/processor/src/chiplets/hasher/mod.rs
+++ b/processor/src/chiplets/hasher/mod.rs
@@ -1,6 +1,7 @@
 use super::{
     trace::LookupTableRow, BTreeMap, ChipletsVTableTraceBuilder, ColMatrix, Felt, FieldElement,
-    HasherState, MerkleRootUpdate, OpBatch, StarkField, TraceFragment, Vec, Word, ONE, ZERO,
+    HasherState, MerklePath, MerkleRootUpdate, OpBatch, StarkField, TraceFragment, Vec, Word, ONE,
+    ZERO,
 };
 use miden_air::trace::chiplets::hasher::{
     Digest, Selectors, DIGEST_LEN, DIGEST_RANGE, HASH_CYCLE_LEN, LINEAR_HASH, LINEAR_HASH_LABEL,
@@ -289,7 +290,7 @@ impl Hasher {
     pub(super) fn build_merkle_root(
         &mut self,
         value: Word,
-        path: &[Word],
+        path: &MerklePath,
         index: Felt,
         lookups: &mut Vec<HasherLookup>,
     ) -> (Felt, Word) {
@@ -321,7 +322,7 @@ impl Hasher {
         &mut self,
         old_value: Word,
         new_value: Word,
-        path: &[Word],
+        path: &MerklePath,
         index: Felt,
         lookups: &mut Vec<HasherLookup>,
     ) -> MerkleRootUpdate {
@@ -377,7 +378,7 @@ impl Hasher {
     fn verify_merkle_path(
         &mut self,
         value: Word,
-        path: &[Word],
+        path: &MerklePath,
         mut index: u64,
         context: MerklePathContext,
         lookups: &mut Vec<HasherLookup>,
@@ -449,7 +450,7 @@ impl Hasher {
     fn verify_mp_leg(
         &mut self,
         root: Word,
-        sibling: Word,
+        sibling: Digest,
         index: &mut u64,
         init_selectors: Selectors,
         final_selectors: Selectors,
@@ -505,13 +506,13 @@ impl Hasher {
         &mut self,
         context: MerklePathContext,
         index: u64,
-        sibling: Word,
+        sibling: Digest,
         depth: usize,
     ) {
         let step = self.trace.trace_len() as u32;
         match context {
             MerklePathContext::MrUpdateOld => {
-                self.aux_trace.sibling_added(step, Felt::new(index), sibling);
+                self.aux_trace.sibling_added(step, Felt::new(index), sibling.into());
             }
             MerklePathContext::MrUpdateNew => {
                 // we use node depth as row offset here because siblings are added to the table

--- a/processor/src/chiplets/hasher/tests.rs
+++ b/processor/src/chiplets/hasher/tests.rs
@@ -1,7 +1,7 @@
 use super::{
     init_state_from_words, lookups::HasherLookupContext, Digest, Felt, Hasher, HasherLookup,
-    HasherState, Selectors, TraceFragment, Vec, Word, LINEAR_HASH, MP_VERIFY, MR_UPDATE_NEW,
-    MR_UPDATE_OLD, RETURN_HASH, RETURN_STATE, TRACE_WIDTH,
+    HasherState, MerklePath, Selectors, TraceFragment, Vec, Word, LINEAR_HASH, MP_VERIFY,
+    MR_UPDATE_NEW, MR_UPDATE_OLD, RETURN_HASH, RETURN_STATE, TRACE_WIDTH,
 };
 use crate::chiplets::aux_trace::{
     ChipletsVTableRow, ChipletsVTableTraceBuilder, ChipletsVTableUpdate,
@@ -452,8 +452,8 @@ fn hasher_update_merkle_root() {
     assert_eq!(expected_hints, aux_hints.hints());
 
     let expected_sibling_rows = vec![
-        ChipletsVTableRow::new_sibling(ZERO, path0[0]),
-        ChipletsVTableRow::new_sibling(ONE, path1[0]),
+        ChipletsVTableRow::new_sibling(ZERO, path0[0].into()),
+        ChipletsVTableRow::new_sibling(ONE, path1[0].into()),
     ];
     assert_eq!(expected_sibling_rows, aux_hints.rows());
 
@@ -616,17 +616,17 @@ fn hasher_update_merkle_root() {
 
     let expected_sibling_rows = vec![
         // first update
-        ChipletsVTableRow::new_sibling(Felt::new(3), path3[0]),
-        ChipletsVTableRow::new_sibling(Felt::new(3 >> 1), path3[1]),
-        ChipletsVTableRow::new_sibling(Felt::new(3 >> 2), path3[2]),
+        ChipletsVTableRow::new_sibling(Felt::new(3), path3[0].into()),
+        ChipletsVTableRow::new_sibling(Felt::new(3 >> 1), path3[1].into()),
+        ChipletsVTableRow::new_sibling(Felt::new(3 >> 2), path3[2].into()),
         // second update
-        ChipletsVTableRow::new_sibling(Felt::new(6), path6[0]),
-        ChipletsVTableRow::new_sibling(Felt::new(6 >> 1), path6[1]),
-        ChipletsVTableRow::new_sibling(Felt::new(6 >> 2), path6[2]),
+        ChipletsVTableRow::new_sibling(Felt::new(6), path6[0].into()),
+        ChipletsVTableRow::new_sibling(Felt::new(6 >> 1), path6[1].into()),
+        ChipletsVTableRow::new_sibling(Felt::new(6 >> 2), path6[2].into()),
         // third update
-        ChipletsVTableRow::new_sibling(Felt::new(3), path3_2[0]),
-        ChipletsVTableRow::new_sibling(Felt::new(3 >> 1), path3_2[1]),
-        ChipletsVTableRow::new_sibling(Felt::new(3 >> 2), path3_2[2]),
+        ChipletsVTableRow::new_sibling(Felt::new(3), path3_2[0].into()),
+        ChipletsVTableRow::new_sibling(Felt::new(3 >> 1), path3_2[1].into()),
+        ChipletsVTableRow::new_sibling(Felt::new(3 >> 2), path3_2[2].into()),
     ];
     assert_eq!(expected_sibling_rows, aux_hints.rows());
 }
@@ -1055,7 +1055,7 @@ fn check_merkle_path(
     trace: &[Vec<Felt>],
     row_idx: usize,
     leaf: Word,
-    path: &[Word],
+    path: &MerklePath,
     node_index: u64,
     init_selectors: Selectors,
 ) {

--- a/processor/src/chiplets/mod.rs
+++ b/processor/src/chiplets/mod.rs
@@ -1,6 +1,6 @@
 use super::{
-    trace, utils, BTreeMap, ChipletsTrace, ColMatrix, ExecutionError, Felt, FieldElement,
-    RangeChecker, StarkField, TraceFragment, Vec, Word, CHIPLETS_WIDTH, ONE, ZERO,
+    crypto::MerklePath, trace, utils, BTreeMap, ChipletsTrace, ColMatrix, ExecutionError, Felt,
+    FieldElement, RangeChecker, StarkField, TraceFragment, Vec, Word, CHIPLETS_WIDTH, ONE, ZERO,
 };
 use miden_air::trace::chiplets::{
     bitwise::{BITWISE_AND_LABEL, BITWISE_XOR_LABEL},
@@ -191,7 +191,12 @@ impl Chiplets {
     /// Panics if:
     /// - The provided path does not contain any nodes.
     /// - The provided index is out of range for the specified path.
-    pub fn build_merkle_root(&mut self, value: Word, path: &[Word], index: Felt) -> (Felt, Word) {
+    pub fn build_merkle_root(
+        &mut self,
+        value: Word,
+        path: &MerklePath,
+        index: Felt,
+    ) -> (Felt, Word) {
         let mut lookups = Vec::new();
         let (addr, root) = self.hasher.build_merkle_root(value, path, index, &mut lookups);
 
@@ -213,7 +218,7 @@ impl Chiplets {
         &mut self,
         old_value: Word,
         new_value: Word,
-        path: &[Word],
+        path: &MerklePath,
         index: Felt,
     ) -> MerkleRootUpdate {
         let mut lookups = Vec::new();

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -68,7 +68,7 @@ pub mod math {
 pub mod crypto {
     pub use vm_core::crypto::{
         hash::{Blake3_192, Blake3_256, ElementHasher, Hasher, Rpo256, RpoDigest},
-        merkle::{MerkleError, MerkleStore, MerkleTree, SimpleSmt},
+        merkle::{MerkleError, MerklePath, MerkleStore, MerkleTree, SimpleSmt},
         random::{RandomCoin, RpoRandomCoin, WinterRandomCoin},
     };
 }

--- a/processor/src/operations/crypto_ops.rs
+++ b/processor/src/operations/crypto_ops.rs
@@ -335,7 +335,8 @@ mod tests {
 
         // appends only the input trees to the Merkle store
         let mut store = MerkleStore::default();
-        store.extend(tree_a.inner_nodes()).extend(tree_b.inner_nodes());
+        store.extend(tree_a.inner_nodes());
+        store.extend(tree_b.inner_nodes());
 
         // set the target coordinates to update the indexes 4..8
         let target_depth = 2;

--- a/processor/src/trace/tests/hasher.rs
+++ b/processor/src/trace/tests/hasher.rs
@@ -22,9 +22,9 @@ fn hasher_p1_mp_verify() {
 
     // build program inputs
     let mut init_stack = vec![];
-    append_word(&mut init_stack, node);
+    append_word(&mut init_stack, node.into());
     init_stack.extend_from_slice(&[3, 1]);
-    append_word(&mut init_stack, tree.root());
+    append_word(&mut init_stack, tree.root().into());
     init_stack.reverse();
     let stack_inputs = StackInputs::try_from_values(init_stack).unwrap();
     let advice_inputs = AdviceInputs::default().with_merkle_store(store);
@@ -54,9 +54,9 @@ fn hasher_p1_mr_update() {
 
     // build program inputs
     let mut init_stack = vec![];
-    append_word(&mut init_stack, old_node);
+    append_word(&mut init_stack, old_node.into());
     init_stack.extend_from_slice(&[3, index]);
-    append_word(&mut init_stack, tree.root());
+    append_word(&mut init_stack, tree.root().into());
     append_word(&mut init_stack, new_node);
 
     init_stack.reverse();
@@ -72,11 +72,11 @@ fn hasher_p1_mr_update() {
     let p1 = aux_columns.get_column(P1_COL_IDX);
 
     let row_values = [
-        ChipletsVTableRow::new_sibling(Felt::new(index), path[0])
+        ChipletsVTableRow::new_sibling(Felt::new(index), path[0].into())
             .to_value(&trace.main_trace, &alphas),
-        ChipletsVTableRow::new_sibling(Felt::new(index >> 1), path[1])
+        ChipletsVTableRow::new_sibling(Felt::new(index >> 1), path[1].into())
             .to_value(&trace.main_trace, &alphas),
-        ChipletsVTableRow::new_sibling(Felt::new(index >> 2), path[2])
+        ChipletsVTableRow::new_sibling(Felt::new(index >> 2), path[2].into())
             .to_value(&trace.main_trace, &alphas),
     ];
 

--- a/stdlib/tests/collections/smt.rs
+++ b/stdlib/tests/collections/smt.rs
@@ -377,6 +377,6 @@ impl SmtLeaf {
 
     /// Insert the leaf onto the [MerkleStore], returning the new root value.
     pub fn insert(&self, store: &mut MerkleStore, root: Word) -> Word {
-        store.set_node(root, self.index, self.node).unwrap().root
+        store.set_node(root.into(), self.index, self.node.into()).unwrap().root.into()
     }
 }

--- a/stdlib/tests/collections/smt64.rs
+++ b/stdlib/tests/collections/smt64.rs
@@ -47,9 +47,9 @@ fn get() {
 
     for (index, value) in LEAVES {
         let mut initial_stack = Vec::new();
-        append_word_to_vec(&mut initial_stack, smt.root());
+        append_word_to_vec(&mut initial_stack, smt.root().into());
         initial_stack.push(index);
-        let expected_output = build_expected_stack(value, smt.root());
+        let expected_output = build_expected_stack(value, smt.root().into());
 
         let store = MerkleStore::from(&smt);
         build_test!(source, &initial_stack, &[], store, vec![]).expect_stack(&expected_output);
@@ -118,7 +118,8 @@ fn set() {
         let value = [ZERO; 4];
         let (init_stack, final_stack, store) = prepare_insert_or_set(*index, value, &mut smt);
 
-        let expected_final_stack = build_expected_stack(*old_value, old_roots.pop().unwrap());
+        let expected_final_stack =
+            build_expected_stack(*old_value, old_roots.pop().unwrap().into());
         assert_eq!(expected_final_stack, final_stack);
         build_test!(source, &init_stack, &[], store, vec![]).expect_stack(&final_stack);
     }
@@ -136,7 +137,7 @@ fn prepare_insert_or_set(
 ) -> (Vec<u64>, Vec<u64>, MerkleStore) {
     // set initial state of the stack to be [VALUE, key, ROOT, ...]
     let mut initial_stack = Vec::new();
-    append_word_to_vec(&mut initial_stack, smt.root());
+    append_word_to_vec(&mut initial_stack, smt.root().into());
     initial_stack.push(index);
     append_word_to_vec(&mut initial_stack, value);
 
@@ -145,7 +146,7 @@ fn prepare_insert_or_set(
     let old_value = smt.update_leaf(index, value).unwrap();
 
     // after insert or set, the stack should be [OLD_VALUE, ROOT, ...]
-    let expected_output = build_expected_stack(old_value, smt.root());
+    let expected_output = build_expected_stack(old_value, smt.root().into());
 
     (initial_stack, expected_output, store)
 }

--- a/stdlib/tests/crypto/stark/verifier_recursive/channel.rs
+++ b/stdlib/tests/crypto/stark/verifier_recursive/channel.rs
@@ -251,18 +251,8 @@ impl VerifierChannel {
                 })
                 .collect();
 
-            let paths: Vec<MerklePath> = unbatched_proof
-                .iter()
-                .map(|list| {
-                    list.iter()
-                        .map(|digest| {
-                            let node = digest.as_elements();
-                            let node = [node[0], node[1], node[2], node[3]];
-                            node
-                        })
-                        .collect()
-                })
-                .collect();
+            let paths: Vec<MerklePath> =
+                unbatched_proof.into_iter().map(|list| list.into()).collect();
 
             let new_set = MerklePathSet::new((current_domain_size / N).ilog2() as u8);
 
@@ -272,7 +262,7 @@ impl VerifierChannel {
             let iter_paths = paths.into_iter();
             let mut tmp_vec = Vec::new();
             for (p, (node, path)) in iter_pos.zip(iter_nodes.zip(iter_paths)) {
-                tmp_vec.push((p, *node, path));
+                tmp_vec.push((p, RpoDigest::from(*node), path));
             }
 
             let new_set = new_set.with_paths(tmp_vec).expect("should not fail from paths");
@@ -501,18 +491,7 @@ pub fn unbatch_to_path_set(
         })
         .collect();
 
-    let paths: Vec<MerklePath> = unbatched_proof
-        .iter()
-        .map(|list| {
-            list.iter()
-                .map(|digest| {
-                    let node = digest.as_elements();
-                    let node = [node[0], node[1], node[2], node[3]];
-                    node
-                })
-                .collect()
-        })
-        .collect();
+    let paths: Vec<MerklePath> = unbatched_proof.into_iter().map(|list| list.into()).collect();
 
     let new_set = MerklePathSet::new(depth - 1);
 
@@ -522,7 +501,7 @@ pub fn unbatch_to_path_set(
     let iter_paths = paths.into_iter();
     let mut tmp_vec = vec![];
     for (p, (node, path)) in iter_pos.zip(iter_nodes.zip(iter_paths)) {
-        tmp_vec.push((p, *node, path));
+        tmp_vec.push((p, RpoDigest::from(*node), path));
     }
 
     let _empty: () = nodes


### PR DESCRIPTION
This PR updates `miden-crypto` crypto dependency to the latest version. Right now this points to the `next` branch, but once the next version of `miden-crypto` is released, I'll update this to point to the crates.io version.

The main update is the change in the API of many Merkle structs to use `RpoDigest` instead of `Word`.