### PR TITLE
feat: add support for module aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Added ability to attach doc comments to re-exported procedures (#994).
 - Added support for nested modules (#992).
 - Added support for the arithmetic expressions in constant values (#1026).
+- Added support for module aliases (#1037).
 
 #### VM Internals
 - Simplified range checker and removed 1 main and 1 auxiliary trace column (#949).

--- a/assembly/src/ast/imports.rs
+++ b/assembly/src/ast/imports.rs
@@ -51,13 +51,12 @@ impl ModuleImports {
         while let Some(token) = tokens.read() {
             match token.parts()[0] {
                 Token::USE => {
-                    let module_path = token.parse_use()?;
-                    let module_name = module_path.last();
-                    if imports.contains_key(module_name) {
+                    let (module_path, module_name) = token.parse_use()?;
+                    if imports.values().any(|path| *path == module_path) {
                         return Err(ParsingError::duplicate_module_import(token, &module_path));
                     }
 
-                    imports.insert(module_name.to_string(), module_path);
+                    imports.insert(module_name, module_path);
 
                     // consume the `use` token
                     tokens.advance();

--- a/assembly/src/errors.rs
+++ b/assembly/src/errors.rs
@@ -593,6 +593,14 @@ impl ParsingError {
         }
     }
 
+    pub fn invalid_module_name(token: &Token, name: &str) -> Self {
+        ParsingError {
+            message: format!("invalid module name: {name}"),
+            location: *token.location(),
+            op: token.to_string(),
+        }
+    }
+
     pub fn import_inside_body(token: &Token) -> Self {
         ParsingError {
             message: "import in procedure body".to_string(),

--- a/docs/src/user_docs/assembly/code_organization.md
+++ b/docs/src/user_docs/assembly/code_organization.md
@@ -90,6 +90,18 @@ end
 ```
 In the above example we import `std::math::u64` module from the [standard library](../stdlib/main.md). We then execute a program which pushes two 64-bit integers onto the stack, and then invokes a 64-bit addition procedure from the imported module.
 
+We can also define aliases for imported modules. For example:
+
+```
+use.std::math::u64->bigint
+
+begin
+    push.1.0
+    push.2.0
+    exec.bigint::checked_add
+end
+```
+
 The set of modules which can be imported by a program can be specified via a Module Provider when instantiating the [Miden Assembler](https://crates.io/crates/miden-assembly) used to compile the program.
 
 #### Re-exporting procedures


### PR DESCRIPTION
## Describe your changes
Addressing #1020. Allows users to define an alias for the imported module. For eg.

```
use.std::math::u64->bigint

begin
    push.1.0
    push.2.0
    exec.bigint::add
end
```

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
