### PR TITLE
stark: compute lde_g earlier and remove tmp0

### DIFF
--- a/stdlib/asm/crypto/fri/helper.masm
+++ b/stdlib/asm/crypto/fri/helper.masm
@@ -1,6 +1,5 @@
 use.std::crypto::fri::ext2fri
 use.std::crypto::stark::random_coin
-use.std::crypto::stark::utils
 use.std::crypto::stark::constants
 
 #! Compute the number of FRI layers given log2 of the size of LDE domain. It also computes the
@@ -8,17 +7,11 @@ use.std::crypto::stark::constants
 #!
 #! Input: [...]
 #! Output: [num_fri_layers, ...]
-#! Cycles: 123
+#! Cycles: 55
 export.generate_fri_parameters
     # Load FRI verifier data
     padw exec.constants::lde_size_ptr mem_loadw
-    #=> [lde_size, log(lde_size), 0, 0, ...] (6 cycles)
-
-    # Compute lde_domain generator
-    dup.1
-    exec.utils::compute_lde_generator
-    movdn.2
-    #=> [lde_size, log2(lde_size), lde_g, 0, 0, ...] (65 cycles)
+    #=> [lde_size, log(lde_size), lde_g, 0, ...] (6 cycles)
 
     # Store in `TMP5` in order to use it for fri layer loading
     exec.constants::tmp5 mem_storew
@@ -30,7 +23,7 @@ export.generate_fri_parameters
     # load z from memory 
     padw
     exec.constants::z_ptr mem_loadw
-    #=> [(z1, z0)^n, z1, z0, lde_size, log2(lde_size), lde_g, 0, 0, ...] (6 cycles)
+    #=> [(z1, z0)^n, z1, z0, lde_size, log2(lde_size), lde_g, 0, ...] (6 cycles)
 
     # prepare stack
     drop
@@ -38,33 +31,29 @@ export.generate_fri_parameters
     dup.1
     dup.1
     dup.6
-    #=> [lde_g, z1, z0, z1, z0, lde_size, log2(lde_size), lde_g, 0, 0, ...] (5 cycles)
+    #=> [lde_g, z1, z0, z1, z0, lde_size, log2(lde_size), lde_g, 0, ...] (5 cycles)
 
     # Compute trace generator `trace_g` = `lde_g^blowup_factor`
     repeat.3
         dup mul
     end
-    #=> [trace_g, z1, z0, z1, z0, lde_size, log2(lde_size), lde_g, 0, 0, ...] (6 cycles)
+    #=> [trace_g, z1, z0, z1, z0, lde_size, log2(lde_size), lde_g, 0, ...] (6 cycles)
 
     # Compute `gz0` = `trace_g * g_0`
     dup
     movup.3
     mul
-    #=> [gz0, trace_g, z1, z0, z1, z0, lde_size, log2(lde_size), lde_g, 0, 0, ...] (3 cycles)
+    #=> [gz0, trace_g, z1, z0, z1, z0, lde_size, log2(lde_size), lde_g, 0, ...] (3 cycles)
 
     # Compute `gz1` = `trace_g * g_1`
     swap.2
     mul
-    #=> [gz1, gz0, z1, z0, lde_size, log2(lde_size), lde_g, 0, 0, ...] (2 cycles)
+    #=> [gz1, gz0, z1, z0, lde_size, log2(lde_size), lde_g, 0, ...] (2 cycles)
 
     # Save `[gz1, gz0, z1, z0]` and clean the stack
     exec.constants::tmp1 mem_storew
     dropw
-    #=> [lde_size, log2(lde_size), lde_g, 0, 0, ...] (6 cycles)
-
-    # This is the same as the word referenced by `TMP5` but is immutable.
-    exec.constants::tmp0 mem_storew
-    # => [lde_size, log2(lde_size), lde_generator, 0, 0, ...] (2 cycles)
+    #=> [lde_size, log2(lde_size), lde_g, 0, ...] (6 cycles)
 
     # Compute the number of FRI layers
     dup
@@ -82,13 +71,12 @@ export.generate_fri_parameters
         sub.6
         div.2
     end
-    # => [num_fri_layers, remainder_size, lde_size, lde_size, log2(lde_size), domain_gen, 0, 0, ...] (12 cycles)
+    # => [num_fri_layers, remainder_size, lde_size, lde_size, log2(lde_size), domain_gen, 0, ...] (12 cycles)
 
     # Save `[num_fri_layers, remainder_size, lde_size, lde_size]` in memory
     exec.constants::tmp6 mem_storew
-    movdn.7
+    movdn.6
     dropw
-    drop
     drop
     drop
     # => [num_fri_layers, ...] (10 cycles)

