### PR TITLE
cli: add command to compile libraries

### DIFF
--- a/assembly/src/assembler/span_builder.rs
+++ b/assembly/src/assembler/span_builder.rs
@@ -98,7 +98,7 @@ impl SpanBuilder {
     ///
     /// This indicates that the provided instruction should be tracked and the cycle count for
     /// this instruction will be computed when the call to set_instruction_cycle_count() is made.
-    pub fn track_instruction(&mut self, instruction: &Instruction, ctx: &mut AssemblyContext) {
+    pub fn track_instruction(&mut self, instruction: &Instruction, ctx: &AssemblyContext) {
         let context_name = ctx.current_context_name().to_string();
         let num_cycles = 0;
         let op = instruction.to_string();

--- a/assembly/src/library/mod.rs
+++ b/assembly/src/library/mod.rs
@@ -152,7 +152,7 @@ impl Module {
 
 impl PartialOrd for Module {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        self.path.partial_cmp(&other.path)
+        Some(self.cmp(other))
     }
 }
 

--- a/miden/src/cli/bundle.rs
+++ b/miden/src/cli/bundle.rs
@@ -8,13 +8,13 @@ use structopt::StructOpt;
     about = "Bundles .masm files into a single .masl library"
 )]
 pub struct BundleCmd {
-    /// Path to a directory containg the `.masm` files which are part of the library
+    /// Path to a directory containing the `.masm` files which are part of the library.
     #[structopt(parse(from_os_str))]
     dir: PathBuf,
-    /// Defines the top-level namespace, e.g. `mylib`, oherwise the directory name is used.
+    /// Defines the top-level namespace, e.g. `mylib`, otherwise the directory name is used.
     #[structopt(short, long)]
     namespace: Option<String>,
-    /// Version of you library, defaults to `0.1.0`.
+    /// Version of the library, defaults to `0.1.0`.
     #[structopt(short, long, default_value = "0.1.0")]
     version: String,
 }
@@ -22,7 +22,7 @@ pub struct BundleCmd {
 impl BundleCmd {
     pub fn execute(&self) -> Result<(), String> {
         println!("============================================================");
-        println!("Compile library");
+        println!("Build library");
         println!("============================================================");
 
         let namespace = match &self.namespace {
@@ -38,15 +38,19 @@ impl BundleCmd {
         let library_namespace =
             LibraryNamespace::try_from(namespace.clone()).expect("invalid base namespace");
         let version = Version::try_from(self.version.as_ref()).expect("invalid cargo version");
-        let locations = true; // store & load locations by default
-        let stdlib =
-            MaslLibrary::read_from_dir(self.dir.clone(), library_namespace, locations, version)
-                .map_err(|e| e.to_string())?;
+        let with_source_locations = true;
+        let stdlib = MaslLibrary::read_from_dir(
+            self.dir.clone(),
+            library_namespace,
+            with_source_locations,
+            version,
+        )
+        .map_err(|e| e.to_string())?;
 
         // write the masl output
         stdlib.write_to_dir(self.dir.clone()).map_err(|e| e.to_string())?;
 
-        println!("Compiled library {}", namespace);
+        println!("Built library {}", namespace);
 
         Ok(())
     }

--- a/miden/src/cli/bundle.rs
+++ b/miden/src/cli/bundle.rs
@@ -1,0 +1,53 @@
+use assembly::{LibraryNamespace, MaslLibrary, Version};
+use std::path::PathBuf;
+use structopt::StructOpt;
+
+#[derive(StructOpt, Debug)]
+#[structopt(
+    name = "Compile Library",
+    about = "Bundles .masm files into a single .masl library"
+)]
+pub struct BundleCmd {
+    /// Path to a directory containg the `.masm` files which are part of the library
+    #[structopt(parse(from_os_str))]
+    dir: PathBuf,
+    /// Defines the top-level namespace, e.g. `mylib`, oherwise the directory name is used.
+    #[structopt(short, long)]
+    namespace: Option<String>,
+    /// Version of you library, defaults to `0.1.0`.
+    #[structopt(short, long, default_value = "0.1.0")]
+    version: String,
+}
+
+impl BundleCmd {
+    pub fn execute(&self) -> Result<(), String> {
+        println!("============================================================");
+        println!("Compile library");
+        println!("============================================================");
+
+        let namespace = match &self.namespace {
+            Some(namespace) => namespace.to_string(),
+            None => self
+                .dir
+                .file_name()
+                .expect("dir must be a folder")
+                .to_string_lossy()
+                .into_owned(),
+        };
+
+        let library_namespace =
+            LibraryNamespace::try_from(namespace.clone()).expect("invalid base namespace");
+        let version = Version::try_from(self.version.as_ref()).expect("invalid cargo version");
+        let locations = true; // store & load locations by default
+        let stdlib =
+            MaslLibrary::read_from_dir(self.dir.clone(), library_namespace, locations, version)
+                .map_err(|e| e.to_string())?;
+
+        // write the masl output
+        stdlib.write_to_dir(self.dir.clone()).map_err(|e| e.to_string())?;
+
+        println!("Compiled library {}", namespace);
+
+        Ok(())
+    }
+}

--- a/miden/src/cli/mod.rs
+++ b/miden/src/cli/mod.rs
@@ -1,3 +1,4 @@
+mod bundle;
 mod compile;
 mod data;
 mod debug;
@@ -6,6 +7,7 @@ mod repl;
 mod run;
 mod verify;
 
+pub use bundle::BundleCmd;
 pub use compile::CompileCmd;
 pub use data::InputFile;
 pub use debug::DebugCmd;

--- a/miden/src/main.rs
+++ b/miden/src/main.rs
@@ -20,6 +20,7 @@ pub struct Cli {
 pub enum Actions {
     Analyze(tools::Analyze),
     Compile(cli::CompileCmd),
+    Bundle(cli::BundleCmd),
     Debug(cli::DebugCmd),
     Example(examples::ExampleOptions),
     Prove(cli::ProveCmd),
@@ -35,6 +36,7 @@ impl Cli {
         match &self.action {
             Actions::Analyze(analyze) => analyze.execute(),
             Actions::Compile(compile) => compile.execute(),
+            Actions::Bundle(compile) => compile.execute(),
             Actions::Debug(debug) => debug.execute(),
             Actions::Example(example) => example.execute(),
             Actions::Prove(prove) => prove.execute(),


### PR DESCRIPTION
## Describe your changes

This adds a CLI command to compile masm files to a masl, useful for CLI users.

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
