### PR TITLE
stark: pushing constants instead of loading from memory

### DIFF
--- a/stdlib/asm/crypto/stark/deep_queries.masm
+++ b/stdlib/asm/crypto/stark/deep_queries.masm
@@ -252,7 +252,7 @@ end
 #! Input: [query_ptr, ...]
 #! Output: [index, query_ptr, ...]
 #!
-#! Cycles: 200
+#! Cycles: 198
 proc.load_query_row
     # Main trace portion of the query
 
@@ -332,8 +332,7 @@ proc.load_query_row
     #=> [L, R, ptr, y, y, y, depth, index, query_ptr, ...]
 
     ## adv_pipe aux trace portion
-    padw
-    exec.constants::zero_zero_zero_one_word mem_loadw
+    push.1.0.0.0
     swapw.2
     adv_pipe hperm
     adv_pipe hperm


### PR DESCRIPTION
## Describe your changes

In this particular case it is better to push the values to the stack instead of loading from memory.

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
