### PR TITLE
AST formatter/pretty-printer

### DIFF
--- a/assembly/src/ast/format.rs
+++ b/assembly/src/ast/format.rs
@@ -1,0 +1,134 @@
+use super::{
+    CodeBody, FormattableNode, InvokedProcsMap, LibraryPath, ProcedureAst, ProcedureId,
+    ProcedureName, Vec,
+};
+use core::fmt;
+
+const INDENT_STRING: &str = "    ";
+
+/// Context for the Ast formatter
+///
+/// The context keeps track of the current indentation level, as well as the declared and imported
+/// procedures in the program/module being formatted.
+pub struct AstFormatterContext<'a> {
+    indent_level: usize,
+    local_procs: &'a Vec<ProcedureAst>,
+    imported_procs: &'a InvokedProcsMap,
+}
+
+impl<'a> AstFormatterContext<'a> {
+    pub fn new(
+        local_procs: &'a Vec<ProcedureAst>,
+        imported_procs: &'a InvokedProcsMap,
+    ) -> AstFormatterContext<'a> {
+        Self {
+            indent_level: 0,
+            local_procs,
+            imported_procs,
+        }
+    }
+
+    /// Build a context for the inner scope, e.g., the body of a while loop
+    pub fn inner_scope_context(&self) -> Self {
+        Self {
+            indent_level: self.indent_level + 1,
+            local_procs: self.local_procs,
+            imported_procs: self.imported_procs,
+        }
+    }
+
+    /// Add indentation to the current line in the formatter
+    pub fn indent(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for _ in 0..self.indent_level {
+            write!(f, "{INDENT_STRING}")?;
+        }
+        Ok(())
+    }
+
+    /// Get the name of the local procedure with the given index.
+    ///
+    /// # Panics
+    /// Panics if the index is not associated with a procedure name
+    pub fn local_proc(&self, index: usize) -> &ProcedureName {
+        assert!(index < self.local_procs.len(), "Local procedure with index {index} not found");
+        &self.local_procs[index].name
+    }
+
+    /// Get the name of the imported procedure with the given id/hash.
+    ///
+    /// # Panics
+    /// Panics if the id/hash is not associated with an imported procedure
+    pub fn imported_proc(&self, id: &ProcedureId) -> &(ProcedureName, LibraryPath) {
+        self.imported_procs
+            .get(id)
+            .expect("Imported procedure with id/hash {id} not found")
+    }
+}
+
+// FORMATTING OF PROCEDURES
+// ================================================================================================
+pub struct FormattableProcedureAst<'a> {
+    proc: &'a ProcedureAst,
+    context: &'a AstFormatterContext<'a>,
+}
+
+impl<'a> FormattableProcedureAst<'a> {
+    pub fn new(
+        proc: &'a ProcedureAst,
+        context: &'a AstFormatterContext<'a>,
+    ) -> FormattableProcedureAst<'a> {
+        Self { proc, context }
+    }
+}
+
+impl fmt::Display for FormattableProcedureAst<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Docs
+        self.context.indent(f)?;
+        if let Some(ref doc) = self.proc.docs {
+            writeln!(f, "#! {doc}")?;
+        }
+        // Procedure header
+        self.context.indent(f)?;
+        if self.proc.is_export {
+            write!(f, "export.")?;
+        } else {
+            write!(f, "proc.")?;
+        }
+        writeln!(f, "{}.{}", self.proc.name, self.proc.num_locals)?;
+        // Body
+        write!(
+            f,
+            "{}",
+            FormattableCodeBody::new(&self.proc.body, &self.context.inner_scope_context())
+        )?;
+        // Procedure footer
+        self.context.indent(f)?;
+        writeln!(f, "end")
+    }
+}
+
+// FORMATTING OF CODE BODIES
+// ================================================================================================
+pub struct FormattableCodeBody<'a> {
+    body: &'a CodeBody,
+    context: &'a AstFormatterContext<'a>,
+}
+
+impl<'a> FormattableCodeBody<'a> {
+    pub fn new(
+        body: &'a CodeBody,
+        context: &'a AstFormatterContext<'a>,
+    ) -> FormattableCodeBody<'a> {
+        Self { body, context }
+    }
+}
+
+impl fmt::Display for FormattableCodeBody<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for node in self.body.nodes() {
+            write!(f, "{}", FormattableNode::new(node, self.context))?;
+        }
+        Ok(())
+    }
+}

--- a/assembly/src/ast/imports.rs
+++ b/assembly/src/ast/imports.rs
@@ -1,14 +1,13 @@
 use super::{
-    BTreeMap, ByteReader, ByteWriter, Deserializable, DeserializationError, LibraryPath,
-    ParsingError, ProcedureId, ProcedureName, Serializable, String, ToString, Token, TokenStream,
-    Vec, MAX_IMPORTS, MAX_INVOKED_IMPORTED_PROCS,
+    BTreeMap, ByteReader, ByteWriter, Deserializable, DeserializationError, InvokedProcsMap,
+    LibraryPath, ParsingError, ProcedureId, ProcedureName, Serializable, String, ToString, Token,
+    TokenStream, Vec, MAX_IMPORTS, MAX_INVOKED_IMPORTED_PROCS,
 };
 
 // TYPE ALIASES
 // ================================================================================================
 
 type ImportedModulesMap = BTreeMap<String, LibraryPath>;
