### PR TITLE
Persist traces lengths in `ExecutionTrace`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - [BREAKING] Added options to specify maximum number of cycles and expected number of cycles for a program (#998).
 - Improved handling of invalid/incomplete parameters in `StackOutputs` constructors (#1010).
 - Allowed the assembler to produce programs with "phantom" calls (#1019).
+- Added `TraceLenSummary` struct which holds information about traces lengths to the `ExecutionTrace` (#1029).
 
 ## 0.6.1 (2023-06-29)
 

--- a/processor/src/chiplets/tests.rs
+++ b/processor/src/chiplets/tests.rs
@@ -117,7 +117,7 @@ fn build_trace(
     let program = CodeBlock::new_span(operations);
     process.execute_code_block(&program, &CodeBlockTable::default()).unwrap();
 
-    let (trace, _) = ExecutionTrace::test_finalize_trace(process);
+    let (trace, _, _) = ExecutionTrace::test_finalize_trace(process);
     let trace_len = get_trace_len(&trace) - ExecutionTrace::NUM_RAND_ROWS;
 
     (

--- a/processor/src/decoder/tests.rs
+++ b/processor/src/decoder/tests.rs
@@ -1504,7 +1504,7 @@ fn build_trace(stack_inputs: &[u64], program: &CodeBlock) -> (DecoderTrace, AuxT
         Process::new(Kernel::default(), stack_inputs, advice_provider, ExecutionOptions::default());
     process.execute_code_block(program, &CodeBlockTable::default()).unwrap();
 
-    let (trace, aux_hints) = ExecutionTrace::test_finalize_trace(process);
+    let (trace, aux_hints, _) = ExecutionTrace::test_finalize_trace(process);
     let trace_len = get_trace_len(&trace) - ExecutionTrace::NUM_RAND_ROWS;
 
     (
@@ -1540,7 +1540,7 @@ fn build_call_trace(
 
     process.execute_code_block(program, &cb_table).unwrap();
 
-    let (trace, aux_hints) = ExecutionTrace::test_finalize_trace(process);
+    let (trace, aux_hints, _) = ExecutionTrace::test_finalize_trace(process);
     let trace_len = get_trace_len(&trace) - ExecutionTrace::NUM_RAND_ROWS;
 
     let sys_trace = trace[SYS_TRACE_RANGE]

--- a/processor/src/trace/mod.rs
+++ b/processor/src/trace/mod.rs
@@ -149,7 +149,7 @@ impl ExecutionTrace {
     }
 
     /// Returns a summary of the lengths of main, range and chiplet traces.
-    pub fn get_len_summary(&self) -> &TraceLenSummary {
+    pub fn trace_len_summary(&self) -> &TraceLenSummary {
         &self.trace_len_summary
     }
 
@@ -309,16 +309,8 @@ where
     );
 
     // get the lengths of the traces: main, range, and chiplets
-    let trace_len_summary = TraceLenSummary::new(
-        clk as usize,
-        range_table_len,
-        ChipletsLengths::new(
-            chiplets.bitwise_start(),
-            chiplets.memory_start() - chiplets.bitwise_start(),
-            chiplets.kernel_rom_start() - chiplets.memory_start(),
-            chiplets.padding_start() - chiplets.kernel_rom_start(),
-        ),
-    );
+    let trace_len_summary =
+        TraceLenSummary::new(clk as usize, range_table_len, ChipletsLengths::new(&chiplets));
 
     // combine all trace segments into the main trace
     let system_trace = system.into_trace(trace_len, NUM_RAND_ROWS);

--- a/processor/src/trace/utils.rs
+++ b/processor/src/trace/utils.rs
@@ -237,42 +237,31 @@ impl HintCycle for u64 {
     }
 }
 
-// TRACE INFO
+// TRACE LENGTH SUMMARY
 // ================================================================================================
 
 /// Contains the data about lengths of the trace parts.
 ///
 /// - `main_trace_len` contains the length of the main trace.
 /// - `range_table_len` contains the length of the range checker table.
-/// - `chiplet_lenghts` contains the trace lenghts of the all chiplets (hasher, bitwise, memory,
+/// - `chiplet_lengths` contains the trace lengths of the all chiplets (hash, bitwise, memory,
 /// kernel ROM)
-/// - `max_len` contains the trace length required to hold all execution trace steps (maximum
-/// length among range table length, main trace length and chiplets trace length).
-/// - `padded_len` contains `max_len` padded to the next power of two.
-#[allow(dead_code)]
-pub struct TraceInfo {
+pub struct TraceLenSummary {
     main_trace_len: usize,
     range_table_len: usize,
-    chiplets_lenghts: ChipletsLengths,
-    max_len: usize,
-    padded_len: usize,
+    chiplets_lengths: ChipletsLengths,
 }
 
-#[allow(dead_code)]
-impl TraceInfo {
+impl TraceLenSummary {
     pub fn new(
         main_trace_len: usize,
         range_table_len: usize,
-        chiplets_lenghts: ChipletsLengths,
-        max_len: usize,
-        padded_len: usize,
+        chiplets_lengths: ChipletsLengths,
     ) -> Self {
-        TraceInfo {
+        TraceLenSummary {
             main_trace_len,
             range_table_len,
-            chiplets_lenghts,
-            max_len,
-            padded_len,
+            chiplets_lengths,
         }
     }
 
@@ -287,63 +276,52 @@ impl TraceInfo {
     }
 
     /// Returns [ChipletsLengths] which contains trace lengths of all chilplets.
-    pub fn chiplets_lenghts(&self) -> ChipletsLengths {
-        self.chiplets_lenghts
-    }
-
-    /// Returns maximum trace length
-    pub fn max_len(&self) -> usize {
-        self.max_len
-    }
-
-    // Returns final padded trace length
-    pub fn padded_len(&self) -> usize {
-        self.padded_len
+    pub fn chiplets_lengths(&self) -> ChipletsLengths {
+        self.chiplets_lengths
     }
 }
 
-/// Contains trace lengths of all chilplets: hasher, bitwise, memory and kernel ROM trace
-/// lenghts.
+/// Contains trace lengths of all chilplets: hash, bitwise, memory and kernel ROM trace
+/// lengths.
 #[derive(Clone, Copy)]
 pub struct ChipletsLengths {
-    hasher_chiplet_len: usize,
+    hash_chiplet_len: usize,
     bitwise_chiplet_len: usize,
     memory_chiplet_len: usize,
     kernel_rom_len: usize,
 }
 
-#[allow(dead_code)]
 impl ChipletsLengths {
     pub fn new(
-        hasher_chiplet_len: usize,
+        hash_chiplet_len: usize,
         bitwise_chiplet_len: usize,
         memory_chiplet_len: usize,
         kernel_rom_len: usize,
     ) -> Self {
         ChipletsLengths {
-            hasher_chiplet_len,
+            hash_chiplet_len,
             bitwise_chiplet_len,
             memory_chiplet_len,
             kernel_rom_len,
         }
     }
 
-    /// Returns the lenght of the hasher trace
-    pub fn hasher_chiplet_len(&self) -> usize {
-        self.hasher_chiplet_len
+    /// Returns the length of the hash chiplet trace
+    pub fn hash_chiplet_len(&self) -> usize {
+        self.hash_chiplet_len
     }
 
-    /// Returns the lenght of the bitwise trace
+    /// Returns the length of the bitwise trace
     pub fn bitwise_chiplet_len(&self) -> usize {
         self.bitwise_chiplet_len
     }
 
-    /// Returns the lenght of the memory trace
+    /// Returns the length of the memory trace
     pub fn memory_chiplet_len(&self) -> usize {
         self.memory_chiplet_len
     }
 
-    /// Returns the lenght of the kernel ROM trace
+    /// Returns the length of the kernel ROM trace
     pub fn kernel_rom_len(&self) -> usize {
         self.kernel_rom_len
     }

--- a/processor/src/trace/utils.rs
+++ b/processor/src/trace/utils.rs
@@ -237,6 +237,118 @@ impl HintCycle for u64 {
     }
 }
 
+// TRACE INFO
+// ================================================================================================
+
+/// Contains the data about lengths of the trace parts.
+///
+/// - `main_trace_len` contains the length of the main trace.
+/// - `range_table_len` contains the length of the range checker table.
+/// - `chiplet_lenghts` contains the trace lenghts of the all chiplets (hasher, bitwise, memory,
+/// kernel ROM)
+/// - `max_len` contains the trace length required to hold all execution trace steps (maximum
+/// length among range table length, main trace length and chiplets trace length).
+/// - `padded_len` contains `max_len` padded to the next power of two.
+#[allow(dead_code)]
+pub struct TraceInfo {
+    main_trace_len: usize,
+    range_table_len: usize,
+    chiplets_lenghts: ChipletsLengths,
+    max_len: usize,
+    padded_len: usize,
+}
+
+#[allow(dead_code)]
+impl TraceInfo {
+    pub fn new(
+        main_trace_len: usize,
+        range_table_len: usize,
+        chiplets_lenghts: ChipletsLengths,
+        max_len: usize,
+        padded_len: usize,
+    ) -> Self {
+        TraceInfo {
+            main_trace_len,
+            range_table_len,
+            chiplets_lenghts,
+            max_len,
+            padded_len,
+        }
+    }
+
+    /// Returns length of the main trace
+    pub fn main_trace_len(&self) -> usize {
+        self.main_trace_len
+    }
+
+    /// Returns length of the range table
+    pub fn range_table_len(&self) -> usize {
+        self.range_table_len
+    }
+
+    /// Returns [ChipletsLengths] which contains trace lengths of all chilplets.
+    pub fn chiplets_lenghts(&self) -> ChipletsLengths {
+        self.chiplets_lenghts
+    }
+
+    /// Returns maximum trace length
+    pub fn max_len(&self) -> usize {
+        self.max_len
+    }
+
+    // Returns final padded trace length
+    pub fn padded_len(&self) -> usize {
+        self.padded_len
+    }
+}
+
+/// Contains trace lengths of all chilplets: hasher, bitwise, memory and kernel ROM trace
+/// lenghts.
+#[derive(Clone, Copy)]
+pub struct ChipletsLengths {
+    hasher_chiplet_len: usize,
+    bitwise_chiplet_len: usize,
+    memory_chiplet_len: usize,
+    kernel_rom_len: usize,
+}
+
+#[allow(dead_code)]
+impl ChipletsLengths {
+    pub fn new(
+        hasher_chiplet_len: usize,
+        bitwise_chiplet_len: usize,
+        memory_chiplet_len: usize,
+        kernel_rom_len: usize,
+    ) -> Self {
+        ChipletsLengths {
+            hasher_chiplet_len,
+            bitwise_chiplet_len,
+            memory_chiplet_len,
+            kernel_rom_len,
+        }
+    }
+
+    /// Returns the lenght of the hasher trace
+    pub fn hasher_chiplet_len(&self) -> usize {
+        self.hasher_chiplet_len
+    }
+
+    /// Returns the lenght of the bitwise trace
+    pub fn bitwise_chiplet_len(&self) -> usize {
+        self.bitwise_chiplet_len
+    }
+
+    /// Returns the lenght of the memory trace
+    pub fn memory_chiplet_len(&self) -> usize {
+        self.memory_chiplet_len
+    }
+
+    /// Returns the lenght of the kernel ROM trace
+    pub fn kernel_rom_len(&self) -> usize {
+        self.kernel_rom_len
+    }
+}
+
 // TEST HELPERS
 // ================================================================================================
 #[cfg(test)]

--- a/processor/src/trace/utils.rs
+++ b/processor/src/trace/utils.rs
@@ -283,12 +283,9 @@ impl TraceLenSummary {
 
     /// Returns the maximum of all component lengths.
     pub fn trace_len(&self) -> usize {
-        let chiplets_len = self.chiplets_trace_len.hash_chiplet_len()
-            + self.chiplets_trace_len.bitwise_chiplet_len()
-            + self.chiplets_trace_len.memory_chiplet_len()
-            + self.chiplets_trace_len.kernel_rom_len()
-            + 1;
-        self.range_trace_len.max(self.main_trace_len).max(chiplets_len)
+        self.range_trace_len
+            .max(self.main_trace_len)
+            .max(self.chiplets_trace_len.trace_len())
     }
 
     /// Returns `trace_len` rounded up to the next power of two.
@@ -335,6 +332,17 @@ impl ChipletsLengths {
     /// Returns the length of the kernel ROM trace
     pub fn kernel_rom_len(&self) -> usize {
         self.kernel_rom_len
+    }
+
+    /// Returns the length of the trace required to accommodate chiplet components and 1
+    /// mandatory padding row required for ensuring sufficient trace length for auxiliary connector
+    /// columns that rely on the memory chiplet.
+    pub fn trace_len(&self) -> usize {
+        self.hash_chiplet_len()
+            + self.bitwise_chiplet_len()
+            + self.memory_chiplet_len()
+            + self.kernel_rom_len()
+            + 1
     }
 }
 


### PR DESCRIPTION
This PR implements `TraceInfo` struct which holds data about lengths of:
- Main trace
- Range checker trace
- Chiplets trace lengths: hasher, bitwise, memory, kernel ROM
- Maximum trace length 
- Final padded trace length
