### PR TITLE
Add map of imported procedures to AST structs

### DIFF
--- a/assembly/src/ast/imports.rs
+++ b/assembly/src/ast/imports.rs
@@ -1,0 +1,159 @@
+use super::{
+    BTreeMap, ByteReader, ByteWriter, Deserializable, DeserializationError, LibraryPath,
+    ParsingError, ProcedureId, ProcedureName, Serializable, String, ToString, Token, TokenStream,
+    Vec, MAX_IMPORTS, MAX_INVOKED_IMPORTED_PROCS,
+};
+
+// TYPE ALIASES
+// ================================================================================================
+
+type ImportedModulesMap = BTreeMap<String, LibraryPath>;
+type InvokedProcsMap = BTreeMap<ProcedureId, (ProcedureName, LibraryPath)>;
+
+// MODULE IMPORTS
+// ================================================================================================
+
+/// Information about imports stored in the AST
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct ModuleImports {
+    /// Imported libraries.
+    imports: ImportedModulesMap,
+    /// Imported procedures that are called from somewhere in the AST.
+    invoked_procs: InvokedProcsMap,
+}
+
+impl ModuleImports {
+    // CONSTRUCTOR
+    // --------------------------------------------------------------------------------------------
+    /// Create a new ModuleImports instance
+    ///
+    /// # Panics
+    /// Panics if the number of imports is greater than MAX_IMPORTS, or if the number of invoked
+    /// procedures is greater than MAX_INVOKED_IMPORTED_PROCS
+    pub fn new(imports: ImportedModulesMap, invoked_procs: InvokedProcsMap) -> Self {
+        assert!(imports.len() <= MAX_IMPORTS, "too many imports");
+        assert!(
+            invoked_procs.len() <= MAX_INVOKED_IMPORTED_PROCS,
+            "too many imported procedures invoked"
+        );
+        Self {
+            imports,
+            invoked_procs,
+        }
+    }
+
+    // PARSER
+    // --------------------------------------------------------------------------------------------
+    /// Parses all `use` statements into a map of imports which maps a module name (e.g., "u64") to
+    /// its fully-qualified path (e.g., "std::math::u64").
+    pub fn parse(tokens: &mut TokenStream) -> Result<Self, ParsingError> {
+        let mut imports = BTreeMap::<String, LibraryPath>::new();
+        // read tokens from the token stream until all `use` tokens are consumed
+        while let Some(token) = tokens.read() {
+            match token.parts()[0] {
+                Token::USE => {
+                    let module_path = token.parse_use()?;
+                    let module_name = module_path.last();
+                    if imports.contains_key(module_name) {
+                        return Err(ParsingError::duplicate_module_import(token, &module_path));
+                    }
+
+                    imports.insert(module_name.to_string(), module_path);
+
+                    // consume the `use` token
+                    tokens.advance();
+                }
+                _ => break,
+            }
+        }
+
+        if imports.len() > MAX_IMPORTS {
+            return Err(ParsingError::too_many_imports(imports.len(), MAX_IMPORTS));
+        }
+        Ok(Self {
+            imports,
+            invoked_procs: BTreeMap::new(),
+        })
+    }
+
+    // PUBLIC ACCESSORS
+    // --------------------------------------------------------------------------------------------
+
+    /// Look up the path of the imported module with the given name.
+    pub fn get_module_path(&self, module_name: &str) -> Option<&LibraryPath> {
+        self.imports.get(&module_name.to_string())
+    }
+
+    /// Return the paths of all imported module
+    pub fn import_paths(&self) -> Vec<&LibraryPath> {
+        self.imports.values().collect()
+    }
+
+    // STATE MUTATORS
+    // --------------------------------------------------------------------------------------------
+
+    /// Adds the specified procedure to the set of procedures invoked from imported modules and
+    /// returns the ID of the invoked procedure.
+    ///
+    /// # Errors
+    /// Return an error if
+    /// - The module with the specified name has not been imported via the `use` statement.
+    /// - The total number of invoked procedures exceeds 2^{16} - 1.
+    pub fn add_invoked_proc(
+        &mut self,
+        proc_name: &ProcedureName,
+        module_name: &str,
+        token: &Token,
+    ) -> Result<ProcedureId, ParsingError> {
+        let module_path = self
+            .imports
+            .get(module_name)
+            .ok_or_else(|| ParsingError::procedure_module_not_imported(token, module_name))?;
+        let proc_id = ProcedureId::from_name(proc_name.as_ref(), module_path);
+        self.invoked_procs.insert(proc_id, (proc_name.clone(), module_path.clone()));
+        if self.invoked_procs.len() > MAX_INVOKED_IMPORTED_PROCS {
+            return Err(ParsingError::too_many_imported_procs_invoked(
+                token,
+                self.invoked_procs.len(),
+                MAX_INVOKED_IMPORTED_PROCS,
+            ));
+        }
+        Ok(proc_id)
+    }
+}
+
+impl Serializable for ModuleImports {
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        target.write_u16(self.imports.len() as u16);
+        // We don't need to serialize the library names (the keys), since the libraty paths (the
+        // values) contain the library names
+        self.imports.values().for_each(|i| i.write_into(target));
+        target.write_u16(self.invoked_procs.len() as u16);
+        for (proc_id, (proc_name, lib_path)) in self.invoked_procs.iter() {
+            proc_id.write_into(target);
+            proc_name.write_into(target);
+            lib_path.write_into(target);
+        }
+    }
+}
+
+impl Deserializable for ModuleImports {
+    fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
+        let mut imports = BTreeMap::<String, LibraryPath>::new();
+        let num_imports = source.read_u16()?;
+        for _ in 0..num_imports {
+            let path = LibraryPath::read_from(source)?;
+            imports.insert(path.last().to_string(), path);
+        }
+
+        let mut used_imported_procs = InvokedProcsMap::new();
+        let num_used_imported_procs = source.read_u16()?;
+        for _ in 0..num_used_imported_procs {
+            let proc_id = ProcedureId::read_from(source)?;
+            let proc_name = ProcedureName::read_from(source)?;
+            let lib_path = LibraryPath::read_from(source)?;
+            used_imported_procs.insert(proc_id, (proc_name, lib_path));
+        }
+        Ok(Self::new(imports, used_imported_procs))
+    }
+}

