### PR TITLE
Create parametrized versions for `adv.push_mapval` instruction

### DIFF
--- a/assembly/src/ast/parsers/context.rs
+++ b/assembly/src/ast/parsers/context.rs
@@ -596,7 +596,7 @@ impl ParserContext<'_> {
             "adv_push" => io_ops::parse_adv_push(op),
             "adv_loadw" => simple_instruction(op, AdvLoadW),
 
-            "adv" => adv_ops::parse_adv_inject(op),
+            "adv" => adv_ops::parse_adv_inject(op, &self.local_constants),
 
             // ----- cryptographic operations -----------------------------------------------------
             "hash" => simple_instruction(op, Hash),

--- a/assembly/src/ast/tests.rs
+++ b/assembly/src/ast/tests.rs
@@ -201,12 +201,50 @@ fn test_ast_parsing_adv_injection() {
     use super::AdviceInjectorNode::*;
     use Instruction::AdvInject;
 
-    let source = "begin adv.push_u64div adv.push_mapval adv.push_smtget adv.insert_mem end";
+    let source = "begin adv.push_u64div adv.push_smtget adv.insert_mem end";
     let nodes: Vec<Node> = vec![
         Node::Instruction(AdvInject(PushU64div)),
-        Node::Instruction(AdvInject(PushMapVal)),
         Node::Instruction(AdvInject(PushSmtGet)),
         Node::Instruction(AdvInject(InsertMem)),
+    ];
+
+    assert_program_output(source, BTreeMap::new(), nodes);
+
+    // test the mapval variants
+    let source = "\
+    const.TEST_VALUE=1234
+    begin 
+        adv.push_mapval.1 
+        adv.push_mapvaln.2 
+        adv.push_mapval_const.1.2.3.4
+        adv.push_mapvaln_const.1.2.3.4 
+        adv.push_mapval_const.TEST_VALUE
+        adv.push_mapvaln_const.10
+        adv.push_mapval_mem.1234 
+        adv.push_mapvaln_mem.TEST_VALUE 
+    end";
+
+    let nodes: Vec<Node> = vec![
+        Node::Instruction(AdvInject(PushMapValImm { offset: 1 })),
+        Node::Instruction(AdvInject(PushMapValNImm { offset: 2 })),
+        Node::Instruction(AdvInject(PushMapValC {
+            key: [Felt::from(1u8), Felt::from(2u8), Felt::from(3u8), Felt::from(4u8)],
+        })),
+        Node::Instruction(AdvInject(PushMapValNC {
+            key: [Felt::from(1u8), Felt::from(2u8), Felt::from(3u8), Felt::from(4u8)],
+        })),
+        Node::Instruction(AdvInject(PushMapValC {
+            key: [Felt::from(1234u32), Felt::from(0u8), Felt::from(0u8), Felt::from(0u8)],
+        })),
+        Node::Instruction(AdvInject(PushMapValNC {
+            key: [Felt::from(10u8), Felt::from(0u8), Felt::from(0u8), Felt::from(0u8)],
+        })),
+        Node::Instruction(AdvInject(PushMapValM {
+            addr: Felt::from(1234u32),
+        })),
+        Node::Instruction(AdvInject(PushMapValNM {
+            addr: Felt::from(1234u32),
+        })),
     ];
 
     assert_program_output(source, BTreeMap::new(), nodes);

--- a/core/src/operations/decorators/advice.rs
+++ b/core/src/operations/decorators/advice.rs
@@ -72,6 +72,37 @@ pub enum AdviceInjector {
         key_offset: usize,
     },
 
+    /// Pushes a list of field elements onto the advice stack. The list is looked up in the advice
+    /// map using the word provided through immediate value as the key. If `include_len` is set to
+    /// true, the number of elements in the value is also pushed onto the advice stack.
+    ///
+    /// Inputs:
+    ///   Operand stack: [...]
+    ///   Advice stack: [...]
+    ///   Advice map: {KEY: values}
+    ///
+    /// Outputs:
+    ///   Operand stack: [...]
+    ///   Advice stack: [values_len?, values, ...]
+    ///   Advice map: {KEY: values}
+    MapValueToStackConst { include_len: bool, key: [Felt; 4] },
+
+    /// Pushes a list of field elements onto the advice stack. The list is looked up in the advice
+    /// map. The provided immediate value specifies a memory address that holds the key for the
+    /// advice map. If `include_len` is set to true, the number of elements in the value is also
+    /// pushed onto the advice stack.
+    ///
+    /// Inputs:
+    ///   Operand stack: [...]
+    ///   Advice stack: [...]
+    ///   Advice map: {KEY: values}
+    ///
+    /// Outputs:
+    ///   Operand stack: [...]
+    ///   Advice stack: [values_len?, values, ...]
+    ///   Advice map: {KEY: values}
+    MapValueToStackMem { include_len: bool, addr: Felt },
+
     /// Pushes the result of [u64] division (both the quotient and the remainder) onto the advice
     /// stack.
     ///
@@ -244,6 +275,28 @@ impl fmt::Display for AdviceInjector {
                     write!(f, "map_value_to_stack_with_len.{key_offset}")
                 } else {
                     write!(f, "map_value_to_stack.{key_offset}")
+                }
+            }
+            Self::MapValueToStackConst { include_len, key } => {
+                if *include_len {
+                    write!(
+                        f,
+                        "map_value_to_stack_with_len_const.{}.{}.{}.{}",
+                        key[0], key[1], key[2], key[3]
+                    )
+                } else {
+                    write!(
+                        f,
+                        "map_value_to_stack_const.{}.{}.{}.{}",
+                        key[0], key[1], key[2], key[3]
+                    )
+                }
+            }
+            Self::MapValueToStackMem { include_len, addr } => {
+                if *include_len {
+                    write!(f, "map_value_to_stack_with_len_mem.{addr}")
+                } else {
+                    write!(f, "map_value_to_stack_mem.{addr}")
                 }
             }
             Self::DivU64 => write!(f, "div_u64"),

