### PR TITLE
`AdviceProvider` finalisation refactoring

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -21,7 +21,7 @@ std = ["math/std", "winter-utils/std"]
 
 [dependencies]
 math = { package = "winter-math", version = "0.6", default-features = false }
-crypto = { package = "miden-crypto", version = "0.6", default-features = false }
+crypto = { package = "miden-crypto", git = "https://github.com/0xPolygonMiden/crypto.git", branch = "next", default-features = false }
 winter-crypto = { package = "winter-crypto", version = "0.6", default-features = false }
 winter-utils = { package = "winter-utils", version = "0.6", default-features = false }
 

--- a/processor/src/advice/inputs.rs
+++ b/processor/src/advice/inputs.rs
@@ -14,6 +14,7 @@ use super::{BTreeMap, Felt, InnerNodeInfo, InputError, MerkleStore, Vec};
 /// 2. Key-mapped element lists which can be pushed onto the advice stack.
 /// 3. Merkle store, which is used to provide nondeterministic inputs for instructions that
 ///    operates with Merkle trees.
+#[cfg(not(feature = "internals"))]
 #[derive(Clone, Debug, Default)]
 pub struct AdviceInputs {
     stack: Vec<Felt>,
@@ -121,4 +122,15 @@ impl AdviceInputs {
         let Self { stack, map, store } = self;
         (stack, map, store)
     }
+}
+
+// INTERNALS
+// ================================================================================================
+
+#[cfg(feature = "internals")]
+#[derive(Clone, Debug, Default)]
+pub struct AdviceInputs {
+    pub stack: Vec<Felt>,
+    pub map: BTreeMap<[u8; 32], Vec<Felt>>,
+    pub store: MerkleStore,
 }


### PR DESCRIPTION
This PR introduces the following changes:
- Introduces instance of `AdviceInputs` which exposes its internal fields.  Put this behind the `internals` feature flag.
- Refactor the finalizer of the `RecordingAdviceMap` to return (`AdviceInputs`, `MemAdviceProvider`) tuple.
- Implement `into_parts()` on `MemAdviceProvider` and `BaseAdviceProvider<SimpleAdviceMap, SimpleMerkleMap>`
