### PR TITLE
Switch CallSet to track RpoDigests instead of ProcedureIds

### DIFF
--- a/assembly/src/assembler/instruction/procedures.rs
+++ b/assembly/src/assembler/instruction/procedures.rs
@@ -18,7 +18,7 @@ impl Assembler {
         // operations from that SPAN block to the span builder instead of returning a code block
 
         // return the code block of the procedure
-        Ok(Some(proc.code_root().clone()))
+        Ok(Some(proc.code().clone()))
     }
 
     pub(super) fn exec_imported(
@@ -42,7 +42,7 @@ impl Assembler {
         // operations from that SPAN block to the span builder instead of returning a code block
 
         // return the code block of the procedure
-        Ok(Some(proc.code_root().clone()))
+        Ok(Some(proc.code().clone()))
     }
 
     pub(super) fn call_local(
@@ -56,8 +56,7 @@ impl Assembler {
         let proc = context.register_local_call(index, false)?;
 
         // create a new CALL block for the procedure call and return
-        let digest = proc.code_root().hash();
-        Ok(Some(CodeBlock::new_call(digest)))
+        Ok(Some(CodeBlock::new_call(proc.mast_root())))
     }
 
     pub(super) fn call_mast_root(
@@ -80,8 +79,7 @@ impl Assembler {
         context.register_external_call(proc, false)?;
 
         // create a new CALL block for the procedure call and return
-        let digest = proc.code_root().hash();
-        Ok(Some(CodeBlock::new_call(digest)))
+        Ok(Some(CodeBlock::new_call(proc.mast_root())))
     }
 
     pub(super) fn call_imported(
@@ -102,8 +100,7 @@ impl Assembler {
         context.register_external_call(proc, false)?;
 
         // create a new CALL block for the procedure call and return
-        let digest = proc.code_root().hash();
-        Ok(Some(CodeBlock::new_call(digest)))
+        Ok(Some(CodeBlock::new_call(proc.mast_root())))
     }
 
     pub(super) fn syscall(
@@ -129,7 +126,6 @@ impl Assembler {
         context.register_external_call(proc, false)?;
 
         // create a new SYSCALL block for the procedure call and return
-        let digest = proc.code_root().hash();
-        Ok(Some(CodeBlock::new_syscall(digest)))
+        Ok(Some(CodeBlock::new_syscall(proc.mast_root())))
     }
 }

--- a/assembly/src/assembler/mod.rs
+++ b/assembly/src/assembler/mod.rs
@@ -226,10 +226,10 @@ impl Assembler {
         //   which has been invoked via a local call instruction.
         for proc in module_procs.into_iter() {
             if proc.is_export() {
-                proc_roots.push(proc.code_root().hash());
+                proc_roots.push(proc.mast_root());
             }
 
-            if proc.is_export() || module_callset.contains(proc.id()) {
+            if proc.is_export() || module_callset.contains(&proc.mast_root()) {
                 // this is safe because we fail if the cache is borrowed.
                 self.proc_cache
                     .try_borrow_mut()

--- a/assembly/src/assembler/procedure_cache.rs
+++ b/assembly/src/assembler/procedure_cache.rs
@@ -57,8 +57,7 @@ impl ProcedureCache {
         match self.proc_map.entry(*proc.id()) {
             Entry::Occupied(_) => Err(AssemblyError::duplicate_proc_id(proc.id())),
             Entry::Vacant(entry) => {
-                let mast_root = proc.code_root().hash();
-                self.mast_map.entry(mast_root).or_insert(*proc.id());
+                self.mast_map.entry(proc.mast_root()).or_insert(*proc.id());
                 entry.insert(proc);
                 Ok(())
             }
@@ -102,7 +101,7 @@ impl ProcedureCache {
         self.proc_aliases.insert(alias_proc_id, proc_id);
         let proc = self.proc_map.get(&proc_id).expect("procedure not in cache");
 
-        Ok(proc.code_root().hash())
+        Ok(proc.mast_root())
     }
 
     // TEST HELPERS

--- a/assembly/src/assembler/tests.rs
+++ b/assembly/src/assembler/tests.rs
@@ -74,7 +74,7 @@ fn nested_blocks() {
         .borrow()
         .values()
         .next()
-        .map(|p| CodeBlock::new_syscall(p.code_root().hash()))
+        .map(|p| CodeBlock::new_syscall(p.mast_root()))
         .unwrap();
 
     let program = r#"

--- a/assembly/src/errors.rs
+++ b/assembly/src/errors.rs
@@ -13,7 +13,7 @@ use vm_core::utils::write_hex_bytes;
 pub enum AssemblyError {
     CallInKernel(String),
     CallerOutOKernel,
-    CallSetProcedureNotFound(ProcedureId),
+    CallSetProcedureNotFound(RpoDigest),
     CircularModuleDependency(Vec<String>),
     DivisionByZero,
     DuplicateProcName(String, String),
@@ -123,7 +123,7 @@ impl fmt::Display for AssemblyError {
         match self {
             CallInKernel(proc_name) => write!(f, "call instruction used kernel procedure '{proc_name}'"),
             CallerOutOKernel => write!(f, "caller instruction used outside of kernel"),
-            CallSetProcedureNotFound(proc_id) => write!(f, "callset procedure not found in assembler cache for procedure  '{proc_id}'"),
+            CallSetProcedureNotFound(mast_root) => write!(f, "callset procedure not found in assembler cache for procedure with MAST root {mast_root}"),
             CircularModuleDependency(dep_chain) => write!(f, "circular module dependency in the following chain: {dep_chain:?}"),
             DivisionByZero => write!(f, "division by zero"),
             DuplicateProcName(proc_name, module_path) => write!(f, "duplicate proc name '{proc_name}' in module {module_path}"),


### PR DESCRIPTION
Addresses #916.