### PR TITLE
Print VM cycles after CLI execution

### DIFF
--- a/miden/tests/integration/cli/cli_test.rs
+++ b/miden/tests/integration/cli/cli_test.rs
@@ -31,7 +31,7 @@ fn cli_run() -> Result<(), Box<dyn std::error::Error>> {
     // This tests what we want. Actually it outputs X steps in Y ms.
     // However we the X and the Y can change in future versions.
     // There is no other 'steps in' in the output
-    output.assert().stdout(predicate::str::contains("steps in"));
+    output.assert().stdout(predicate::str::contains("VM cycles"));
 
     Ok(())
 }

--- a/processor/src/trace/utils.rs
+++ b/processor/src/trace/utils.rs
@@ -247,6 +247,7 @@ impl HintCycle for u64 {
 /// - `range_trace_len` contains the length of the range checker trace.
 /// - `chiplets_trace_len` contains the trace lengths of the all chiplets (hash, bitwise, memory,
 /// kernel ROM)
+#[derive(Debug)]
 pub struct TraceLenSummary {
     main_trace_len: usize,
     range_trace_len: usize,
@@ -296,7 +297,7 @@ impl TraceLenSummary {
 
 /// Contains trace lengths of all chilplets: hash, bitwise, memory and kernel ROM trace
 /// lengths.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct ChipletsLengths {
     hash_chiplet_len: usize,
     bitwise_chiplet_len: usize,

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -62,10 +62,16 @@ where
         *options.execution_options(),
     )?;
     #[cfg(feature = "std")]
+    let padding_percentage = (trace.trace_len_summary().padded_trace_len()
+        - trace.trace_len_summary().trace_len())
+        * 100
+        / trace.trace_len_summary().padded_trace_len();
+    #[cfg(feature = "std")]
     debug!(
-        "Generated execution trace of {} columns and {} steps in {} ms",
+        "Generated execution trace of {} columns and {} steps ({}% padded) in {} ms",
         trace.layout().main_trace_width(),
-        trace.length(),
+        trace.trace_len_summary().padded_trace_len(),
+        padding_percentage,
         now.elapsed().as_millis()
     );
 


### PR DESCRIPTION
This small PR improves the print of the cycles required for the each VM component. Currently it looks like so:
```
VM cycles: 3045 (stack: 3045, range checker: 39, chiplets: hash 336, bitwise 0, memory 0, kernel 0) extended to 4096 steps.
```
This PR closes issues #442 and #1047 