-type InvokedProcsMap = BTreeMap<ProcedureId, (ProcedureName, LibraryPath)>;
 
 // MODULE IMPORTS
 // ================================================================================================
@@ -87,6 +86,11 @@ impl ModuleImports {
     /// Return the paths of all imported module
     pub fn import_paths(&self) -> Vec<&LibraryPath> {
         self.imports.values().collect()
+    }
+
+    /// Returns a reference to the invoked procedure map which maps procedure IDs to their names.
+    pub fn invoked_procs(&self) -> &InvokedProcsMap {
+        &self.invoked_procs
     }
 
     // STATE MUTATORS

--- a/assembly/src/ast/nodes/format.rs
+++ b/assembly/src/ast/nodes/format.rs
@@ -1,0 +1,151 @@
+use super::{AstFormatterContext, FormattableCodeBody, Instruction, Node};
+use core::fmt;
+
+// FORMATTING OF NODES
+// ================================================================================================
+pub struct FormattableNode<'a> {
+    node: &'a Node,
+    context: &'a AstFormatterContext<'a>,
+}
+
+impl<'a> FormattableNode<'a> {
+    pub fn new(node: &'a Node, context: &'a AstFormatterContext<'a>) -> Self {
+        Self { node, context }
+    }
+}
+
+impl fmt::Display for FormattableNode<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.node {
+            Node::Instruction(i) => {
+                write!(f, "{}", FormattableInstruction::new(i, self.context))
+            }
+            Node::IfElse {
+                true_case,
+                false_case,
+            } => {
+                self.context.indent(f)?;
+                writeln!(f, "if.true")?;
+                write!(
+                    f,
+                    "{}",
+                    FormattableCodeBody::new(true_case, &self.context.inner_scope_context())
+                )?;
+                if !false_case.nodes().is_empty() {
+                    // No false branch - don't output else branch
+                    self.context.indent(f)?;
+                    writeln!(f, "else")?;
+
+                    write!(
+                        f,
+                        "{}",
+                        FormattableCodeBody::new(false_case, &self.context.inner_scope_context())
+                    )?;
+                }
+                self.context.indent(f)?;
+                writeln!(f, "end")
+            }
+            Node::Repeat { times, body } => {
+                self.context.indent(f)?;
+                writeln!(f, "repeat.{times}")?;
+
+                write!(
+                    f,
+                    "{}",
+                    FormattableCodeBody::new(body, &self.context.inner_scope_context())
+                )?;
+
+                self.context.indent(f)?;
+                writeln!(f, "end")
+            }
+            Node::While { body } => {
+                self.context.indent(f)?;
+                writeln!(f, "while.true")?;
+
+                write!(
+                    f,
+                    "{}",
+                    FormattableCodeBody::new(body, &self.context.inner_scope_context())
+                )?;
+
+                self.context.indent(f)?;
+                writeln!(f, "end")
+            }
+        }
+    }
+}
+
+// FORMATTING OF INSTRUCTIONS WITH INDENTATION
+// ================================================================================================
+pub struct FormattableInstruction<'a> {
+    instruction: &'a Instruction,
+    context: &'a AstFormatterContext<'a>,
+}
+
+impl<'a> FormattableInstruction<'a> {
+    pub fn new(instruction: &'a Instruction, context: &'a AstFormatterContext<'a>) -> Self {
+        Self {
+            instruction,
+            context,
+        }
+    }
+}
+
+impl fmt::Display for FormattableInstruction<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.context.indent(f)?;
+        match self.instruction {
+            // procedure calls are represented by indices or hashes, so must be handled specially
+            Instruction::ExecLocal(index) => {
+                let proc_name = self.context.local_proc(*index as usize);
+                write!(f, "exec.{proc_name}")?;
+            }
+            Instruction::CallLocal(index) => {
+                let proc_name = self.context.local_proc(*index as usize);
+                write!(f, "call.{proc_name}")?;
+            }
+            Instruction::ExecImported(proc_id) => {
+                let (_, path) = self.context.imported_proc(proc_id);
+                write!(f, "exec.{path}")?;
+            }
+            Instruction::CallImported(proc_id) => {
+                let (_, path) = self.context.imported_proc(proc_id);
+                write!(f, "call.{path}")?;
+            }
+            Instruction::SysCall(proc_id) => {
+                let (_, path) = self.context.imported_proc(proc_id);
+                write!(f, "syscall.{path}")?;
+            }
+            Instruction::CallMastRoot(root) => {
+                write!(f, "call.")?;
+                display_hex_bytes(f, &root.as_bytes())?;
+            }
+            _ => {
+                // Not a procedure call. Use the normal formatting
+                write!(f, "{}", self.instruction)?;
+            }
+        }
+        writeln!(f)
+    }
+}
+
+// HELPER FUNCTIONS
+// ================================================================================================
+
+/// Builds a hex string from a byte slice
+pub fn display_hex_bytes(f: &mut fmt::Formatter<'_>, bytes: &[u8]) -> fmt::Result {
+    write!(f, "0x")?;
+    for byte in bytes {
+        write!(f, "{byte:02x}")?;
+    }
+    Ok(())
+}
+
+/// Builds a string from input vector to display push operation
+pub fn display_push_vec<T: fmt::Display>(f: &mut fmt::Formatter<'_>, values: &[T]) -> fmt::Result {
+    write!(f, "push")?;
+    for elem in values {
+        write!(f, ".{elem}")?;
+    }
+    Ok(())
+}