--- a/assembly/src/ast/parsers/mod.rs
+++ b/assembly/src/ast/parsers/mod.rs
@@ -1,8 +1,8 @@
 use super::{
-    bound_into_included_u64, AdviceInjectorNode, BTreeMap, CodeBody, Deserializable, Felt,
-    Instruction, InvocationTarget, LabelError, LibraryPath, LocalConstMap, LocalProcMap, Node,
-    ParsingError, ProcedureAst, ProcedureId, ReExportedProcMap, RpoDigest, SliceReader, StarkField,
-    String, ToString, Token, TokenStream, Vec, MAX_BODY_LEN, MAX_DOCS_LEN, MAX_IMPORTS,
+    bound_into_included_u64, AdviceInjectorNode, CodeBody, Deserializable, Felt, Instruction,
+    InvocationTarget, LabelError, LibraryPath, LocalConstMap, LocalProcMap, ModuleImports, Node,
+    ParsingError, ProcedureAst, ProcedureId, ProcedureName, ReExportedProcMap, RpoDigest,
+    SliceReader, StarkField, String, ToString, Token, TokenStream, Vec, MAX_BODY_LEN, MAX_DOCS_LEN,
     MAX_LABEL_LEN, MAX_STACK_WORD_OFFSET,
 };
 use core::{fmt::Display, ops::RangeBounds};
