### PR TITLE
BUG: Duplicate MAST in different modules

### DIFF
--- a/stdlib/asm/math/ntt512.masm
+++ b/stdlib/asm/math/ntt512.masm
@@ -1,3 +1,8 @@
+export.test_1
+    push.1 drop
+end
+
+
 #! Applies four NTT butterflies on four different indices, given following stack state
 #!
 #! [k0, k1, k2, k3, A0, B0, C0, D0, A1, B1, C1, D1]

--- a/stdlib/asm/math/poly512.masm
+++ b/stdlib/asm/math/poly512.masm
@@ -1,6 +1,10 @@
 use.std::math::ntt512
 use.std::math::u64
 
+export.test_1
+    push.1 drop
+end
+
 #! Given two consecutive words on stack, this routine performs
 #! element wise multiplication, while keeping resulting single
 #! word on stack.

--- a/stdlib/tests/crypto/falcon.rs
+++ b/stdlib/tests/crypto/falcon.rs
@@ -2661,3 +2661,18 @@ fn test_falcon512_verify() {
     let test = build_test!(source, &[]);
     assert!(test.execute().is_ok());
 }
+
+#[test]
+fn test_dup_mast() {
+    let source = "
+    use.std::math::poly512
+    use.std::math::ntt512
+    begin
+        exec.poly512::test_1
+        exec.ntt512::test_1
+    end
+    ";
+
+    let test = build_test!(source, &[]);
+    assert!(test.execute().is_ok());
+}


### PR DESCRIPTION
This serves as an example for a bug report.  See failing test.