--- a/assembly/src/ast/nodes/mod.rs
+++ b/assembly/src/ast/nodes/mod.rs
@@ -1,8 +1,13 @@
-use super::{CodeBody, Felt, ProcedureId, RpoDigest, ToString, Vec};
+use super::{
+    AstFormatterContext, CodeBody, Felt, FormattableCodeBody, ProcedureId, RpoDigest, ToString, Vec,
+};
 use core::fmt;
 
 mod advice;
 pub use advice::AdviceInjectorNode;
+
+mod format;
+pub use format::*;
 
 mod serde;
 
@@ -556,7 +561,6 @@ impl fmt::Display for Instruction {
             Self::FriExt2Fold4 => write!(f, "fri_ext2fold4"),
 
             // ----- exec / call ------------------------------------------------------------------
-            // TODO: print exec/call instructions with procedures names, not indexes or id's
             Self::ExecLocal(index) => write!(f, "exec.{index}"),
             Self::ExecImported(proc_id) => write!(f, "exec.{proc_id}"),
             Self::CallLocal(index) => write!(f, "call.{index}"),
@@ -571,27 +575,6 @@ impl fmt::Display for Instruction {
             Self::Breakpoint => write!(f, "breakpoint"),
         }
     }
-}
-
-// HELPER FUNCTIONS
-// ================================================================================================
-
-/// Builds a hex string from a byte slice
-pub fn display_hex_bytes(f: &mut fmt::Formatter<'_>, bytes: &[u8]) -> fmt::Result {
-    write!(f, "0x")?;
-    for byte in bytes {
-        write!(f, "{byte:02x}")?;
-    }
-    Ok(())
-}
-
-/// Builds a string from input vector to display push operation
-fn display_push_vec<T: fmt::Display>(f: &mut fmt::Formatter<'_>, values: &[T]) -> fmt::Result {
-    write!(f, "push")?;
-    for elem in values {
-        write!(f, ".{elem}")?;
-    }
-    Ok(())
 }
 
 // TESTS

--- a/assembly/src/library/path.rs
+++ b/assembly/src/library/path.rs
@@ -2,7 +2,7 @@ use super::{
     ByteReader, ByteWriter, Deserializable, DeserializationError, PathError, Serializable, String,
     ToString, MAX_LABEL_LEN,
 };
-use core::{ops::Deref, str::from_utf8};
+use core::{fmt, ops::Deref, str::from_utf8};
 
 // CONSTANTS
 // ================================================================================================
@@ -309,6 +309,12 @@ impl Deserializable for LibraryPath {
         let path =
             from_utf8(&path).map_err(|e| DeserializationError::InvalidValue(e.to_string()))?;
         Self::new(path).map_err(|e| DeserializationError::InvalidValue(e.to_string()))
+    }
+}
+
+impl fmt::Display for LibraryPath {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.path)
     }
 }
 

--- a/assembly/src/procedures/mod.rs
+++ b/assembly/src/procedures/mod.rs
@@ -182,6 +182,12 @@ impl Deserializable for ProcedureName {
     }
 }
 
+impl fmt::Display for ProcedureName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.name)
+    }
+}
+
 // PROCEDURE ID
 // ================================================================================================
 


### PR DESCRIPTION
## Describe your changes

A default formatter is added to `ProgramAst` and `ModuleAst`. The formatter acts as a pretty-printer for the AST, including indentation and procedure names rather than procedure indices/ids.

In order to perform indentation and to output legal assembly, a set of `Formattable` structs have been added. These keep track of the formatting context.

Call instructions are handled separately from other instructions, because the procedure indices and ids must be transformed into procedure names. 

No tests have been added at this stage, because the formatter will be tested when connected to the compiler. It might also be worthwhile to add a `-pp` or `-format` option to the command-line assembler - comments regarding this feature would be appreciated.

No documentation has been added, since this PR is not user-facing.

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
