### PR TITLE
Enable resolver 2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
   "test-utils",
   "verifier"
 ]
+resolver = "2"
 
 [profile.optimized]
 inherits = "release"

--- a/assembly/src/ast/code_body.rs
+++ b/assembly/src/ast/code_body.rs
@@ -1,6 +1,6 @@
 use super::{
     ByteReader, ByteWriter, Deserializable, DeserializationError, Node, Serializable,
-    SourceLocation,
+    SourceLocation, Vec,
 };
 use core::{iter, slice};
 

--- a/assembly/src/ast/nodes/advice.rs
+++ b/assembly/src/ast/nodes/advice.rs
@@ -1,5 +1,5 @@
 use super::super::{
-    ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable,
+    ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable, ToString,
     MAX_STACK_WORD_OFFSET,
 };
 use core::fmt;

--- a/assembly/src/ast/nodes/mod.rs
+++ b/assembly/src/ast/nodes/mod.rs
@@ -1,4 +1,4 @@
-use super::{CodeBody, Felt, ProcedureId, RpoDigest, Vec};
+use super::{CodeBody, Felt, ProcedureId, RpoDigest, ToString, Vec};
 use core::fmt;
 
 mod advice;

--- a/assembly/src/ast/nodes/serde/deserialization.rs
+++ b/assembly/src/ast/nodes/serde/deserialization.rs
@@ -1,6 +1,6 @@
 use super::{
     super::AdviceInjectorNode, ByteReader, CodeBody, Deserializable, DeserializationError, Felt,
-    Instruction, Node, OpCode, ProcedureId, RpoDigest, MAX_PUSH_INPUTS,
+    Instruction, Node, OpCode, ProcedureId, RpoDigest, ToString, MAX_PUSH_INPUTS,
 };
 
 // NODE DESERIALIZATION

--- a/assembly/src/ast/nodes/serde/mod.rs
+++ b/assembly/src/ast/nodes/serde/mod.rs
@@ -1,4 +1,4 @@
-use super::{CodeBody, Felt, Instruction, Node, ProcedureId, RpoDigest};
+use super::{CodeBody, Felt, Instruction, Node, ProcedureId, RpoDigest, ToString};
 use crate::MAX_PUSH_INPUTS;
 use num_enum::TryFromPrimitive;
 

--- a/assembly/src/ast/parsers/labels.rs
+++ b/assembly/src/ast/parsers/labels.rs
@@ -1,4 +1,4 @@
-use super::{Deserializable, LabelError, RpoDigest, SliceReader, MAX_LABEL_LEN};
+use super::{Deserializable, LabelError, RpoDigest, SliceReader, ToString, Vec, MAX_LABEL_LEN};
 
 // LABEL PARSERS
 // ================================================================================================

--- a/assembly/src/ast/parsers/mod.rs
+++ b/assembly/src/ast/parsers/mod.rs
@@ -2,8 +2,8 @@ use super::{
     bound_into_included_u64, AdviceInjectorNode, BTreeMap, CodeBody, Deserializable, Felt,
     Instruction, InvocationTarget, LabelError, LibraryPath, LocalConstMap, LocalProcMap, Node,
     ParsingError, ProcedureAst, ProcedureId, ReExportedProcMap, RpoDigest, SliceReader, StarkField,
-    Token, TokenStream, Vec, MAX_BODY_LEN, MAX_DOCS_LEN, MAX_IMPORTS, MAX_LABEL_LEN,
-    MAX_STACK_WORD_OFFSET,
+    String, ToString, Token, TokenStream, Vec, MAX_BODY_LEN, MAX_DOCS_LEN, MAX_IMPORTS,
+    MAX_LABEL_LEN, MAX_STACK_WORD_OFFSET,
 };
 use core::{fmt::Display, ops::RangeBounds};
 

--- a/assembly/src/library/mod.rs
+++ b/assembly/src/library/mod.rs
@@ -1,7 +1,7 @@
 use super::{
     ast::{AstSerdeOptions, ModuleAst},
     ByteReader, ByteWriter, Deserializable, DeserializationError, LibraryError, PathError,
-    Serializable, Vec, MAX_LABEL_LEN, NAMESPACE_LABEL_PARSER,
+    Serializable, String, ToString, Vec, MAX_LABEL_LEN, NAMESPACE_LABEL_PARSER,
 };
 use core::{cmp::Ordering, fmt, ops::Deref, str::from_utf8};
 

--- a/assembly/src/library/path.rs
+++ b/assembly/src/library/path.rs
@@ -1,6 +1,6 @@
 use super::{
-    ByteReader, ByteWriter, Deserializable, DeserializationError, PathError, Serializable,
-    MAX_LABEL_LEN,
+    ByteReader, ByteWriter, Deserializable, DeserializationError, PathError, Serializable, String,
+    ToString, MAX_LABEL_LEN,
 };
 use core::{ops::Deref, str::from_utf8};
 

--- a/processor/src/chiplets/aux_trace/bus.rs
+++ b/processor/src/chiplets/aux_trace/bus.rs
@@ -233,7 +233,7 @@ pub struct ChipletsBusRow {
 impl ChipletsBusRow {
     pub(crate) fn new(requests: &[u32], response: Option<u32>) -> Self {
         ChipletsBusRow {
-            requests: requests.to_owned(),
+            requests: requests.to_vec(),
             response,
         }
     }

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -1,6 +1,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #[cfg(not(feature = "std"))]
+#[macro_use]
 extern crate alloc;
 
 // IMPORTS
@@ -119,7 +120,7 @@ impl Test {
 
     /// Asserts that running the test for the expected TestError variant will result in an error
     /// that contains the TestError's error substring in its error message.
-    #[cfg(not(target_family = "wasm"))]
+    #[cfg(all(feature = "std", not(target_family = "wasm")))]
     pub fn expect_error(&self, error: TestError) {
         match error {
             TestError::AssemblyError(substr) => {


### PR DESCRIPTION
This PR enables resolver 2 feature resolution. It is similar to #980 but is made against the `main` branch and fixes things in a slightly different way.