### PR TITLE
chore: enable github's Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This PR enables automated dependency updates built into GitHub.  That's useful for keeping up-to-date on security updates for example.

https://github.com/0xPolygonMiden/miden-vm/pull/1012 fixes the spurious clippy error we see here.