### PR TITLE
Serialize and deserialize imports in ProgramAst and ModuleAst

### DIFF
--- a/assembly/src/ast/serde.rs
+++ b/assembly/src/ast/serde.rs
@@ -1,0 +1,32 @@
+//! Serialization and deserialization of Abstract syntax trees (ASTs).
+//!
+//! Structs in this module are used to serialize and deserialize ASTs into a binary format.
+
+use super::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable};
+
+/// Serialization options
+/// Used to enable or disable serialization of parts of the AST.  Serialization options are
+/// serialized along with the AST to make the serialization format self-contained.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct AstSerdeOptions {
+    pub serialize_imports: bool,
+}
+
+impl AstSerdeOptions {
+    pub fn new(serialize_imports: bool) -> Self {
+        Self { serialize_imports }
+    }
+}
+
+impl Serializable for AstSerdeOptions {
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        target.write_bool(self.serialize_imports);
+    }
+}
+
+impl Deserializable for AstSerdeOptions {
+    fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
+        let serialize_imports = source.read_bool()?;
+        Ok(Self::new(serialize_imports))
+    }
+}


### PR DESCRIPTION
## Describe your changes

Imports have added to ProgramAst and ModuleAst serialization and deserialization.

The struct `AstSerializationOptions` has been added to allow for serialization with or without imports. The serialization options are also serialized as a sort of header, so that deserialization can happen without knowing which options were used for serialization.

Serialization currently happens in two places elsewhere in the repo, and in a few tests. I have assumed that we don't want changes to the behavior in those places, so imports are not serialized from there. 

I'd like to add a couple of tests, but otherwise the code can be reviewed as is.

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