@@ -24,37 +24,6 @@ pub use labels::{
 
 // PARSERS FUNCTIONS
 // ================================================================================================
-
-/// Parses all `use` statements into a map of imports which maps a module name (e.g., "u64") to
-/// its fully-qualified path (e.g., "std::math::u64").
-pub fn parse_imports(
-    tokens: &mut TokenStream,
-) -> Result<BTreeMap<String, LibraryPath>, ParsingError> {
-    let mut imports = BTreeMap::<String, LibraryPath>::new();
-    // read tokens from the token stream until all `use` tokens are consumed
-    while let Some(token) = tokens.read() {
-        match token.parts()[0] {
-            Token::USE => {
-                let module_path = token.parse_use()?;
-                let module_name = module_path.last();
-                if imports.contains_key(module_name) {
-                    return Err(ParsingError::duplicate_module_import(token, &module_path));
-                }
-
-                imports.insert(module_name.to_string(), module_path);
-
-                // consume the `use` token
-                tokens.advance();
-            }
-            _ => break,
-        }
-    }
-
-    if imports.len() > MAX_IMPORTS {
-        return Err(ParsingError::too_many_imports(imports.len(), MAX_IMPORTS));
-    }
-    Ok(imports)
-}
 
 /// Parses all `const` statements into a map which maps a const name to a value
 pub fn parse_constants(tokens: &mut TokenStream) -> Result<LocalConstMap, ParsingError> {

--- a/assembly/src/errors.rs
+++ b/assembly/src/errors.rs
@@ -550,6 +550,20 @@ impl ParsingError {
         }
     }
 
+    pub fn too_many_imported_procs_invoked(
+        token: &Token,
+        num_procs: usize,
+        max_procs: usize,
+    ) -> Self {
+        ParsingError {
+            message: format!(
+                "a module cannot invoke more than {max_procs} imported procedures, but had {num_procs}"
+            ),
+            location: *token.location(),
+            op: token.to_string(),
+        }
+    }
+
     // IMPORTS AND MODULES
     // --------------------------------------------------------------------------------------------
 

--- a/assembly/src/library/masl.rs
+++ b/assembly/src/library/masl.rs
@@ -9,8 +9,9 @@ use core::slice::Iter;
 // ================================================================================================
 //
 
-/// Serialization options for [ModuleAst]. Imports are part of the ModuleAst serialization.
-const AST_SERDE_OPTIONS: AstSerdeOptions = AstSerdeOptions {
+/// Serialization options for [ModuleAst]. Imports and information about imported procedures are
+/// part of the ModuleAst serialization by default.
+const AST_DEFAULT_SERDE_OPTIONS: AstSerdeOptions = AstSerdeOptions {
     serialize_imports: true,
 };
 
@@ -250,7 +251,7 @@ mod use_std {
                     let ast = ModuleAst::parse(&contents)?;
 
                     // add dependencies of this module to the dependencies of this library
-                    for path in ast.imports().values() {
+                    for path in ast.import_paths() {
                         let ns = LibraryNamespace::new(path.first())?;
                         deps.insert(ns);
                     }
@@ -290,7 +291,7 @@ impl Serializable for MaslLibrary {
             LibraryPath::strip_first(&module.path)
                 .expect("module path consists of a single component")
                 .write_into(target);
-            module.ast.write_into(target, AST_SERDE_OPTIONS);
+            module.ast.write_into(target, AST_DEFAULT_SERDE_OPTIONS);
         });
 
         // optionally write the locations into the target. given the modules count is already
@@ -321,7 +322,7 @@ impl Deserializable for MaslLibrary {
             let path = LibraryPath::read_from(source)?
                 .prepend(&namespace)
                 .map_err(|err| DeserializationError::InvalidValue(format!("{err}")))?;
-            let ast = ModuleAst::read_from(source, AST_SERDE_OPTIONS)?;
+            let ast = ModuleAst::read_from(source, AST_DEFAULT_SERDE_OPTIONS)?;
             modules.push(Module { path, ast });
         }
 

--- a/assembly/src/procedures/mod.rs
+++ b/assembly/src/procedures/mod.rs
@@ -131,8 +131,16 @@ impl TryFrom<String> for ProcedureName {
     type Error = LabelError;
 
     fn try_from(name: String) -> Result<Self, Self::Error> {
+        Self::try_from(name.as_ref())
+    }
+}
+
+impl TryFrom<&str> for ProcedureName {
+    type Error = LabelError;
+
+    fn try_from(name: &str) -> Result<Self, Self::Error> {
         Ok(Self {
-            name: (PROCEDURE_LABEL_PARSER.parse_label(&name)?).to_string(),
+            name: (PROCEDURE_LABEL_PARSER.parse_label(name)?).to_string(),
         })
     }
 }


### PR DESCRIPTION
## Describe your changes

A map from procedure IDs of imported procedures to the procedure's name and module path has been added to `ProgramAst` and `ModuleAst`.

This map is needed for the MASM pretty-printer, because the instructions that represent calls to imported procedures only contain the procedure's ID and not its name. The procedure's ID is a hash, and it is therefore impossible to print the assembly for the call instruction without this map.

The map is populated during parsing as part of the `ParserContext`. Since the parser does not have access to the code of imported modules, only the procedures that are actually called are represented in the map. This also explains why the map is named `used_imported_procs`.  

Like the imports map, this new map can optionally be serialized when the AST is serialized. Serialization and deserialization tests have been added.

The only user-facing change is the new limitation of max 2^16-1 calls to imported procedures in each program and module. We have not added documentation for similar restrictions in the past, so I haven't added anything this time either.

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