--- a/stdlib/asm/crypto/stark/constants.masm
+++ b/stdlib/asm/crypto/stark/constants.masm
@@ -85,7 +85,6 @@ const.R1_PTR=4294903312
 const.R2_PTR=4294903313
 
 # Address used for storing temporary values:
-const.TMP0=4294903314
 const.TMP1=4294903315
 const.TMP2=4294903316
 const.TMP3=4294903317
@@ -123,7 +122,6 @@ const.TMP8=4294903322
 #   | C_PTR                                    |       4294903311        |
 #   | R1_PTR                                   |       4294903312        |
 #   | R2_PTR                                   |       4294903313        |
-#   | TMP0                                     |       4294903314        |
 #   | TMP1                                     |       4294903315        |
 #   | TMP2                                     |       4294903316        |
 #   | TMP3                                     |       4294903317        |
@@ -195,7 +193,7 @@ end
 
 #! Address to store details about the lde size.
 #!
-#! Memory is `[lde_size, log(lde_size), 0, 0]`
+#! Memory is `[lde_size, log(lde_size), lde_g, 0]`
 export.lde_size_ptr
     push.LDE_SIZE_PTR
 end
@@ -253,13 +251,6 @@ end
 #! second rate word of the RPO.
 export.r2_ptr
     push.R2_PTR
-end
-
-#! Address to store details to compute deep queries.
-#!
-#! Memory is `[lde_size, log2(lde_size), lde_generator, 0]`
-export.tmp0
-    push.TMP0
 end
 
 #! Address to store details to compute deep query denominators.

--- a/stdlib/asm/crypto/stark/deep_queries.masm
+++ b/stdlib/asm/crypto/stark/deep_queries.masm
@@ -395,7 +395,7 @@ end
 proc.compute_denominators
     # Compute x = offset * domain_gen^index
     padw
-    exec.constants::tmp0 mem_loadw
+    exec.constants::lde_size_ptr mem_loadw
     #=> [lde_size, depth, domain_gen, 0, index, ...]
     movup.2
     dup.4

--- a/stdlib/asm/crypto/stark/random_coin.masm
+++ b/stdlib/asm/crypto/stark/random_coin.masm
@@ -1,4 +1,5 @@
 use.std::crypto::stark::constants
+use.std::crypto::stark::utils
 
 
 #! Helper procedure to compute addition of two words component-wise.
@@ -75,7 +76,7 @@ end
 #!
 #! Input: [log(trace_length), num_queries, blowup, grinding, ...]
 #! Output: [C]
-#! Cycles: 104
+#! Cycles: 168
 export.init_seed
 
     # Save the parameters in memory for later use
@@ -124,7 +125,6 @@ export.init_seed
     assert_eq
 
     ## Compute log(lde_size) and lde_size and store them
-    ## Cycles: 32
     add
     swap
     movup.3
@@ -135,17 +135,23 @@ export.init_seed
     dup
     movdn.3
     mul
-    push.0
-    movdn.2
-    push.0
-    movdn.2
-    exec.constants::lde_size_ptr mem_storew
-    #=> [lde_size, log(lde_size), 0, 0, trace_length, num_queries, blowup, grinding]
 
+    # Compute lde_domain generator
+    dup.1
+    exec.utils::compute_lde_generator
+    movdn.2
+    #=> [lde_size, log(lde_size), lde_g, trace_length, num_queries, blowup, grinding]
+
+    push.0
+    movdn.3
+    #=> [lde_size, log(lde_size), lde_g, 0, trace_length, num_queries, blowup, grinding]
+
+    # Save `[lde_size, log(lde_size), lde_g, 0]` and clean stack
+    exec.constants::lde_size_ptr mem_storew
+    dropw
+    #=> [trace_length, num_queries, blowup, grinding]
 
     # Construct the proof context
-    # Cycles: 9
-    dropw
 
     ##trace layout info
     push.1208027408
@@ -616,7 +622,7 @@ end
 export.generate_list_indices
     # Create mask
     padw
-    exec.constants::tmp0 mem_loadw
+    exec.constants::lde_size_ptr mem_loadw
     movup.2 drop
     movup.2 drop
     sub.1

--- a/stdlib/asm/crypto/stark/verifier.masm
+++ b/stdlib/asm/crypto/stark/verifier.masm
@@ -236,7 +236,7 @@ export.verify
     #
     # Cycles: 15
     padw
-    exec.constants::tmp0 mem_loadw
+    exec.constants::lde_size_ptr mem_loadw
     push.0.0
     exec.constants::tmp8 mem_loadw
     swap.3


### PR DESCRIPTION
## Describe your changes

Why? https://github.com/0xPolygonMiden/miden-vm/pull/960 needs the lde_g to compute the trace_g, so the computation is moved to the initialization step for that. This PR doesn't compute trace_g yet because it also removes the tmp0, so a small PR like this should be easier to review.


## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
