### PR TITLE
chore: enable resolver 2 for workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
   "test-utils",
   "verifier"
 ]
+resolver = "2"
 
 [profile.optimized]
 inherits = "release"

--- a/assembly/src/assembler/context.rs
+++ b/assembly/src/assembler/context.rs
@@ -83,8 +83,11 @@ impl AssemblyContext {
 
         // make sure this module is not in the chain of modules which are currently being compiled
         if self.module_stack.iter().any(|m| &m.path == module_path) {
-            let dep_chain =
-                self.module_stack.iter().map(|m| m.path.to_string()).collect::<Vec<_>>();
+            let dep_chain = self
+                .module_stack
+                .iter()
+                .map(|m| m.path.as_ref().to_string())
+                .collect::<Vec<_>>();
             return Err(AssemblyError::circular_module_dependency(&dep_chain));
         }
 
@@ -359,7 +362,7 @@ impl ModuleContext {
         if self.compiled_procs.iter().any(|p| p.label() == name)
             || self.proc_stack.iter().any(|p| &p.name == name)
         {
-            return Err(AssemblyError::duplicate_proc_name(name, &self.path));
+            return Err(AssemblyError::duplicate_proc_name(name, self.path.as_ref()));
         }
 
         let name = ProcedureName::try_from(name.to_string())?;
@@ -412,7 +415,7 @@ impl ModuleContext {
         let called_proc = self
             .compiled_procs
             .get(proc_idx as usize)
-            .ok_or_else(|| AssemblyError::local_proc_not_found(proc_idx, &self.path))?;
+            .ok_or_else(|| AssemblyError::local_proc_not_found(proc_idx, self.path.as_ref()))?;
 
         // get the context of the procedure currently being compiled
         let context = self.proc_stack.last_mut().expect("no proc context");

--- a/assembly/src/assembler/mod.rs
+++ b/assembly/src/assembler/mod.rs
@@ -375,7 +375,7 @@ impl Assembler {
             if !self.proc_cache.borrow().contains_id(proc_id) {
                 return Err(AssemblyError::imported_proc_not_found_in_module(
                     proc_id,
-                    &module.path,
+                    module.path.as_ref(),
                 ));
             }
         }

--- a/assembly/src/assembler/module_provider.rs
+++ b/assembly/src/assembler/module_provider.rs
@@ -32,7 +32,7 @@ impl ModuleProvider {
     /// Will error if there is a duplicated module path.
     fn add_module(&mut self, module: Module) -> Result<(), LibraryError> {
         if self.modules.iter().any(|m| module.path == m.path) {
-            return Err(LibraryError::duplicate_module_path(&module.path));
+            return Err(LibraryError::duplicate_module_path(module.path.as_ref()));
         }
         let module_idx = self.modules.len();
         for proc in module.ast.reexported_procs().iter() {

--- a/assembly/src/ast/code_body.rs
+++ b/assembly/src/ast/code_body.rs
@@ -3,6 +3,7 @@ use super::{
     SourceLocation,
 };
 use core::{iter, slice};
+use vm_core::utils::collections::Vec;
 
 // CODE BODY
 // ================================================================================================

--- a/assembly/src/ast/nodes/advice.rs
+++ b/assembly/src/ast/nodes/advice.rs
@@ -1,3 +1,6 @@
+#[cfg(not(feature = "std"))]
+use alloc::string::ToString;
+
 use super::super::{
     ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable,
     MAX_STACK_WORD_OFFSET,

--- a/assembly/src/ast/nodes/serde/deserialization.rs
+++ b/assembly/src/ast/nodes/serde/deserialization.rs
@@ -1,3 +1,6 @@
+#[cfg(not(feature = "std"))]
+use alloc::string::ToString;
+
 use super::{
     super::AdviceInjectorNode, ByteReader, CodeBody, Deserializable, DeserializationError, Felt,
     Instruction, Node, OpCode, ProcedureId, RpoDigest, MAX_PUSH_INPUTS,

--- a/assembly/src/ast/nodes/serde/mod.rs
+++ b/assembly/src/ast/nodes/serde/mod.rs
@@ -1,3 +1,6 @@
+#[cfg(not(feature = "std"))]
+use alloc::string::ToString;
+
 use super::{CodeBody, Felt, Instruction, Node, ProcedureId, RpoDigest};
 use crate::MAX_PUSH_INPUTS;
 use num_enum::TryFromPrimitive;

--- a/assembly/src/ast/parsers/labels.rs
+++ b/assembly/src/ast/parsers/labels.rs
@@ -1,4 +1,8 @@
 use super::{Deserializable, LabelError, RpoDigest, SliceReader, MAX_LABEL_LEN};
+use vm_core::utils::collections::Vec;
+
+#[cfg(not(feature = "std"))]
+use crate::alloc::string::ToString;
 
 // LABEL PARSERS
 // ================================================================================================

--- a/assembly/src/ast/parsers/mod.rs
+++ b/assembly/src/ast/parsers/mod.rs
@@ -1,3 +1,8 @@
+#[cfg(not(feature = "std"))]
+use alloc::string::ToString;
+
+use vm_core::utils::string::String;
+
 use super::{
     bound_into_included_u64, AdviceInjectorNode, BTreeMap, CodeBody, Deserializable, Felt,
     Instruction, InvocationTarget, LabelError, LibraryPath, LocalConstMap, LocalProcMap, Node,
@@ -38,7 +43,7 @@ pub fn parse_imports(
                 let module_path = token.parse_use()?;
                 let module_name = module_path.last();
                 if imports.contains_key(module_name) {
-                    return Err(ParsingError::duplicate_module_import(token, &module_path));
+                    return Err(ParsingError::duplicate_module_import(token, module_path.as_ref()));
                 }
 
                 imports.insert(module_name.to_string(), module_path);
@@ -65,7 +70,7 @@ pub fn parse_constants(tokens: &mut TokenStream) -> Result<LocalConstMap, Parsin
     while let Some(token) = tokens.read() {
         match token.parts()[0] {
             Token::CONST => {
-                let (name, value) = parse_constant(token)?;
+                let (name, value): (String, u64) = parse_constant(token)?;
 
                 if constants.contains_key(&name) {
                     return Err(ParsingError::duplicate_const_name(token, &name));

--- a/assembly/src/errors.rs
+++ b/assembly/src/errors.rs
@@ -849,7 +849,7 @@ impl fmt::Display for LibraryError {
             }
             ModuleNotFound(path) => write!(f, "module '{path}' not found"),
             NoModulesInLibrary { name } => {
-                write!(f, "library '{}' does not contain any modules", name.as_str())
+                write!(f, "library '{}' does not contain any modules", name.as_ref())
             }
             TooManyDependenciesInLibrary {
                 name,
@@ -859,7 +859,7 @@ impl fmt::Display for LibraryError {
                 write!(
                     f,
                     "library '{}' contains {num_dependencies} dependencies, but max is {max_dependencies}",
-                    name.as_str()
+                    name.as_ref()
                 )
             }
             TooManyModulesInLibrary {
@@ -870,7 +870,7 @@ impl fmt::Display for LibraryError {
                 write!(
                     f,
                     "library '{}' contains {num_modules} modules, but max is {max_modules}",
-                    name.as_str()
+                    name.as_ref()
                 )
             }
             TooManyVersionComponents { version } => {

--- a/assembly/src/library/mod.rs
+++ b/assembly/src/library/mod.rs
@@ -1,9 +1,13 @@
+#[cfg(not(feature = "std"))]
+use alloc::string::ToString;
+
 use super::{
     ast::{AstSerdeOptions, ModuleAst},
     ByteReader, ByteWriter, Deserializable, DeserializationError, LibraryError, PathError,
     Serializable, Vec, MAX_LABEL_LEN, NAMESPACE_LABEL_PARSER,
 };
 use core::{cmp::Ordering, fmt, ops::Deref, str::from_utf8};
+use vm_core::utils::string::String;
 
 mod masl;
 pub use masl::MaslLibrary;
@@ -102,8 +106,8 @@ impl Module {
 
     /// Validate if the module belongs to the provided namespace.
     pub fn check_namespace(&self, namespace: &LibraryNamespace) -> Result<(), LibraryError> {
-        (self.path.first() == namespace.as_str()).then_some(()).ok_or_else(|| {
-            LibraryError::inconsistent_namespace(self.path.first(), namespace.as_str())
+        (self.path.first() == namespace.as_ref()).then_some(()).ok_or_else(|| {
+            LibraryError::inconsistent_namespace(self.path.first(), namespace.as_ref())
         })
     }
 

--- a/assembly/src/library/path.rs
+++ b/assembly/src/library/path.rs
@@ -1,8 +1,12 @@
+#[cfg(not(feature = "std"))]
+use alloc::string::ToString;
+
 use super::{
     ByteReader, ByteWriter, Deserializable, DeserializationError, PathError, Serializable,
     MAX_LABEL_LEN,
 };
 use core::{ops::Deref, str::from_utf8};
+use vm_core::utils::string::String;
 
 // CONSTANTS
 // ================================================================================================
@@ -127,7 +131,8 @@ impl LibraryPath {
     /// - The joined path is either for a kernel or an executable module.
     /// - The resulting path requires more than 1KB to serialize.
     pub fn join(&self, other: &Self) -> Result<Self, PathError> {
-        if other.path.starts_with(Self::KERNEL_PATH) || other.starts_with(Self::EXEC_PATH) {
+        if other.path.starts_with(Self::KERNEL_PATH) || other.as_ref().starts_with(Self::EXEC_PATH)
+        {
             return Err(PathError::component_invalid_char(&other.path));
         }
 

--- a/processor/src/chiplets/aux_trace/bus.rs
+++ b/processor/src/chiplets/aux_trace/bus.rs
@@ -1,3 +1,6 @@
+#[cfg(not(feature = "std"))]
+use crate::alloc::borrow::ToOwned;
+
 use super::{
     super::{hasher::HasherLookup, BitwiseLookup, KernelProcLookup, MemoryLookup},
     BTreeMap, BusTraceBuilder, ColMatrix, Felt, FieldElement, LookupTableRow, Vec,


### PR DESCRIPTION
## Describe your changes

The resolver 2 needs to be explicitly enabled on workspaces [1]. Without the `workspace.resolver=2` the old resolver 1 is used. Which during feature unification will use unify with the bin and dev-dependencies, even for release builds. The consequence of that is that running `cargo build --no-default-features` on the workspace have most of the features enabled because of the dev dependencies.

1- https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
