### PR TITLE
fix(docs): constraint expression multiplies same term twice

### DIFF
--- a/docs/src/design/lookups/logup.md
+++ b/docs/src/design/lookups/logup.md
@@ -37,7 +37,7 @@ $$
 Since constraints must be expressed without division, the actual constraint which is enforced will be the following:
 
 > $$
-b' \cdot (\alpha - v) \cdot (\alpha - x) = b \cdot (\alpha - v) \cdot (\alpha - v) + m \cdot (\alpha - x) - (\alpha - v) \text{ | degree} = 3
+b' \cdot (\alpha - v) \cdot (\alpha - x) = b \cdot (\alpha - x) \cdot (\alpha - v) + m \cdot (\alpha - x) - (\alpha - v) \text{ | degree} = 3
 $$
 
 In general, we will write constraints within these docs using the previous form, since it's clearer and more readable.


### PR DESCRIPTION
The `alpha - v` term is being multiplied twice, when it should be

> $$
b \cdot (\alpha - x) \cdot (\alpha - v)
$$

instead.

## Describe your changes


## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
