### PR TITLE
Implement basic arithmetic on constant values 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### Assembly
 - Added ability to attach doc comments to re-exported procedures (#994).
 - Added support for nested modules (#992).
+- Added support for the arithmetic expressions in constant values (#1026).
 
 #### VM Internals
 - Simplified range checker and removed 1 main and 1 auxiliary trace column (#949).

--- a/assembly/src/ast/parsers/constants.rs
+++ b/assembly/src/ast/parsers/constants.rs
@@ -1,0 +1,262 @@
+use super::{Felt, LocalConstMap, ParsingError, StarkField, String, ToString, Token, Vec};
+use core::fmt::Display;
+
+// CONSTANT VALUE EXPRESSIONS
+// ================================================================================================
+
+/// An operation used in constant expressions
+#[derive(Debug, PartialEq)]
+enum Operation {
+    Add,
+    Sub,
+    Mul,
+    Div,
+    IntDiv,
+    LPar,
+    RPar,
+    Value(Felt),
+}
+
+impl Operation {
+    /// Returns operator from [Operation] based on provided character
+    pub fn get_operator(char: &char) -> Self {
+        match char {
+            '+' => Self::Add,
+            '-' => Self::Sub,
+            '*' => Self::Mul,
+            '/' => Self::Div,
+            '(' => Self::LPar,
+            ')' => Self::RPar,
+            _ => unreachable!("Invalid operator character"),
+        }
+    }
+}
+
+impl Display for Operation {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        use Operation::*;
+
+        match self {
+            Add => write!(f, "+"),
+            Sub => write!(f, "-"),
+            Mul => write!(f, "*"),
+            Div => write!(f, "/"),
+            IntDiv => write!(f, "//"),
+            LPar => write!(f, "("),
+            RPar => write!(f, ")"),
+            Value(v) => write!(f, "{}", v),
+        }
+    }
+}
+
+/// Calculates expression in the constant value.
+pub fn calculate_const_value(
+    op: &Token,
+    expression: &str,
+    constants: &LocalConstMap,
+) -> Result<Felt, ParsingError> {
+    let postfix_expression = build_postfix_expression(op, expression, constants)?;
+    evaluate_postfix_expression(op, expression, postfix_expression)
+}
+
+/// Parses constant value expression and transforms it into the postfix notation
+fn build_postfix_expression(
+    op: &Token,
+    expression: &str,
+    constants: &LocalConstMap,
+) -> Result<Vec<Operation>, ParsingError> {
+    let ops = ['+', '-', '*', '/', '(', ')'];
+
+    let mut stack = Vec::new();
+    let mut postfix_expression = Vec::new();
+    let mut parsed_value = String::new();
+
+    // Create a "window" of chars containing current and next char of the expression. It is needed
+    // to determine field division `//`.
+    let mut chars = expression.chars();
+    let mut next_char = chars.next();
+    let mut current_char: Option<char>;
+
+    loop {
+        current_char = next_char;
+        next_char = chars.next();
+
+        let current_char = current_char.unwrap();
+
+        // if char is an operator
+        if ops.contains(&current_char) {
+            // if we already parsed some value before push it to the postfix expression
+            if !parsed_value.is_empty() {
+                let parsed_number = parse_number(op, expression, constants, parsed_value)?;
+                postfix_expression.push(parsed_number);
+                parsed_value = "".to_string();
+            }
+
+            // if we get `(` push it on the stack
+            if current_char == '(' {
+                stack.push(Operation::LPar);
+            }
+            // if we get `)` push operators from the stack to the postfix expression untill we
+            // get `(` on stack
+            else if current_char == ')' {
+                while stack.last() != Some(&Operation::LPar) {
+                    postfix_expression.push(stack.pop().unwrap());
+                }
+                // pop the `(` from stack
+                stack.pop();
+            }
+            // if stack is empty or the last operator on stack is `(` or we got an operator
+            // with higher priority than stack top operator -- push obtained operator to the
+            // stack
+            else if stack.is_empty()
+                || stack.last() == Some(&Operation::LPar)
+                || left_has_greater_priority(&current_char, stack.last().unwrap())
+            {
+                // if we get field division
+                if current_char == '/' && next_char == Some('/') {
+                    stack.push(Operation::IntDiv);
+                    next_char = chars.next();
+                } else {
+                    stack.push(Operation::get_operator(&current_char));
+                }
+            }
+            // if the obtained operator has priority equal or lower than stack top operator
+            // push the operators from the stack to the postfix expression until stack is empty
+            // or we get from the stack an operation with lower priority
+            else {
+                postfix_expression.push(stack.pop().unwrap());
+                while !stack.is_empty()
+                    && !left_has_greater_priority(&current_char, stack.last().unwrap())
+                {
+                    postfix_expression.push(stack.pop().unwrap());
+                }
+                // if we get field division
+                if current_char == '/' && next_char == Some('/') {
+                    stack.push(Operation::IntDiv);
+                    next_char = chars.next();
+                } else {
+                    stack.push(Operation::get_operator(&current_char));
+                }
+            }
+        } else {
+            // push character of the number (or its name) to the `parsed_number` string
+            parsed_value.push(current_char);
+        }
+
+        if next_char.is_none() {
+            break;
+        }
+    }
+
+    // push the remaining number to the postfix expression
+    if !parsed_value.is_empty() {
+        let parsed_number = parse_number(op, expression, constants, parsed_value)?;
+        postfix_expression.push(parsed_number);
+    }
+
+    // push remaining on the stack operators to the postfix expression
+    while let Some(element) = stack.pop() {
+        postfix_expression.push(element);
+    }
+
+    Ok(postfix_expression)
+}
+
+/// Evaluates constant expression represented in postfix notation
+fn evaluate_postfix_expression(
+    op: &Token,
+    expression: &str,
+    postfix_expression: Vec<Operation>,
+) -> Result<Felt, ParsingError> {
+    let mut stack = Vec::new();
+
+    for operation in postfix_expression.iter() {
+        match operation {
+            // if the operation is a value
+            Operation::Value(value) => stack.push(*value),
+            // if the operation is an operator
+            _ => {
+                let right = stack.pop().expect("stack is empty");
+                let left = stack.pop().expect("stack is empty");
+                stack.push(compute_statement(left, right, operation, op, expression)?);
+            }
+        }
+    }
+
+    // get the result from the stack
+    stack.pop().ok_or_else(|| {
+        ParsingError::invalid_const_value(
+            op,
+            expression,
+            &format!("constant expression {} is incorrect", op),
+        )
+    })
+}
+
+// HELPER FUNCTIONS
+// ================================================================================================
+
+/// Returns the number in `value` or the constant value if the value is the name of the constant.
+fn parse_number(
+    op: &Token,
+    expression: &str,
+    constants: &LocalConstMap,
+    value: String,
+) -> Result<Operation, ParsingError> {
+    let parsed_number = value.parse::<u64>();
+    // if the parsed value is a number push it on the stack
+    if let Ok(parsed_number) = parsed_number {
+        Ok(Operation::Value(Felt::new(parsed_number)))
+    }
+    // if it is a name of the constant get its value from the `constants` map
+    else {
+        let parsed_number = constants.get(&value).ok_or_else(|| {
+            ParsingError::invalid_const_value(
+                op,
+                expression,
+                &format!("constant with name {} was not initialized", value),
+            )
+        })?;
+        Ok(Operation::Value(Felt::new(*parsed_number)))
+    }
+}
+
+/// Returns `true` if th left operator has higher priority than the right, `false` otherwise.
+fn left_has_greater_priority(left: &char, right: &Operation) -> bool {
+    use Operation::*;
+
+    let left_level = match left {
+        '*' | '/' => 2,
+        '+' | '-' => 1,
+        _ => 0,
+    };
+    let right_level = match right {
+        Mul | Div | IntDiv => 2,
+        Add | Sub => 1,
+        _ => 0,
+    };
+    left_level > right_level
+}
+
+/// Computes the expression based on provided `operator` character.
+fn compute_statement(
+    left: Felt,
+    right: Felt,
+    operator: &Operation,
+    op: &Token,
+    expression: &str,
+) -> Result<Felt, ParsingError> {
+    use Operation::*;
+    match operator {
+        Add => Ok(left + right),
+        Sub => Ok(left - right),
+        Mul => Ok(left * right),
+        Div => Ok(Felt::new(left.as_int() / right.as_int())),
+        IntDiv => Ok(left / right),
+        _ => Err(ParsingError::invalid_const_value(
+            op,
+            expression,
+            &format!("expression contains unsupported operator: {}", operator),
+        )),
+    }
+}

--- a/assembly/src/ast/parsers/mod.rs
+++ b/assembly/src/ast/parsers/mod.rs
@@ -1,9 +1,9 @@
 use super::{
-    bound_into_included_u64, AdviceInjectorNode, BTreeMap, CodeBody, Deserializable, Felt,
-    Instruction, InvocationTarget, LabelError, LibraryPath, LocalConstMap, LocalProcMap,
-    ModuleImports, Node, ParsingError, ProcedureAst, ProcedureId, ProcedureName, ReExportedProcMap,
-    RpoDigest, SliceReader, StarkField, String, ToString, Token, TokenStream, Vec, MAX_BODY_LEN,
-    MAX_DOCS_LEN, MAX_LABEL_LEN, MAX_STACK_WORD_OFFSET,
+    bound_into_included_u64, AdviceInjectorNode, CodeBody, Deserializable, Felt, Instruction,
+    InvocationTarget, LabelError, LibraryPath, LocalConstMap, LocalProcMap, ModuleImports, Node,
+    ParsingError, ProcedureAst, ProcedureId, ProcedureName, ReExportedProcMap, RpoDigest,
+    SliceReader, StarkField, String, ToString, Token, TokenStream, Vec, MAX_BODY_LEN, MAX_DOCS_LEN,
+    MAX_LABEL_LEN, MAX_STACK_WORD_OFFSET,
 };
 use core::{fmt::Display, ops::RangeBounds};
 
@@ -12,6 +12,9 @@ pub mod field_ops;
 pub mod io_ops;
 pub mod stack_ops;
 pub mod u32_ops;
+
+pub mod constants;
+pub use constants::calculate_const_value;
 
 mod context;
 pub use context::ParserContext;
@@ -51,10 +54,7 @@ pub fn parse_constants(tokens: &mut TokenStream) -> Result<LocalConstMap, Parsin
 }
 
 /// Parses a constant token and returns a (constant_name, constant_value) tuple
-fn parse_constant(
-    token: &Token,
-    constants: &BTreeMap<String, u64>,
-) -> Result<(String, u64), ParsingError> {
+fn parse_constant(token: &Token, constants: &LocalConstMap) -> Result<(String, u64), ParsingError> {
     match token.num_parts() {
         0 => unreachable!(),
         1 => Err(ParsingError::missing_param(token)),
@@ -84,11 +84,11 @@ fn parse_constant(
 fn parse_const_value(
     op: &Token,
     const_value: &str,
-    constants: &BTreeMap<String, u64>,
+    constants: &LocalConstMap,
 ) -> Result<u64, ParsingError> {
     let result = match const_value.parse::<u64>() {
         Ok(value) => value,
-        Err(_) => calculate_const_value_with_stack(op, const_value, constants)? as u64,
+        Err(_) => calculate_const_value(op, const_value, constants)?.as_int(),
     };
 
     let range = 0..Felt::MODULUS;
@@ -97,314 +97,6 @@ fn parse_const_value(
         upper_bound = bound_into_included_u64(range.end_bound(), false)
     )
     .as_str(),))
-}
-
-/// Parses and calculates expression in the constant value.
-///
-/// The idea is to split expression by operators in the correct order and invoke this function on
-/// the obtained prefix and suffix.
-#[allow(dead_code)]
-fn calculate_const_value_without_stack(
-    op: &Token,
-    expression: &str,
-    constants: &BTreeMap<String, u64>,
-) -> Result<i64, ParsingError> {
-    // handle the parentheses
-    let l_par_split = expression.split_once('(');
-    if let Some(l_par_split) = l_par_split {
-        let right_side = l_par_split.1;
-        // get the expression in the parentheses
-        let (in_par_string, remainder) = split_parenthesis_content(right_side);
-        // calculate the statement in the parentheses
-        let par_result = calculate_const_value_without_stack(op, in_par_string, constants)?;
-        let precalc_expression = [l_par_split.0, &par_result.to_string(), remainder].concat();
-        //
-        return calculate_const_value_without_stack(op, &precalc_expression, constants);
-    }
-
-    // handle the addition
-    let res = expression.split_once('+');
-    if let Some(res) = res {
-        return Ok(calculate_const_value_without_stack(op, res.0, constants)?
-            + calculate_const_value_without_stack(op, res.1, constants)?);
-    }
-
-    // handle the subtraction
-    // notice that subtraction splitting is performed from the end of the expression
-    let res = expression.rsplit_once('-');
-    if let Some(res) = res {
-        return Ok(calculate_const_value_without_stack(op, res.0, constants)?
-            - calculate_const_value_without_stack(op, res.1, constants)?);
-    }
-
-    let div_split = expression.split_once('/');
-    let mul_split = expression.split_once('*');
-
-    match (div_split, mul_split) {
-        (None, None) => {}
-        (Some(parts), None) => return handle_division(op, constants, parts),
-        (None, Some(parts)) => return handle_multiplication(op, constants, parts),
-        (Some(div_parts), Some(mul_parts)) => {
-            // if multiplication and division are only left, perform the first operation on the
-            // right (less prioritized)
-            if div_parts.0.len() > mul_parts.0.len() {
-                return handle_division(op, constants, div_parts);
-            } else {
-                return handle_multiplication(op, constants, mul_parts);
-            }
-        }
-    }
-
-    // handle a constant value
-    let number = expression.parse::<i64>();
-    if let Ok(number) = number {
-        // just return it if it is a number
-        Ok(number)
-    } else {
-        // get its value from the constants map if it is a constant name
-        constants
-            .get(&expression.to_string())
-            .ok_or_else(|| {
-                ParsingError::invalid_const_value(
-                    op,
-                    expression,
-                    &format!("constant with name {} was not initialized", expression),
-                )
-            })
-            .map(|&value| value as i64)
-    }
-}
-
-/// Returns the result of division performed in the constant value. Supports `Felt` and `i64`
-/// divison operations.
-pub fn handle_division(
-    op: &Token,
-    constants: &BTreeMap<String, u64>,
-    parts: (&str, &str),
-) -> Result<i64, ParsingError> {
-    if parts.1.starts_with('/') {
-        let felt_result =
-            Felt::from(calculate_const_value_without_stack(op, parts.0, constants)? as u64)
-                / Felt::from(
-                    calculate_const_value_without_stack(op, &parts.1[1..], constants)? as u64
-                );
-        return Ok(felt_result.as_int() as i64);
-    }
-    calculate_const_value_without_stack(op, parts.0, constants)?
-        .checked_div(calculate_const_value_without_stack(op, parts.1, constants)?)
-        .ok_or_else(|| ParsingError::const_division_by_zero(op))
-}
-
-/// Returns the result of multiplication performed in the constant value.
-pub fn handle_multiplication(
-    op: &Token,
-    constants: &BTreeMap<String, u64>,
-    parts: (&str, &str),
-) -> Result<i64, ParsingError> {
-    Ok(calculate_const_value_without_stack(op, parts.0, constants)?
-        * calculate_const_value_without_stack(op, parts.1, constants)?)
-}
-
-/// Returns the internals of the current parsing parentheses along with remaining string.
-///
-/// # Example:
-/// If the expression is `3+(2+1))*(5/2)` this function will return `("3+(2+1)", "*(5/2)")`.
-///
-/// The first parenthesis of the expression is absent because it was consumed on the parsing stage.
-pub fn split_parenthesis_content(expression: &str) -> (&str, &str) {
-    let mut counter = 0;
-    let mut result = "";
-    let mut remainder = expression;
-    for (index, char) in expression.chars().enumerate() {
-        match char {
-            '(' => counter += 1,
-            ')' if counter == 0 => {
-                result = &expression[..index];
-                remainder = &expression[index + 1..];
-                break;
-            }
-            ')' if counter != 0 => counter -= 1,
-            _ => {}
-        }
-    }
-    (result, remainder)
-}
-
-/// Parses and calculates expression in the constant value.
-///
-/// The idea is to rebuild expression in the postfix representation and then evaluate it.
-pub fn calculate_const_value_with_stack(
-    op: &Token,
-    expression: &str,
-    constants: &BTreeMap<String, u64>,
-) -> Result<i64, ParsingError> {
-    let ops = ['+', '-', '*', '/', '(', ')'];
-
-    let mut stack = Vec::new();
-    let mut postfix_expression = Vec::new();
-    let mut parsed_number = String::new();
-
-    // Create a "window" of chars containing current and next char of the expression. It is needed
-    // to determine field division `//`.
-    let mut chars = expression.chars();
-    let mut next_char = chars.next();
-    let mut current_char: Option<char>;
-
-    loop {
-        current_char = next_char;
-        next_char = chars.next();
-
-        let current_char = current_char.unwrap();
-
-        // if char is an operator
-        if ops.contains(&current_char) {
-            // if we already parsed some value before push it to the postfix expression
-            if !parsed_number.is_empty() {
-                postfix_expression.push(parsed_number);
-                parsed_number = "".to_string();
-            }
-
-            // if we get `(` push it on the stack
-            if current_char == '(' {
-                stack.push(current_char.to_string());
-            }
-            // if we get `)` push operators from the stack to the postfix expression untill we
-            // get `(` on stack
-            else if current_char == ')' {
-                while stack.last() != Some(&"(".to_string()) {
-                    postfix_expression.push(stack.pop().unwrap().to_string());
-                }
-                // pop the `(` from stack
-                stack.pop();
-            }
-            // if stack is empty or the last operator on stack is `(` or we got an operator
-            // with higher priority than stack top operator -- push obtained operator to the
-            // stack
-            else if stack.is_empty()
-                || *stack.last().unwrap() == "("
-                || left_has_greater_priority(&current_char, stack.last().unwrap())
-            {
-                // if we get field division
-                if current_char == '/' && next_char == Some('/') {
-                    stack.push("//".to_string());
-                    next_char = chars.next();
-                } else {
-                    stack.push(current_char.to_string());
-                }
-            }
-            // if the obtained operator has priority equal or lower than stack top operator
-            // push the operators from the stack to the postfix expression until stack is empty
-            // or we get from the stack an operation with lower priority
-            else {
-                postfix_expression.push(stack.pop().unwrap().to_string());
-                while !stack.is_empty()
-                    && !left_has_greater_priority(&current_char, stack.last().unwrap())
-                {
-                    postfix_expression.push(stack.pop().unwrap().to_string());
-                }
-                // if we get field division
-                if current_char == '/' && next_char == Some('/') {
-                    stack.push("//".to_string());
-                    next_char = chars.next();
-                } else {
-                    stack.push(current_char.to_string());
-                }
-            }
-        } else {
-            // push character of the number (or its name) to the `parsed_number` string
-            parsed_number.push(current_char);
-        }
-
-        if next_char.is_none() {
-            break;
-        }
-    }
-
-    // push the remaining number to the postfix expression
-    if !parsed_number.is_empty() {
-        postfix_expression.push(parsed_number);
-    }
-
-    // push remaining on the stack operators to the postfix expression
-    while !stack.is_empty() {
-        postfix_expression.push(stack.pop().unwrap().to_string());
-    }
-
-    let mut stack = Vec::new();
-    for elem in postfix_expression.iter() {
-        if ops.contains(&elem.chars().next().unwrap()) {
-            // if the parsed element is an operator
-            let right = stack.pop().expect("stack is empty");
-            let left = stack.pop().expect("stack is empty");
-            stack.push(compute_statement(left, right, elem, op, expression)?);
-        } else {
-            let number = elem.parse::<i64>();
-            // if the parsed element is a number
-            if let Ok(number) = number {
-                stack.push(number);
-            }
-            // if it is a name of the constant get its value from the `constants` map
-            else {
-                let const_value = constants.get(elem).ok_or_else(|| {
-                    ParsingError::invalid_const_value(
-                        op,
-                        expression,
-                        &format!("constant with name {} was not initialized", expression),
-                    )
-                })?;
-                stack.push(*const_value as i64);
-            }
-        }
-    }
-
-    // get the result from the stack
-    stack
-        .last()
-        .ok_or_else(|| {
-            ParsingError::invalid_const_value(
-                op,
-                expression,
-                &format!("constant expression {} is incorrect", op),
-            )
-        })
-        .map(|&value| value)
-}
-
-/// Returns `true` if th left operator has higher priority than the right, `false` otherwise.
-fn left_has_greater_priority(left: &char, right: &str) -> bool {
-    let left_level = match left {
-        '*' | '/' => 2,
-        '+' | '-' => 1,
-        _ => 0,
-    };
-    let right_level = match right {
-        "*" | "/" | "//" => 2,
-        "+" | "-" => 1,
-        _ => 0,
-    };
-    left_level > right_level
-}
-
-/// Computes the expression based on provided `operator` character.
-fn compute_statement(
-    left: i64,
-    right: i64,
-    operator: &String,
-    op: &Token,
-    expression: &str,
-) -> Result<i64, ParsingError> {
-    match operator.as_str() {
-        "+" => Ok(left + right),
-        "-" => Ok(left - right),
-        "*" => Ok(left * right),
-        "/" => Ok(left.checked_div(right).unwrap()),
-        "//" => Ok((Felt::from(left as u64) / Felt::from(right as u64)).as_int() as i64),
-        _ => Err(ParsingError::invalid_const_value(
-            op,
-            expression,
-            &format!("expression contains unsupported operator: {}", operator),
-        )),
-    }
 }
 
 /// Parses a param from the op token with the specified type and index. If the param is a constant

--- a/assembly/src/ast/parsers/mod.rs
+++ b/assembly/src/ast/parsers/mod.rs
@@ -1,9 +1,9 @@
 use super::{
-    bound_into_included_u64, AdviceInjectorNode, CodeBody, Deserializable, Felt, Instruction,
-    InvocationTarget, LabelError, LibraryPath, LocalConstMap, LocalProcMap, ModuleImports, Node,
-    ParsingError, ProcedureAst, ProcedureId, ProcedureName, ReExportedProcMap, RpoDigest,
-    SliceReader, StarkField, String, ToString, Token, TokenStream, Vec, MAX_BODY_LEN, MAX_DOCS_LEN,
-    MAX_LABEL_LEN, MAX_STACK_WORD_OFFSET,
+    bound_into_included_u64, AdviceInjectorNode, BTreeMap, CodeBody, Deserializable, Felt,
+    Instruction, InvocationTarget, LabelError, LibraryPath, LocalConstMap, LocalProcMap,
+    ModuleImports, Node, ParsingError, ProcedureAst, ProcedureId, ProcedureName, ReExportedProcMap,
+    RpoDigest, SliceReader, StarkField, String, ToString, Token, TokenStream, Vec, MAX_BODY_LEN,
+    MAX_DOCS_LEN, MAX_LABEL_LEN, MAX_STACK_WORD_OFFSET,
 };
 use core::{fmt::Display, ops::RangeBounds};
 
@@ -34,7 +34,7 @@ pub fn parse_constants(tokens: &mut TokenStream) -> Result<LocalConstMap, Parsin
     while let Some(token) = tokens.read() {
         match token.parts()[0] {
             Token::CONST => {
-                let (name, value) = parse_constant(token)?;
+                let (name, value) = parse_constant(token, &constants)?;
 
                 if constants.contains_key(&name) {
                     return Err(ParsingError::duplicate_const_name(token, &name));
@@ -51,7 +51,10 @@ pub fn parse_constants(tokens: &mut TokenStream) -> Result<LocalConstMap, Parsin
 }
 
 /// Parses a constant token and returns a (constant_name, constant_value) tuple
-fn parse_constant(token: &Token) -> Result<(String, u64), ParsingError> {
+fn parse_constant(
+    token: &Token,
+    constants: &BTreeMap<String, u64>,
+) -> Result<(String, u64), ParsingError> {
     match token.num_parts() {
         0 => unreachable!(),
         1 => Err(ParsingError::missing_param(token)),
@@ -64,7 +67,7 @@ fn parse_constant(token: &Token) -> Result<(String, u64), ParsingError> {
                     let name = CONSTANT_LABEL_PARSER
                         .parse_label(const_declaration[0])
                         .map_err(|err| ParsingError::invalid_const_name(token, err))?;
-                    let value = parse_const_value(token, const_declaration[1])?;
+                    let value = parse_const_value(token, const_declaration[1], constants)?;
                     Ok((name.to_string(), value))
                 }
                 _ => Err(ParsingError::extra_param(token)),
@@ -78,10 +81,15 @@ fn parse_constant(token: &Token) -> Result<(String, u64), ParsingError> {
 // ================================================================================================
 
 /// Parses a constant value and ensures it falls within bounds specified by the caller
-fn parse_const_value(op: &Token, const_value: &str) -> Result<u64, ParsingError> {
-    let result = const_value
-        .parse::<u64>()
-        .map_err(|err| ParsingError::invalid_const_value(op, const_value, &err.to_string()))?;
+fn parse_const_value(
+    op: &Token,
+    const_value: &str,
+    constants: &BTreeMap<String, u64>,
+) -> Result<u64, ParsingError> {
+    let result = match const_value.parse::<u64>() {
+        Ok(value) => value,
+        Err(_) => calculate_const_value_with_stack(op, const_value, constants)? as u64,
+    };
 
     let range = 0..Felt::MODULUS;
     range.contains(&result).then_some(result).ok_or_else(|| ParsingError::invalid_const_value(op, const_value, format!(
@@ -89,6 +97,314 @@ fn parse_const_value(op: &Token, const_value: &str) -> Result<u64, ParsingError>
         upper_bound = bound_into_included_u64(range.end_bound(), false)
     )
     .as_str(),))
+}
+
+/// Parses and calculates expression in the constant value.
+///
+/// The idea is to split expression by operators in the correct order and invoke this function on
+/// the obtained prefix and suffix.
+#[allow(dead_code)]
+fn calculate_const_value_without_stack(
+    op: &Token,
+    expression: &str,
+    constants: &BTreeMap<String, u64>,
+) -> Result<i64, ParsingError> {
+    // handle the parentheses
+    let l_par_split = expression.split_once('(');
+    if let Some(l_par_split) = l_par_split {
+        let right_side = l_par_split.1;
+        // get the expression in the parentheses
+        let (in_par_string, remainder) = split_parenthesis_content(right_side);
+        // calculate the statement in the parentheses
+        let par_result = calculate_const_value_without_stack(op, in_par_string, constants)?;
+        let precalc_expression = [l_par_split.0, &par_result.to_string(), remainder].concat();
+        //
+        return calculate_const_value_without_stack(op, &precalc_expression, constants);
+    }
+
+    // handle the addition
+    let res = expression.split_once('+');
+    if let Some(res) = res {
+        return Ok(calculate_const_value_without_stack(op, res.0, constants)?
+            + calculate_const_value_without_stack(op, res.1, constants)?);
+    }
+
+    // handle the subtraction
+    // notice that subtraction splitting is performed from the end of the expression
+    let res = expression.rsplit_once('-');
+    if let Some(res) = res {
+        return Ok(calculate_const_value_without_stack(op, res.0, constants)?
+            - calculate_const_value_without_stack(op, res.1, constants)?);
+    }
+
+    let div_split = expression.split_once('/');
+    let mul_split = expression.split_once('*');
+
+    match (div_split, mul_split) {
+        (None, None) => {}
+        (Some(parts), None) => return handle_division(op, constants, parts),
+        (None, Some(parts)) => return handle_multiplication(op, constants, parts),
+        (Some(div_parts), Some(mul_parts)) => {
+            // if multiplication and division are only left, perform the first operation on the
+            // right (less prioritized)
+            if div_parts.0.len() > mul_parts.0.len() {
+                return handle_division(op, constants, div_parts);
+            } else {
+                return handle_multiplication(op, constants, mul_parts);
+            }
+        }
+    }
+
+    // handle a constant value
+    let number = expression.parse::<i64>();
+    if let Ok(number) = number {
+        // just return it if it is a number
+        Ok(number)
+    } else {
+        // get its value from the constants map if it is a constant name
+        constants
+            .get(&expression.to_string())
+            .ok_or_else(|| {
+                ParsingError::invalid_const_value(
+                    op,
+                    expression,
+                    &format!("constant with name {} was not initialized", expression),
+                )
+            })
+            .map(|&value| value as i64)
+    }
+}
+
+/// Returns the result of division performed in the constant value. Supports `Felt` and `i64`
+/// divison operations.
+pub fn handle_division(
+    op: &Token,
+    constants: &BTreeMap<String, u64>,
+    parts: (&str, &str),
+) -> Result<i64, ParsingError> {
+    if parts.1.starts_with('/') {
+        let felt_result =
+            Felt::from(calculate_const_value_without_stack(op, parts.0, constants)? as u64)
+                / Felt::from(
+                    calculate_const_value_without_stack(op, &parts.1[1..], constants)? as u64
+                );
+        return Ok(felt_result.as_int() as i64);
+    }
+    calculate_const_value_without_stack(op, parts.0, constants)?
+        .checked_div(calculate_const_value_without_stack(op, parts.1, constants)?)
+        .ok_or_else(|| ParsingError::const_division_by_zero(op))
+}
+
+/// Returns the result of multiplication performed in the constant value.
+pub fn handle_multiplication(
+    op: &Token,
+    constants: &BTreeMap<String, u64>,
+    parts: (&str, &str),
+) -> Result<i64, ParsingError> {
+    Ok(calculate_const_value_without_stack(op, parts.0, constants)?
+        * calculate_const_value_without_stack(op, parts.1, constants)?)
+}
+
+/// Returns the internals of the current parsing parentheses along with remaining string.
+///
+/// # Example:
+/// If the expression is `3+(2+1))*(5/2)` this function will return `("3+(2+1)", "*(5/2)")`.
+///
+/// The first parenthesis of the expression is absent because it was consumed on the parsing stage.
+pub fn split_parenthesis_content(expression: &str) -> (&str, &str) {
+    let mut counter = 0;
+    let mut result = "";
+    let mut remainder = expression;
+    for (index, char) in expression.chars().enumerate() {
+        match char {
+            '(' => counter += 1,
+            ')' if counter == 0 => {
+                result = &expression[..index];
+                remainder = &expression[index + 1..];
+                break;
+            }
+            ')' if counter != 0 => counter -= 1,
+            _ => {}
+        }
+    }
+    (result, remainder)
+}
+
+/// Parses and calculates expression in the constant value.
+///
+/// The idea is to rebuild expression in the postfix representation and then evaluate it.
+pub fn calculate_const_value_with_stack(
+    op: &Token,
+    expression: &str,
+    constants: &BTreeMap<String, u64>,
+) -> Result<i64, ParsingError> {
+    let ops = ['+', '-', '*', '/', '(', ')'];
+
+    let mut stack = Vec::new();
+    let mut postfix_expression = Vec::new();
+    let mut parsed_number = String::new();
+
+    // Create a "window" of chars containing current and next char of the expression. It is needed
+    // to determine field division `//`.
+    let mut chars = expression.chars();
+    let mut next_char = chars.next();
+    let mut current_char: Option<char>;
+
+    loop {
+        current_char = next_char;
+        next_char = chars.next();
+
+        let current_char = current_char.unwrap();
+
+        // if char is an operator
+        if ops.contains(&current_char) {
+            // if we already parsed some value before push it to the postfix expression
+            if !parsed_number.is_empty() {
+                postfix_expression.push(parsed_number);
+                parsed_number = "".to_string();
+            }
+
+            // if we get `(` push it on the stack
+            if current_char == '(' {
+                stack.push(current_char.to_string());
+            }
+            // if we get `)` push operators from the stack to the postfix expression untill we
+            // get `(` on stack
+            else if current_char == ')' {
+                while stack.last() != Some(&"(".to_string()) {
+                    postfix_expression.push(stack.pop().unwrap().to_string());
+                }
+                // pop the `(` from stack
+                stack.pop();
+            }
+            // if stack is empty or the last operator on stack is `(` or we got an operator
+            // with higher priority than stack top operator -- push obtained operator to the
+            // stack
+            else if stack.is_empty()
+                || *stack.last().unwrap() == "("
+                || left_has_greater_priority(&current_char, stack.last().unwrap())
+            {
+                // if we get field division
+                if current_char == '/' && next_char == Some('/') {
+                    stack.push("//".to_string());
+                    next_char = chars.next();
+                } else {
+                    stack.push(current_char.to_string());
+                }
+            }
+            // if the obtained operator has priority equal or lower than stack top operator
+            // push the operators from the stack to the postfix expression until stack is empty
+            // or we get from the stack an operation with lower priority
+            else {
+                postfix_expression.push(stack.pop().unwrap().to_string());
+                while !stack.is_empty()
+                    && !left_has_greater_priority(&current_char, stack.last().unwrap())
+                {
+                    postfix_expression.push(stack.pop().unwrap().to_string());
+                }
+                // if we get field division
+                if current_char == '/' && next_char == Some('/') {
+                    stack.push("//".to_string());
+                    next_char = chars.next();
+                } else {
+                    stack.push(current_char.to_string());
+                }
+            }
+        } else {
+            // push character of the number (or its name) to the `parsed_number` string
+            parsed_number.push(current_char);
+        }
+
+        if next_char.is_none() {
+            break;
+        }
+    }
+
+    // push the remaining number to the postfix expression
+    if !parsed_number.is_empty() {
+        postfix_expression.push(parsed_number);
+    }
+
+    // push remaining on the stack operators to the postfix expression
+    while !stack.is_empty() {
+        postfix_expression.push(stack.pop().unwrap().to_string());
+    }
+
+    let mut stack = Vec::new();
+    for elem in postfix_expression.iter() {
+        if ops.contains(&elem.chars().next().unwrap()) {
+            // if the parsed element is an operator
+            let right = stack.pop().expect("stack is empty");
+            let left = stack.pop().expect("stack is empty");
+            stack.push(compute_statement(left, right, elem, op, expression)?);
+        } else {
+            let number = elem.parse::<i64>();
+            // if the parsed element is a number
+            if let Ok(number) = number {
+                stack.push(number);
+            }
+            // if it is a name of the constant get its value from the `constants` map
+            else {
+                let const_value = constants.get(elem).ok_or_else(|| {
+                    ParsingError::invalid_const_value(
+                        op,
+                        expression,
+                        &format!("constant with name {} was not initialized", expression),
+                    )
+                })?;
+                stack.push(*const_value as i64);
+            }
+        }
+    }
+
+    // get the result from the stack
+    stack
+        .last()
+        .ok_or_else(|| {
+            ParsingError::invalid_const_value(
+                op,
+                expression,
+                &format!("constant expression {} is incorrect", op),
+            )
+        })
+        .map(|&value| value)
+}
+
+/// Returns `true` if th left operator has higher priority than the right, `false` otherwise.
+fn left_has_greater_priority(left: &char, right: &str) -> bool {
+    let left_level = match left {
+        '*' | '/' => 2,
+        '+' | '-' => 1,
+        _ => 0,
+    };
+    let right_level = match right {
+        "*" | "/" | "//" => 2,
+        "+" | "-" => 1,
+        _ => 0,
+    };
+    left_level > right_level
+}
+
+/// Computes the expression based on provided `operator` character.
+fn compute_statement(
+    left: i64,
+    right: i64,
+    operator: &String,
+    op: &Token,
+    expression: &str,
+) -> Result<i64, ParsingError> {
+    match operator.as_str() {
+        "+" => Ok(left + right),
+        "-" => Ok(left - right),
+        "*" => Ok(left * right),
+        "/" => Ok(left.checked_div(right).unwrap()),
+        "//" => Ok((Felt::from(left as u64) / Felt::from(right as u64)).as_int() as i64),
+        _ => Err(ParsingError::invalid_const_value(
+            op,
+            expression,
+            &format!("expression contains unsupported operator: {}", operator),
+        )),
+    }
 }
 
 /// Parses a param from the op token with the specified type and index. If the param is a constant

--- a/assembly/src/errors.rs
+++ b/assembly/src/errors.rs
@@ -252,6 +252,14 @@ impl ParsingError {
         }
     }
 
+    pub fn const_division_by_zero(token: &Token) -> Self {
+        ParsingError {
+            message: format!("constant expression {token} contains division by zero"),
+            location: *token.location(),
+            op: token.to_string(),
+        }
+    }
+
     // INVALID / MALFORMED INSTRUCTIONS
     // --------------------------------------------------------------------------------------------
 

--- a/assembly/src/tests.rs
+++ b/assembly/src/tests.rs
@@ -232,11 +232,10 @@ fn constant_alphanumeric_expression() {
     assert_eq!(expected, format!("{program}"));
 }
 
-// TODO: improve field division test
 #[test]
 fn constant_field_division() {
     let assembler = super::Assembler::default();
-    let source = "const.TEST_CONSTANT=(16/4)//(2/2)*4 \
+    let source = "const.TEST_CONSTANT=(16//4)/(2//2)*4 \
     begin \
     push.TEST_CONSTANT \
     end \
@@ -249,6 +248,20 @@ fn constant_field_division() {
     end";
     let program = assembler.compile(source).unwrap();
     assert_eq!(expected, format!("{program}"));
+}
+
+#[test]
+fn constant_err() {
+    let assembler = super::Assembler::default();
+    let source = "const.TEST_CONSTANT=5+A \
+    begin \
+    push.TEST_CONSTANT \
+    end";
+    let result = assembler.compile(source);
+    assert!(result.is_err());
+    let err = result.err().unwrap();
+    let expected_error = "malformed constant `const.TEST_CONSTANT=5+A` - invalid value: `5+A` - reason: constant with name A was not initialized";
+    assert_eq!(expected_error, err.to_string());
 }
 
 #[test]

--- a/assembly/src/tests.rs
+++ b/assembly/src/tests.rs
@@ -195,6 +195,63 @@ fn multiple_constants_push() {
 }
 
 #[test]
+fn constant_numeric_expression() {
+    let assembler = super::Assembler::default();
+    let source = "const.TEST_CONSTANT=11-2+4*(12-(10+1))+9+8/4*2 \
+    begin \
+    push.TEST_CONSTANT \
+    end \
+    ";
+    let expected = "\
+    begin \
+        span \
+            push(26) \
+        end \
+    end";
+    let program = assembler.compile(source).unwrap();
+    assert_eq!(expected, format!("{program}"));
+}
+
+#[test]
+fn constant_alphanumeric_expression() {
+    let assembler = super::Assembler::default();
+    let source = "const.TEST_CONSTANT_1=(18-1+10)*6-((13+7)*2) \
+    const.TEST_CONSTANT_2=11-2+4*(12-(10+1))+9
+    const.TEST_CONSTANT_3=(TEST_CONSTANT_1-(TEST_CONSTANT_2+10))/5+3
+    begin \
+    push.TEST_CONSTANT_3 \
+    end \
+    ";
+    let expected = "\
+    begin \
+        span \
+            push(21) \
+        end \
+    end";
+    let program = assembler.compile(source).unwrap();
+    assert_eq!(expected, format!("{program}"));
+}
+
+// TODO: improve field division test
+#[test]
+fn constant_field_division() {
+    let assembler = super::Assembler::default();
+    let source = "const.TEST_CONSTANT=(16/4)//(2/2)*4 \
+    begin \
+    push.TEST_CONSTANT \
+    end \
+    ";
+    let expected = "\
+    begin \
+        span \
+            push(16) \
+        end \
+    end";
+    let program = assembler.compile(source).unwrap();
+    assert_eq!(expected, format!("{program}"));
+}
+
+#[test]
 fn constants_must_be_uppercase() {
     let assembler = super::Assembler::default();
     let source = "const.constant_1=12 \
@@ -234,7 +291,7 @@ fn constant_must_be_valid_felt() {
     assert!(result.is_err());
     let err = result.err().unwrap();
     let expected_error = "malformed constant `const.CONSTANT=1122INVALID` - invalid value: \
-     `1122INVALID` - reason: invalid digit found in string";
+     `1122INVALID` - reason: constant with name 1122INVALID was not initialized";
     assert_eq!(expected_error, err.to_string());
 }
 

--- a/assembly/src/tokens/mod.rs
+++ b/assembly/src/tokens/mod.rs
@@ -70,6 +70,14 @@ impl<'a> Token<'a> {
         }
     }
 
+    /// Returns a new token intended for use in tests
+    pub fn new_dummy() -> Self {
+        Self {
+            parts: vec!["dummy_token"],
+            location: SourceLocation::new(0, 0),
+        }
+    }
+
     // PUBLIC ACCESSORS
     // --------------------------------------------------------------------------------------------
 

--- a/docs/src/user_docs/assembly/code_organization.md
+++ b/docs/src/user_docs/assembly/code_organization.md
@@ -109,13 +109,14 @@ In addition to the locally-defined procedure `foo`, the above module also export
 ### Constants
 Miden assembly supports constant declarations. These constants are scoped to the module they are defined in and can be used as immediate parameters for Miden assembly instructions. Constants are supported as immediate values for the following instructions: `push`, `locaddr`, `loc_load`, `loc_loadw`, `loc_store`, `loc_storew`, `mem_load`, `mem_loadw`, `mem_store`, `mem_storew`.
 
-Constants must be declared right after module imports and before any procedures or program bodies. A constant's name must start with an upper-case letter and can contain any combination of numbers, upper-case ASCII letters, and underscores (`_`). The number of characters in a constant name cannot exceed 100.
+Constants must be declared right after module imports and before any procedures or program bodies. A constant's name must start with an upper-case letter and can contain any combination of numbers, upper-case ASCII letters, and underscores (`_`). The number of characters in a constant name cannot exceed 100. 
+A constant's value must be in the range between $0$ and $2^{64} - 2^{32}$ (both inclusive) and can be defined by an arithmetic expression using `+`, `-`, `*`, `/`, `//`, `(`, `)` operators and references to the previously defined constants. Here `/` is a field division and `//` is an integer division. Note that the arithmetic expression cannot contain spaces.
 
 ```
 use.std::math::u64
 
 const.CONSTANT_1=100
-const.CONSTANT_2=200
+const.CONSTANT_2=200+(CONSTANT_1-50)
 const.ADDR_1=3
 
 begin


### PR DESCRIPTION
This PR implements basic arithmetic for constant values. Currently supported operations are `+`, `-`, `*`, `/`, and `//`, where `//` is the field division. Round parentheses are also supported. 