--- a/core/src/operations/mod.rs
+++ b/core/src/operations/mod.rs
@@ -199,7 +199,7 @@ pub enum Operation {
     /// Pushes 0 onto the stack.
     Pad,
 
-    /// Removes to element from the stack.
+    /// Removes the top element from the stack.
     Drop,
 
     /// Pushes a copy of stack element 0 onto the stack.

--- a/processor/src/decorators/adv_stack_injectors.rs
+++ b/processor/src/decorators/adv_stack_injectors.rs
@@ -110,6 +110,52 @@ where
         self.advice_provider.push_stack(AdviceSource::Map { key, include_len })
     }
 
+    /// Pushes a list of field elements onto the advice stack. The list is looked up in the advice
+    /// map using the word provided through immediate value as the key. If `include_len` is set to
+    /// true, the number of elements in the value is also pushed onto the advice stack.
+    ///
+    /// Inputs:
+    ///   Operand stack: [...]
+    ///   Advice stack: [...]
+    ///   Advice map: {KEY: values}
+    ///
+    /// Outputs:
+    ///   Operand stack: [...]
+    ///   Advice stack: [values_len?, values, ...]
+    ///   Advice map: {KEY: values}
+    pub(super) fn copy_map_value_to_adv_stack_const(
+        &mut self,
+        include_len: bool,
+        key: Word,
+    ) -> Result<(), ExecutionError> {
+        self.advice_provider.push_stack(AdviceSource::Map { key, include_len })
+    }
+
+    /// Pushes a list of field elements onto the advice stack. The list is looked up in the advice
+    /// map. The provided immediate value specifies a memory address that holds the key for the
+    /// advice map. If `include_len` is set to true, the number of elements in the value is also
+    /// pushed onto the advice stack.
+    ///
+    /// Inputs:
+    ///   Operand stack: [...]
+    ///   Advice stack: [...]
+    ///   Advice map: {KEY: values}
+    ///
+    /// Outputs:
+    ///   Operand stack: [...]
+    ///   Advice stack: [values_len?, values, ...]
+    ///   Advice map: {KEY: values}
+    pub(super) fn copy_map_value_to_adv_stack_mem(
+        &mut self,
+        include_len: bool,
+        addr: Felt,
+    ) -> Result<(), ExecutionError> {
+        let ctx = self.system.ctx();
+        let key = self.chiplets.read_mem(ctx, addr);
+
+        self.advice_provider.push_stack(AdviceSource::Map { key, include_len })
+    }
+
     /// Pushes the result of [u64] division (both the quotient and the remainder) onto the advice
     /// stack.
     ///

--- a/processor/src/decorators/mod.rs
+++ b/processor/src/decorators/mod.rs
@@ -41,6 +41,12 @@ where
                 include_len,
                 key_offset,
             } => self.copy_map_value_to_adv_stack(*include_len, *key_offset),
+            AdviceInjector::MapValueToStackConst { include_len, key } => {
+                self.copy_map_value_to_adv_stack_const(*include_len, *key)
+            }
+            AdviceInjector::MapValueToStackMem { include_len, addr } => {
+                self.copy_map_value_to_adv_stack_mem(*include_len, *addr)
+            }
             AdviceInjector::DivU64 => self.push_u64_div_result(),
             AdviceInjector::Ext2Inv => self.push_ext2_inv_result(),
             AdviceInjector::Ext2Intt => self.push_ext2_intt_result(),


### PR DESCRIPTION
This PR adds 4 new parsing options for the `adv.push_mapval` instruction:
- `adv.push_mapval_const` — option where immediate value holds a key of the advice map. It can hold 4 values which forms a `Word` (e.g. `adv.push_mapval_const.1.2.3.4` where `[Felt(1), Felt(2), Felt(3), Felt(4)]` is a key of the advice map), or only one value which represent the first value of the word, as it was suggested in [this comment](https://github.com/0xPolygonMiden/miden-vm/pull/944#pullrequestreview-1487607911) (e.g. `adv.push_mapval_const.1234` or `adv.push_mapval_const.KEY` where `[Felt(1234), Felt(0), Felt(0), Felt(0)]` is a key of the advice map).
- `adv.push_mapvaln_const` — same as the previous one but it also adds a values length to the advice stack (as well as `adv.push_mapvaln`).
- `adv.push_mapval_mem` — option where immediate value holds a memory address where the key of the advice map is stored. Similar to the first option an immediate value can be a `Felt` or a constant name.
- `adv.push_mapvaln_mem` — same as the previous one but it also adds a values length to the advice stack.

I don't really like the current approach since there is a lot of copy-paste code took from the original `adv.push_mapval` instruction. I tried to get rid of the copying the code, but this led to overcomplication and reduced readability of the code. So for now I'm not sure that the chosen approach is the best.

Tasks:
- [ ] Update changelog and documentation
