### PR TITLE
Track procedures by their MAST root in procedure cache

### DIFF
--- a/assembly/src/assembler/instruction/procedures.rs
+++ b/assembly/src/assembler/instruction/procedures.rs
@@ -32,7 +32,6 @@ impl Assembler {
         // get the procedure from the assembler
         let proc_cache = self.proc_cache.borrow();
         let proc = proc_cache.get_by_id(proc_id).expect("procedure not in cache");
-        debug_assert!(proc.is_export(), "not imported procedure");
 
         // register and "inlined" call to the procedure; this updates the callset of the
         // procedure currently being compiled
@@ -72,7 +71,6 @@ impl Assembler {
         let proc = proc_cache
             .get_by_hash(root)
             .ok_or(AssemblyError::proc_mast_root_not_found(root))?;
-        debug_assert!(proc.is_export(), "not imported procedure");
 
         // register and "non-inlined" call to the procedure; this updates the callset of the
         // procedure currently being compiled
@@ -93,7 +91,6 @@ impl Assembler {
         // get the procedure from the assembler
         let proc_cache = self.proc_cache.borrow();
         let proc = proc_cache.get_by_id(proc_id).expect("procedure not in cache");
-        debug_assert!(proc.is_export(), "not imported procedure");
 
         // register and "non-inlined" call to the procedure; this updates the callset of the
         // procedure currently being compiled

--- a/assembly/src/assembler/mod.rs
+++ b/assembly/src/assembler/mod.rs
@@ -3,8 +3,8 @@ use super::{
     btree_map,
     crypto::hash::RpoDigest,
     AssemblyError, BTreeMap, CallSet, CodeBlock, CodeBlockTable, Felt, Kernel, Library,
-    LibraryError, LibraryPath, Module, Operation, Procedure, ProcedureId, ProcedureName, Program,
-    ToString, Vec, ONE, ZERO,
+    LibraryError, LibraryPath, Module, NamedProcedure, Operation, Procedure, ProcedureId,
+    ProcedureName, Program, ToString, Vec, ONE, ZERO,
 };
 use core::{borrow::Borrow, cell::RefCell};
 use vm_core::{utils::group_vector_elements, Decorator, DecoratorList};

--- a/assembly/src/errors.rs
+++ b/assembly/src/errors.rs
@@ -15,6 +15,7 @@ pub enum AssemblyError {
     CallerOutOKernel,
     CallSetProcedureNotFound(RpoDigest),
     CircularModuleDependency(Vec<String>),
+    ConflictingNumLocals(String),
     DivisionByZero,
     DuplicateProcName(String, String),
     DuplicateProcId(ProcedureId),
@@ -48,6 +49,10 @@ impl AssemblyError {
 
     pub fn circular_module_dependency(dep_chain: &[String]) -> Self {
         Self::CircularModuleDependency(dep_chain.to_vec())
+    }
+
+    pub fn conflicting_num_locals(proc_name: &str) -> Self {
+        Self::ConflictingNumLocals(proc_name.to_string())
     }
 
     pub fn division_by_zero() -> Self {
@@ -125,6 +130,7 @@ impl fmt::Display for AssemblyError {
             CallerOutOKernel => write!(f, "caller instruction used outside of kernel"),
             CallSetProcedureNotFound(mast_root) => write!(f, "callset procedure not found in assembler cache for procedure with MAST root {mast_root}"),
             CircularModuleDependency(dep_chain) => write!(f, "circular module dependency in the following chain: {dep_chain:?}"),
+            ConflictingNumLocals(proc_name) => write!(f, "procedure `{proc_name}` has the same MAST as another procedure but different number of locals"),
             DivisionByZero => write!(f, "division by zero"),
             DuplicateProcName(proc_name, module_path) => write!(f, "duplicate proc name '{proc_name}' in module {module_path}"),
             DuplicateProcId(proc_id) => write!(f, "duplicate proc id {proc_id}"),

--- a/assembly/src/lib.rs
+++ b/assembly/src/lib.rs
@@ -19,7 +19,7 @@ mod library;
 pub use library::{Library, LibraryNamespace, LibraryPath, MaslLibrary, Module, Version};
 
 mod procedures;
-use procedures::{CallSet, Procedure};
+use procedures::{CallSet, NamedProcedure, Procedure};
 pub use procedures::{ProcedureId, ProcedureName};
 
 pub mod ast;


### PR DESCRIPTION
This PR refactors `ProcedureCache` to track procedures based on their MAST root (rather than ID) in procedure cache. It also introduces the concept of a `NamedProcedure` (same as previous `Procedure`) and keeps only basic metadata in the `Procedure` struct.

To be reviewed after #1017.
