### PR TITLE
Allow the assembler to produce programs with phantom calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Simplified range checker and removed 1 main and 1 auxiliary trace column (#949).
 - Added `get_mapped_values()` and `get_store_subset()` methods to the `AdviceProvider` trait (#987).
 - Improved handling of invalid/incomplete parameters in `StackOutputs` constructors (#1010).
+- Allowed the assembler to produce programs with "phantom" calls (#1019).
 
 ## 0.6.1 (2023-06-29)
 

--- a/assembly/src/library/mod.rs
+++ b/assembly/src/library/mod.rs
@@ -89,7 +89,7 @@ impl Module {
         Self { path, ast }
     }
 
-    /// Create a new kernel module from a AST using the constant [`LibraryPath::kernel_path`].
+    /// Create a new kernel module from a AST using the constant [LibraryPath::kernel_path].
     pub fn kernel(ast: ModuleAst) -> Self {
         Self {
             path: LibraryPath::kernel_path(),


### PR DESCRIPTION
This PR addresses #918. Specifically, a flag has been added to `AssemblyContext` which specifies whether phantom calls are allowed.

Phantom calls are not allowed by default. To enable them, `AssemblyContext::with_phantom_calls` method should be used. Thus, only the methods which accept `AssemblyContext` can produce programs with phantom calls (these methods are `Assembler::compile_in_context()` and `Assembler::compile_module()`.

I did not enable this functionality for `Assembler::compile()` method as I wanted to avoid breaking changes in this PR. So, phantom calls are currently not allowed in programs compiled via this method.

To be reviewed after #1018.