### PR TITLE
Replace `[ZERO; 4]` with an `EMPTY_WORD` constant

### DIFF
--- a/air/benches/enforce_stack_constraint.rs
+++ b/air/benches/enforce_stack_constraint.rs
@@ -8,7 +8,7 @@ use miden_air::{
     Felt, FieldElement,
 };
 use std::time::Duration;
-use vm_core::Operation;
+use vm_core::{Operation, ZERO};
 
 fn enforce_stack_constraint(c: &mut Criterion) {
     let mut group = c.benchmark_group("enforce_stack_constraint");
@@ -27,7 +27,7 @@ fn enforce_stack_constraint(c: &mut Criterion) {
         frame.current_mut()[STACK_TRACE_OFFSET] = Felt::new(89u64);
         frame.next_mut()[STACK_TRACE_OFFSET] = Felt::new(89u64).inv();
 
-        let mut result = [Felt::ZERO; NUM_CONSTRAINTS];
+        let mut result = [ZERO; NUM_CONSTRAINTS];
 
         let frame = generate_evaluation_frame(36);
         bench.iter(|| {

--- a/air/src/constraints/chiplets/bitwise/mod.rs
+++ b/air/src/constraints/chiplets/bitwise/mod.rs
@@ -6,6 +6,7 @@ use crate::{
         BITWISE_OUTPUT_COL_IDX, BITWISE_PREV_OUTPUT_COL_IDX, BITWISE_SELECTOR_COL_IDX,
     },
     utils::{are_equal, binary_not, is_binary, is_zero, EvaluationResult},
+    ONE, ZERO,
 };
 use winter_air::TransitionConstraintDegree;
 
@@ -413,27 +414,9 @@ pub fn agg_bits<E: FieldElement>(row: &[E], start_idx: usize) -> E {
 
 // CYCLE MASKS
 // ================================================================================================
-pub const BITWISE_K0_MASK: [Felt; OP_CYCLE_LEN] = [
-    Felt::ONE,
-    Felt::ZERO,
-    Felt::ZERO,
-    Felt::ZERO,
-    Felt::ZERO,
-    Felt::ZERO,
-    Felt::ZERO,
-    Felt::ZERO,
-];
+pub const BITWISE_K0_MASK: [Felt; OP_CYCLE_LEN] = [ONE, ZERO, ZERO, ZERO, ZERO, ZERO, ZERO, ZERO];
 
-pub const BITWISE_K1_MASK: [Felt; OP_CYCLE_LEN] = [
-    Felt::ONE,
-    Felt::ONE,
-    Felt::ONE,
-    Felt::ONE,
-    Felt::ONE,
-    Felt::ONE,
-    Felt::ONE,
-    Felt::ZERO,
-];
+pub const BITWISE_K1_MASK: [Felt; OP_CYCLE_LEN] = [ONE, ONE, ONE, ONE, ONE, ONE, ONE, ZERO];
 
 // TEST HELPERS
 // ================================================================================================
@@ -442,8 +425,8 @@ pub const BITWISE_K1_MASK: [Felt; OP_CYCLE_LEN] = [
 #[cfg(test)]
 fn get_periodic_values(cycle_row: usize) -> [Felt; 2] {
     match cycle_row {
-        0 => [Felt::ONE, Felt::ONE],
-        8 => [Felt::ZERO, Felt::ZERO],
-        _ => [Felt::ZERO, Felt::ONE],
+        0 => [ONE, ONE],
+        8 => [ZERO, ZERO],
+        _ => [ZERO, ONE],
     }
 }

--- a/air/src/constraints/chiplets/bitwise/tests.rs
+++ b/air/src/constraints/chiplets/bitwise/tests.rs
@@ -1,8 +1,8 @@
 use super::{
     enforce_constraints, get_periodic_values, EvaluationFrame, BITWISE_A_COL_IDX,
     BITWISE_A_COL_RANGE, BITWISE_B_COL_IDX, BITWISE_B_COL_RANGE, BITWISE_OUTPUT_COL_IDX,
-    BITWISE_PREV_OUTPUT_COL_IDX, BITWISE_SELECTOR_COL_IDX, NUM_CONSTRAINTS, NUM_DECOMP_BITS,
-    OP_CYCLE_LEN,
+    BITWISE_PREV_OUTPUT_COL_IDX, BITWISE_SELECTOR_COL_IDX, NUM_CONSTRAINTS, NUM_DECOMP_BITS, ONE,
+    OP_CYCLE_LEN, ZERO,
 };
 use crate::{
     trace::{
@@ -12,7 +12,7 @@ use crate::{
         },
         TRACE_WIDTH,
     },
-    Felt, FieldElement,
+    Felt,
 };
 use rand_utils::rand_value;
 
@@ -25,7 +25,7 @@ use proptest::prelude::*;
 /// specify the operation change within a cycle.
 #[test]
 fn test_bitwise_change_ops_fail() {
-    let expected = [Felt::ZERO; NUM_CONSTRAINTS];
+    let expected = [ZERO; NUM_CONSTRAINTS];
 
     let a = rand_value::<u32>();
     let b = rand_value::<u32>();
@@ -48,28 +48,28 @@ fn output_aggregation_and() {
     let cycle_row = 0;
 
     // create a valid test frame manually
-    let mut current = vec![Felt::ZERO; TRACE_WIDTH];
-    let mut next = vec![Felt::ZERO; TRACE_WIDTH];
+    let mut current = vec![ZERO; TRACE_WIDTH];
+    let mut next = vec![ZERO; TRACE_WIDTH];
 
     let current_bitwise = [
         // selector
         BITWISE_AND,
         // a
-        Felt::ONE,
+        ONE,
         // b
         Felt::new(9),
         // decomposition of a
-        Felt::ONE,
-        Felt::ZERO,
-        Felt::ZERO,
-        Felt::ZERO,
+        ONE,
+        ZERO,
+        ZERO,
+        ZERO,
         // decomposition of b
-        Felt::ONE,
-        Felt::ZERO,
-        Felt::ZERO,
-        Felt::ONE,
+        ONE,
+        ZERO,
+        ZERO,
+        ONE,
         // previous output
-        Felt::ZERO,
+        ZERO,
         // assert a false output
         Felt::new(1337),
     ];
@@ -82,15 +82,15 @@ fn output_aggregation_and() {
         // b
         Felt::new(157),
         // decomposition of a
-        Felt::ONE,
-        Felt::ONE,
-        Felt::ZERO,
-        Felt::ZERO,
+        ONE,
+        ONE,
+        ZERO,
+        ZERO,
         // decomposition of b
-        Felt::ONE,
-        Felt::ZERO,
-        Felt::ONE,
-        Felt::ONE,
+        ONE,
+        ZERO,
+        ONE,
+        ONE,
         // previous output
         Felt::new(1337),
         // output
@@ -104,7 +104,7 @@ fn output_aggregation_and() {
     let result = get_constraint_evaluation(frame, cycle_row);
 
     // expect a failure for the output aggregation constraint (the last one)
-    assert_ne!(Felt::ZERO, result[NUM_CONSTRAINTS - 1]);
+    assert_ne!(ZERO, result[NUM_CONSTRAINTS - 1]);
 }
 
 // RANDOMIZED TESTS
@@ -115,7 +115,7 @@ proptest! {
     /// compute the bitwise AND operation.
     #[test]
     fn test_bitwise_and(a in any::<u32>(), b in any::<u32>(), cycle_row in 0..(OP_CYCLE_LEN - 1)) {
-        let expected = [Felt::ZERO; NUM_CONSTRAINTS];
+        let expected = [ZERO; NUM_CONSTRAINTS];
         let frame = get_test_frame(BITWISE_AND, a, b, cycle_row);
         let result = get_constraint_evaluation(frame, cycle_row);
         assert_eq!(expected, result);
@@ -125,7 +125,7 @@ proptest! {
     /// compute the bitwise XOR operation.
     #[test]
     fn test_bitwise_xor(a in any::<u32>(), b in any::<u32>(), cycle_row in 0..(OP_CYCLE_LEN - 1)) {
-        let expected = [Felt::ZERO; NUM_CONSTRAINTS];
+        let expected = [ZERO; NUM_CONSTRAINTS];
         let frame = get_test_frame(BITWISE_XOR, a, b, cycle_row);
         let result = get_constraint_evaluation(frame, cycle_row);
         assert_eq!(expected, result);
@@ -139,9 +139,9 @@ proptest! {
 /// specified row.
 fn get_constraint_evaluation(frame: EvaluationFrame<Felt>, row: usize) -> [Felt; NUM_CONSTRAINTS] {
     let periodic_values = get_periodic_values(row);
-    let mut result = [Felt::ZERO; NUM_CONSTRAINTS];
+    let mut result = [ZERO; NUM_CONSTRAINTS];
 
-    enforce_constraints(&frame, &periodic_values, &mut result, Felt::ONE);
+    enforce_constraints(&frame, &periodic_values, &mut result, ONE);
 
     result
 }
@@ -165,8 +165,8 @@ pub fn get_test_frame(
     );
 
     // Initialize the rows.
-    let mut current = vec![Felt::ZERO; TRACE_WIDTH];
-    let mut next = vec![Felt::ZERO; TRACE_WIDTH];
+    let mut current = vec![ZERO; TRACE_WIDTH];
+    let mut next = vec![ZERO; TRACE_WIDTH];
 
     // Set the operation selectors.
     current[BITWISE_SELECTOR_COL_IDX] = operation;
@@ -183,7 +183,7 @@ pub fn get_test_frame(
 
     // Set the previous output.
     let output_prev = if cycle_row_num == 0 {
-        Felt::ZERO
+        ZERO
     } else {
         Felt::new((result >> previous_shift) as u64)
     };
@@ -217,8 +217,8 @@ pub fn get_test_frame_with_two_ops(
     );
 
     // Initialize the rows.
-    let mut current = vec![Felt::ZERO; TRACE_WIDTH];
-    let mut next = vec![Felt::ZERO; TRACE_WIDTH];
+    let mut current = vec![ZERO; TRACE_WIDTH];
+    let mut next = vec![ZERO; TRACE_WIDTH];
 
     // Set the operation selector.
     current[BITWISE_SELECTOR_COL_IDX] = op_current;
@@ -235,7 +235,7 @@ pub fn get_test_frame_with_two_ops(
 
     // Set the previous output.
     let output_prev = if cycle_row_num == 0 {
-        Felt::ZERO
+        ZERO
     } else {
         Felt::new((result_op_current >> previous_shift) as u64)
     };

--- a/air/src/constraints/chiplets/hasher/mod.rs
+++ b/air/src/constraints/chiplets/hasher/mod.rs
@@ -5,7 +5,10 @@ use crate::trace::chiplets::{
     },
     HASHER_NODE_INDEX_COL_IDX, HASHER_SELECTOR_COL_RANGE, HASHER_STATE_COL_RANGE,
 };
-use crate::utils::{are_equal, binary_not, is_binary, EvaluationResult};
+use crate::{
+    utils::{are_equal, binary_not, is_binary, EvaluationResult},
+    ONE, ZERO,
+};
 
 #[cfg(test)]
 mod tests;
@@ -517,40 +520,13 @@ impl<E: FieldElement> EvaluationFrameExt<E> for &EvaluationFrame<E> {
 // ================================================================================================
 
 /// Periodic column mask used to indicate the last row of a cycle.
-pub const HASH_K0_MASK: [Felt; HASH_CYCLE_LEN] = [
-    Felt::ZERO,
-    Felt::ZERO,
-    Felt::ZERO,
-    Felt::ZERO,
-    Felt::ZERO,
-    Felt::ZERO,
-    Felt::ZERO,
-    Felt::ONE,
-];
+pub const HASH_K0_MASK: [Felt; HASH_CYCLE_LEN] = [ZERO, ZERO, ZERO, ZERO, ZERO, ZERO, ZERO, ONE];
 
 /// Periodic column mask used to indicate when the next row will be the last row of a cycle.
-pub const HASH_K1_MASK: [Felt; HASH_CYCLE_LEN] = [
-    Felt::ZERO,
-    Felt::ZERO,
-    Felt::ZERO,
-    Felt::ZERO,
-    Felt::ZERO,
-    Felt::ZERO,
-    Felt::ONE,
-    Felt::ZERO,
-];
+pub const HASH_K1_MASK: [Felt; HASH_CYCLE_LEN] = [ZERO, ZERO, ZERO, ZERO, ZERO, ZERO, ONE, ZERO];
 
 /// Periodic column mask used to identify the first row of a cycle.
-pub const HASH_K2_MASK: [Felt; HASH_CYCLE_LEN] = [
-    Felt::ONE,
-    Felt::ZERO,
-    Felt::ZERO,
-    Felt::ZERO,
-    Felt::ZERO,
-    Felt::ZERO,
-    Felt::ZERO,
-    Felt::ZERO,
-];
+pub const HASH_K2_MASK: [Felt; HASH_CYCLE_LEN] = [ONE, ZERO, ZERO, ZERO, ZERO, ZERO, ZERO, ZERO];
 
 // ROUND CONSTANTS
 // ================================================================================================
@@ -559,7 +535,7 @@ pub const HASH_K2_MASK: [Felt; HASH_CYCLE_LEN] = [
 pub fn get_round_constants() -> Vec<Vec<Felt>> {
     let mut constants = Vec::new();
     for _ in 0..(STATE_WIDTH * 2) {
-        constants.push(vec![Felt::ZERO; HASH_CYCLE_LEN]);
+        constants.push(vec![ZERO; HASH_CYCLE_LEN]);
     }
 
     #[allow(clippy::needless_range_loop)]

--- a/air/src/constraints/chiplets/hasher/tests.rs
+++ b/air/src/constraints/chiplets/hasher/tests.rs
@@ -1,10 +1,10 @@
 use super::{
     enforce_constraints, Hasher, HASHER_NODE_INDEX_COL_IDX, HASHER_SELECTOR_COL_RANGE,
-    HASHER_STATE_COL_RANGE, NUM_CONSTRAINTS,
+    HASHER_STATE_COL_RANGE, NUM_CONSTRAINTS, ONE, ZERO,
 };
 use crate::{
     trace::chiplets::hasher::{Selectors, LINEAR_HASH, STATE_WIDTH},
-    Felt, FieldElement, TRACE_WIDTH,
+    Felt, TRACE_WIDTH,
 };
 use rand_utils::rand_array;
 use vm_core::{chiplets::hasher::apply_round, utils::collections::Vec};
@@ -17,10 +17,10 @@ use winter_air::EvaluationFrame;
 /// eight, and applies a round of the VM's native hash function.
 #[test]
 fn hash_round() {
-    let expected = [Felt::ZERO; NUM_CONSTRAINTS];
+    let expected = [ZERO; NUM_CONSTRAINTS];
 
     let cycle_row_num: usize = 3;
-    let current_selectors = [Felt::ZERO, LINEAR_HASH[1], LINEAR_HASH[2]];
+    let current_selectors = [ZERO, LINEAR_HASH[1], LINEAR_HASH[2]];
     let next_selectors = current_selectors;
 
     let frame = get_test_hashing_frame(current_selectors, next_selectors, cycle_row_num);
@@ -37,10 +37,10 @@ fn get_constraint_evaluation(
     frame: EvaluationFrame<Felt>,
     cycle_row_num: usize,
 ) -> [Felt; NUM_CONSTRAINTS] {
-    let mut result = [Felt::ZERO; NUM_CONSTRAINTS];
+    let mut result = [ZERO; NUM_CONSTRAINTS];
     let periodic_values = get_test_periodic_values(cycle_row_num);
 
-    enforce_constraints(&frame, &periodic_values, &mut result, Felt::ONE);
+    enforce_constraints(&frame, &periodic_values, &mut result, ONE);
 
     result
 }
@@ -49,15 +49,15 @@ fn get_constraint_evaluation(
 fn get_test_periodic_values(cycle_row: usize) -> Vec<Felt> {
     // Set the periodic column values.
     let mut periodic_values = match cycle_row {
-        0 => vec![Felt::ZERO, Felt::ZERO, Felt::ONE],
-        7 => vec![Felt::ZERO, Felt::ONE, Felt::ZERO],
-        8 => vec![Felt::ONE, Felt::ZERO, Felt::ZERO],
-        _ => vec![Felt::ZERO, Felt::ZERO, Felt::ZERO],
+        0 => vec![ZERO, ZERO, ONE],
+        7 => vec![ZERO, ONE, ZERO],
+        8 => vec![ONE, ZERO, ZERO],
+        _ => vec![ZERO, ZERO, ZERO],
     };
 
     // Add the RPO round constants for the first 7 rows of the cycle, or pad with zeros.
     if cycle_row == 7 {
-        periodic_values.resize(periodic_values.len() + STATE_WIDTH * 2, Felt::ZERO);
+        periodic_values.resize(periodic_values.len() + STATE_WIDTH * 2, ZERO);
     } else {
         periodic_values.extend_from_slice(&Hasher::ARK1[cycle_row]);
         periodic_values.extend_from_slice(&Hasher::ARK2[cycle_row]);
@@ -71,8 +71,8 @@ fn get_test_hashing_frame(
     next_selectors: Selectors,
     cycle_row_num: usize,
 ) -> EvaluationFrame<Felt> {
-    let mut current = vec![Felt::ZERO; TRACE_WIDTH];
-    let mut next = vec![Felt::ZERO; TRACE_WIDTH];
+    let mut current = vec![ZERO; TRACE_WIDTH];
+    let mut next = vec![ZERO; TRACE_WIDTH];
 
     // Set the selectors for the hash operation.
     current[HASHER_SELECTOR_COL_RANGE].copy_from_slice(&current_selectors);
@@ -87,8 +87,8 @@ fn get_test_hashing_frame(
     next[HASHER_STATE_COL_RANGE].copy_from_slice(&state);
 
     // Set the node index values to zero for hash computations.
-    current[HASHER_NODE_INDEX_COL_IDX] = Felt::ZERO;
-    next[HASHER_NODE_INDEX_COL_IDX] = Felt::ZERO;
+    current[HASHER_NODE_INDEX_COL_IDX] = ZERO;
+    next[HASHER_NODE_INDEX_COL_IDX] = ZERO;
 
     EvaluationFrame::from_rows(current, next)
 }

--- a/air/src/constraints/chiplets/memory/tests.rs
+++ b/air/src/constraints/chiplets/memory/tests.rs
@@ -9,7 +9,7 @@ use crate::trace::{
     },
     TRACE_WIDTH,
 };
-use crate::{chiplets::memory, Felt, FieldElement};
+use crate::{chiplets::memory, Felt, FieldElement, ONE, ZERO};
 use rand_utils::rand_value;
 use vm_core::utils::collections::Vec;
 
@@ -18,7 +18,7 @@ use vm_core::utils::collections::Vec;
 
 #[test]
 fn test_memory_write() {
-    let expected = [Felt::ZERO; memory::NUM_CONSTRAINTS];
+    let expected = [ZERO; memory::NUM_CONSTRAINTS];
 
     let old_values = vec![0, 0, 0, 0];
     let new_values = vec![1, 0, 0, 0];
@@ -53,7 +53,7 @@ fn test_memory_write() {
 
 #[test]
 fn test_memory_read() {
-    let expected = [Felt::ZERO; memory::NUM_CONSTRAINTS];
+    let expected = [ZERO; memory::NUM_CONSTRAINTS];
 
     let init_values = vec![0, 0, 0, 0];
     let old_values = vec![1, 0, 0, 0];
@@ -116,9 +116,9 @@ fn get_constraint_evaluation(
     let delta_row = get_test_delta_row(&delta_type);
     let frame = get_test_frame(selectors, &delta_type, &delta_row, old_values, new_values);
 
-    let mut result = [Felt::ZERO; memory::NUM_CONSTRAINTS];
+    let mut result = [ZERO; memory::NUM_CONSTRAINTS];
 
-    memory::enforce_constraints(&frame, &mut result, Felt::ONE);
+    memory::enforce_constraints(&frame, &mut result, ONE);
 
     result
 }
@@ -142,8 +142,8 @@ fn get_test_frame(
     old_values: &[u32],
     new_values: &[u32],
 ) -> EvaluationFrame<Felt> {
-    let mut current = vec![Felt::ZERO; TRACE_WIDTH];
-    let mut next = vec![Felt::ZERO; TRACE_WIDTH];
+    let mut current = vec![ZERO; TRACE_WIDTH];
+    let mut next = vec![ZERO; TRACE_WIDTH];
 
     // Set the operation in the next row.
     next[MEMORY_TRACE_OFFSET] = selectors[0];
@@ -164,9 +164,9 @@ fn get_test_frame(
     }
 
     // Set the delta and delta inverse values. Treat the current row as if it's the first row.
-    current[MEMORY_D0_COL_IDX] = Felt::ZERO;
-    current[MEMORY_D1_COL_IDX] = Felt::ZERO;
-    current[MEMORY_D_INV_COL_IDX] = Felt::ZERO;
+    current[MEMORY_D0_COL_IDX] = ZERO;
+    current[MEMORY_D1_COL_IDX] = ZERO;
+    current[MEMORY_D_INV_COL_IDX] = ZERO;
 
     // Set the delta in the next row according to the specified delta type.
     let delta: u64 = match delta_type {

--- a/air/src/constraints/range.rs
+++ b/air/src/constraints/range.rs
@@ -5,7 +5,7 @@ use crate::{
     utils::are_equal,
     Assertion, EvaluationFrame, Felt, FieldElement, TransitionConstraintDegree,
 };
-use vm_core::{utils::collections::Vec, ExtensionOf};
+use vm_core::{utils::collections::Vec, ExtensionOf, ZERO};
 use winter_air::AuxTraceRandElements;
 
 // CONSTANTS
@@ -40,7 +40,7 @@ pub const AUX_CONSTRAINT_DEGREES: [usize; NUM_AUX_CONSTRAINTS] = [9];
 /// Returns the range checker's boundary assertions for the main trace at the first step.
 pub fn get_assertions_first_step(result: &mut Vec<Assertion<Felt>>) {
     let step = 0;
-    result.push(Assertion::single(V_COL_IDX, step, Felt::ZERO));
+    result.push(Assertion::single(V_COL_IDX, step, ZERO));
 }
 
 /// Returns the range checker's boundary assertions for the main trace at the last step.

--- a/air/src/constraints/stack/field_ops/tests.rs
+++ b/air/src/constraints/stack/field_ops/tests.rs
@@ -19,7 +19,7 @@ proptest! {
 
     #[test]
     fn test_eqz_stack_operation(a in any::<u64>()) {
-        let expected = [Felt::ZERO; NUM_CONSTRAINTS];
+        let expected = [ZERO; NUM_CONSTRAINTS];
 
         // ----------------- top element is anything except 0 ------------------------------------
         if a != 0 {
@@ -39,7 +39,7 @@ proptest! {
 
     #[test]
     fn test_incr_stack_operation(a in any::<u64>()) {
-        let expected = [Felt::ZERO; NUM_CONSTRAINTS];
+        let expected = [ZERO; NUM_CONSTRAINTS];
         let frame = get_incr_test_frame(a);
         let result = get_constraint_evaluation(frame);
         assert_eq!(expected, result);
@@ -49,7 +49,7 @@ proptest! {
 
     #[test]
     fn test_inv_stack_operation(a in any::<u64>()) {
-        let expected = [Felt::ZERO; NUM_CONSTRAINTS];
+        let expected = [ZERO; NUM_CONSTRAINTS];
         let frame = get_inv_test_frame(a);
         let result = get_constraint_evaluation(frame);
         assert_eq!(expected, result);
@@ -58,7 +58,7 @@ proptest! {
 
     #[test]
     fn test_neg_stack_operation(a in any::<u64>()) {
-        let expected = [Felt::ZERO; NUM_CONSTRAINTS];
+        let expected = [ZERO; NUM_CONSTRAINTS];
         let frame = get_neg_test_frame(a);
         let result = get_constraint_evaluation(frame);
         assert_eq!(expected, result);
@@ -68,7 +68,7 @@ proptest! {
 
     #[test]
     fn test_add_stack_operation(a in any::<u64>(), b in any::<u64>()) {
-        let expected = [Felt::ZERO; NUM_CONSTRAINTS];
+        let expected = [ZERO; NUM_CONSTRAINTS];
         let frame = get_add_test_frame(a, b);
         let result = get_constraint_evaluation(frame);
         assert_eq!(expected, result);
@@ -78,7 +78,7 @@ proptest! {
 
     #[test]
     fn test_mul_stack_operation(a in any::<u64>(), b in any::<u64>()) {
-        let expected = [Felt::ZERO; NUM_CONSTRAINTS];
+        let expected = [ZERO; NUM_CONSTRAINTS];
         let frame = get_mul_test_frame(a, b);
         let result = get_constraint_evaluation(frame);
         assert_eq!(expected, result);
@@ -88,7 +88,7 @@ proptest! {
 
     #[test]
     fn test_eq_stack_operation(a in any::<u64>(), b in any::<u64>()) {
-        let expected = [Felt::ZERO; NUM_CONSTRAINTS];
+        let expected = [ZERO; NUM_CONSTRAINTS];
 
         // ----------------- top two elements are not same ------------------------------------
         if a != b {
@@ -108,7 +108,7 @@ proptest! {
 
     #[test]
     fn test_expacc_stack_operation(a in any::<u64>(), b in any::<u64>()) {
-        let expected = [Felt::ZERO; NUM_CONSTRAINTS];
+        let expected = [ZERO; NUM_CONSTRAINTS];
         let no_bits_stack = (b as f64).log2().ceil() as u64;
         for c in 0..no_bits_stack{
             let frame = get_expacc_test_frame(c, a, b);
@@ -121,7 +121,7 @@ proptest! {
 
     #[test]
     fn test_ext2mul_stack_operation(a0 in any::<u64>(), a1 in any::<u64>(), b0 in any::<u64>(), b1 in any::<u64>()) {
-        let expected = [Felt::ZERO; NUM_CONSTRAINTS];
+        let expected = [ZERO; NUM_CONSTRAINTS];
         let frame = get_ext2_mul_test_frame(Felt::new(a0), Felt::new(a1), Felt::new(b0), Felt::new(b1));
         let result = get_constraint_evaluation(frame);
         assert_eq!(expected, result);
@@ -135,7 +135,7 @@ proptest! {
 
 #[test]
 fn test_not_stack_operation() {
-    let expected = [Felt::ZERO; NUM_CONSTRAINTS];
+    let expected = [ZERO; NUM_CONSTRAINTS];
 
     // ----------------- top element is 1 -----------------------------------------------------
     let a = ONE;
@@ -154,7 +154,7 @@ fn test_not_stack_operation() {
 
 #[test]
 fn test_and_stack_operation() {
-    let expected = [Felt::ZERO; NUM_CONSTRAINTS];
+    let expected = [ZERO; NUM_CONSTRAINTS];
 
     // ----------------- top elements are 0 and 0 -----------------------------------------------------
     let a = ZERO;
@@ -192,7 +192,7 @@ fn test_and_stack_operation() {
 
 #[test]
 fn test_or_stack_operation() {
-    let expected = [Felt::ZERO; NUM_CONSTRAINTS];
+    let expected = [ZERO; NUM_CONSTRAINTS];
 
     // ----------------- top elements are 0 and 0 -----------------------------------------------------
     let a = ZERO;
@@ -231,7 +231,7 @@ fn test_or_stack_operation() {
 
 /// Returns the result of stack operation constraint evaluations on the provided frame.
 fn get_constraint_evaluation(frame: EvaluationFrame<Felt>) -> [Felt; NUM_CONSTRAINTS] {
-    let mut result = [Felt::ZERO; NUM_CONSTRAINTS];
+    let mut result = [ZERO; NUM_CONSTRAINTS];
 
     let op_flag = OpFlags::new(&frame);
 

--- a/air/src/constraints/stack/io_ops/tests.rs
+++ b/air/src/constraints/stack/io_ops/tests.rs
@@ -4,14 +4,14 @@ use crate::stack::{
     B0_COL_IDX, STACK_TRACE_OFFSET,
 };
 use rand_utils::rand_value;
-use vm_core::{Felt, FieldElement, Operation};
+use vm_core::{Felt, Operation, ZERO};
 
 // UNIT TESTS
 // ================================================================================================
 
 #[test]
 fn test_sdepth_operation() {
-    let expected = [Felt::ZERO; NUM_CONSTRAINTS];
+    let expected = [ZERO; NUM_CONSTRAINTS];
     let depth = rand_value::<u32>() as u64;
 
     let frame = get_sdepth_test_frame(depth);
@@ -24,7 +24,7 @@ fn test_sdepth_operation() {
 
 /// Returns the result of stack operation constraint evaluations on the provided frame.
 fn get_constraint_evaluation(frame: EvaluationFrame<Felt>) -> [Felt; NUM_CONSTRAINTS] {
-    let mut result = [Felt::ZERO; NUM_CONSTRAINTS];
+    let mut result = [ZERO; NUM_CONSTRAINTS];
 
     let op_flag = &OpFlags::new(&frame);
 

--- a/air/src/constraints/stack/overflow/tests.rs
+++ b/air/src/constraints/stack/overflow/tests.rs
@@ -12,7 +12,7 @@ use vm_core::{Felt, FieldElement, Operation, ONE, ZERO};
 
 #[test]
 fn test_stack_overflow_constraints() {
-    let expected = [Felt::ZERO; NUM_CONSTRAINTS];
+    let expected = [ZERO; NUM_CONSTRAINTS];
 
     // ------------------ right shift operation ----------------------------------------------------
 
@@ -116,7 +116,7 @@ fn test_stack_depth_air() {
     frame.next_mut()[B1_COL_IDX] = Felt::new(12);
     frame.next_mut()[H0_COL_IDX] = Felt::new(depth - 1 - 16).inv();
 
-    let expected = [Felt::ZERO; NUM_CONSTRAINTS];
+    let expected = [ZERO; NUM_CONSTRAINTS];
     let result = get_constraint_evaluation(frame);
 
     assert_eq!(expected, result);
@@ -127,7 +127,7 @@ fn test_stack_depth_air() {
 
 /// Returns the result of stack operation constraint evaluations on the provided frame.
 fn get_constraint_evaluation(frame: EvaluationFrame<Felt>) -> [Felt; NUM_CONSTRAINTS] {
-    let mut result = [Felt::ZERO; NUM_CONSTRAINTS];
+    let mut result = [ZERO; NUM_CONSTRAINTS];
 
     let op_flag = &OpFlags::new(&frame);
 

--- a/air/src/constraints/stack/stack_manipulation/tests.rs
+++ b/air/src/constraints/stack/stack_manipulation/tests.rs
@@ -1,6 +1,6 @@
 use super::{super::STACK_TRACE_OFFSET, enforce_constraints, EvaluationFrame, NUM_CONSTRAINTS};
 use crate::stack::op_flags::{generate_evaluation_frame, OpFlags};
-use vm_core::{Felt, FieldElement, Operation, ONE, ZERO};
+use vm_core::{Felt, Operation, ONE, ZERO};
 
 use proptest::prelude::*;
 
@@ -13,7 +13,7 @@ proptest! {
 
     #[test]
     fn test_dupn_operation(a in any::<u64>()) {
-        let expected = [Felt::ZERO; NUM_CONSTRAINTS];
+        let expected = [ZERO; NUM_CONSTRAINTS];
         let nidex = [0,1,2,3,4,5,6,7,9,11,13,15];
         for n in nidex.iter() {
             let frame = get_dup_test_frame(a, *n);
@@ -26,7 +26,7 @@ proptest! {
 
     #[test]
     fn test_swap_operation(a in any::<u64>(), b in any::<u64>()) {
-        let expected = [Felt::ZERO; NUM_CONSTRAINTS];
+        let expected = [ZERO; NUM_CONSTRAINTS];
         let frame = get_swap_test_frame(a, b);
         let result = get_constraint_evaluation(frame);
         assert_eq!(expected, result);
@@ -47,7 +47,7 @@ proptest! {
     {
         // -----------  swapw operation ---------------------------------------
 
-        let expected = [Felt::ZERO; NUM_CONSTRAINTS];
+        let expected = [ZERO; NUM_CONSTRAINTS];
         let frame = get_swapw_test_frame(a, b, c, d, e, f, g, h);
         let result = get_constraint_evaluation(frame);
         assert_eq!(expected, result);
@@ -86,7 +86,7 @@ proptest! {
         o in any::<u64>(),
         p in any::<u64>(),
     ) {
-        let expected = [Felt::ZERO; NUM_CONSTRAINTS];
+        let expected = [ZERO; NUM_CONSTRAINTS];
         let frame = get_swapdw_test_frame(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p);
         let result = get_constraint_evaluation(frame);
         assert_eq!(expected, result);
@@ -96,7 +96,7 @@ proptest! {
 
     #[test]
     fn test_movupn_operation(a in any::<u64>()) {
-        let expected = [Felt::ZERO; NUM_CONSTRAINTS];
+        let expected = [ZERO; NUM_CONSTRAINTS];
         let nidex = [2, 3, 4, 5, 6, 7, 8];
         for n in nidex.iter() {
             let frame = get_movup_test_frame(a, *n);
@@ -109,7 +109,7 @@ proptest! {
 
     #[test]
     fn test_movdnn_operation(a in any::<u64>()) {
-        let expected = [Felt::ZERO; NUM_CONSTRAINTS];
+        let expected = [ZERO; NUM_CONSTRAINTS];
         let nidex = [2, 3, 4, 5, 6, 7, 8];
         for n in nidex.iter() {
             let frame = get_movdn_test_frame(a, *n);
@@ -122,7 +122,7 @@ proptest! {
 
     #[test]
     fn test_cswap_operation(a in any::<u64>(), b in any::<u64>()) {
-        let expected = [Felt::ZERO; NUM_CONSTRAINTS];
+        let expected = [ZERO; NUM_CONSTRAINTS];
 
         // -------------- when the first element is 0 ---------------------
 
@@ -153,7 +153,7 @@ proptest! {
         g in any::<u64>(),
         h in any::<u64>()
     ) {
-        let expected = [Felt::ZERO; NUM_CONSTRAINTS];
+        let expected = [ZERO; NUM_CONSTRAINTS];
 
         // -------------- when the first element is 0 ---------------------
 
@@ -180,7 +180,7 @@ proptest! {
 
 #[test]
 fn test_pad_operation() {
-    let expected = [Felt::ZERO; NUM_CONSTRAINTS];
+    let expected = [ZERO; NUM_CONSTRAINTS];
     let frame = get_pad_test_frame();
     let result = get_constraint_evaluation(frame);
     assert_eq!(expected, result);
@@ -191,7 +191,7 @@ fn test_pad_operation() {
 
 /// Returns the result of stack operation constraint evaluations on the provided frame.
 fn get_constraint_evaluation(frame: EvaluationFrame<Felt>) -> [Felt; NUM_CONSTRAINTS] {
-    let mut result = [Felt::ZERO; NUM_CONSTRAINTS];
+    let mut result = [ZERO; NUM_CONSTRAINTS];
 
     let op_flag = &OpFlags::new(&frame);
 

--- a/air/src/constraints/stack/system_ops/tests.rs
+++ b/air/src/constraints/stack/system_ops/tests.rs
@@ -3,7 +3,7 @@ use super::{
     enforce_constraints, EvaluationFrame, NUM_CONSTRAINTS,
 };
 use crate::stack::op_flags::{generate_evaluation_frame, OpFlags};
-use vm_core::{Felt, FieldElement, Operation, ONE};
+use vm_core::{Felt, Operation, ONE, ZERO};
 
 use proptest::prelude::*;
 
@@ -16,7 +16,7 @@ proptest! {
 
     #[test]
     fn test_fmpadd_operation(a in any::<u64>()) {
-        let expected = [Felt::ZERO; NUM_CONSTRAINTS];
+        let expected = [ZERO; NUM_CONSTRAINTS];
         let frame = get_fmpadd_test_frame(a);
         let result = get_constraint_evaluation(frame);
         assert_eq!(expected, result);
@@ -26,7 +26,7 @@ proptest! {
 
     #[test]
     fn test_fmpupdate_operation(a in any::<u64>()) {
-        let expected = [Felt::ZERO; NUM_CONSTRAINTS];
+        let expected = [ZERO; NUM_CONSTRAINTS];
         let frame = get_fmpupdate_test_frame(a);
         let result = get_constraint_evaluation(frame);
         assert_eq!(expected, result);
@@ -36,7 +36,7 @@ proptest! {
 
     #[test]
     fn test_clk_operation(a in any::<u64>()) {
-        let expected = [Felt::ZERO; NUM_CONSTRAINTS];
+        let expected = [ZERO; NUM_CONSTRAINTS];
         let frame = get_clk_test_frame(a);
         let result = get_constraint_evaluation(frame);
         assert_eq!(expected, result);
@@ -48,7 +48,7 @@ proptest! {
 
 #[test]
 fn test_assert_operation() {
-    let expected = [Felt::ZERO; NUM_CONSTRAINTS];
+    let expected = [ZERO; NUM_CONSTRAINTS];
     let frame = get_assert_test_frame();
     let result = get_constraint_evaluation(frame);
     assert_eq!(expected, result);
@@ -59,7 +59,7 @@ fn test_assert_operation() {
 
 /// Returns the result of stack operation constraint evaluations on the provided frame.
 fn get_constraint_evaluation(frame: EvaluationFrame<Felt>) -> [Felt; NUM_CONSTRAINTS] {
-    let mut result = [Felt::ZERO; NUM_CONSTRAINTS];
+    let mut result = [ZERO; NUM_CONSTRAINTS];
 
     let op_flag = &OpFlags::new(&frame);
 

--- a/air/src/constraints/stack/u32_ops/tests.rs
+++ b/air/src/constraints/stack/u32_ops/tests.rs
@@ -17,7 +17,7 @@ proptest! {
 
     #[test]
     fn test_u32split_operation(a in any::<u64>()) {
-        let expected = [Felt::ZERO; NUM_CONSTRAINTS];
+        let expected = [ZERO; NUM_CONSTRAINTS];
         let frame = get_u32split_test_frame(a);
         let result = get_constraint_evaluation(frame);
         assert_eq!(expected, result);
@@ -27,7 +27,7 @@ proptest! {
 
     #[test]
     fn test_u32add_operation(a in any::<u32>(), b in any::<u32>()) {
-        let expected = [Felt::ZERO; NUM_CONSTRAINTS];
+        let expected = [ZERO; NUM_CONSTRAINTS];
         let frame = get_u32add_test_frame(a, b);
         let result = get_constraint_evaluation(frame);
         assert_eq!(expected, result);
@@ -37,7 +37,7 @@ proptest! {
 
     #[test]
     fn test_u32add3_operation(a in any::<u32>(), b in any::<u32>(), c in any::<u32>()) {
-        let expected = [Felt::ZERO; NUM_CONSTRAINTS];
+        let expected = [ZERO; NUM_CONSTRAINTS];
         let frame = get_u32add3_test_frame(a, b, c);
         let result = get_constraint_evaluation(frame);
         assert_eq!(expected, result);
@@ -47,7 +47,7 @@ proptest! {
 
     #[test]
     fn test_u32mul_operation(a in any::<u32>(), b in any::<u32>()) {
-        let expected = [Felt::ZERO; NUM_CONSTRAINTS];
+        let expected = [ZERO; NUM_CONSTRAINTS];
         let frame = get_u32mul_test_frame(a, b);
         let result = get_constraint_evaluation(frame);
         assert_eq!(expected, result);
@@ -58,7 +58,7 @@ proptest! {
     #[test]
     #[allow(arithmetic_overflow)]
     fn test_u32madd_operation(a in any::<u32>(), b in any::<u32>(), c in any::<u32>()) {
-        let expected = [Felt::ZERO; NUM_CONSTRAINTS];
+        let expected = [ZERO; NUM_CONSTRAINTS];
         let frame = get_u32madd_test_frame(a, b, c);
         let result = get_constraint_evaluation(frame);
         assert_eq!(expected, result);
@@ -68,7 +68,7 @@ proptest! {
 
     #[test]
     fn test_u32sub_operation(a in any::<u32>(), b in any::<u32>()) {
-        let expected = [Felt::ZERO; NUM_CONSTRAINTS];
+        let expected = [ZERO; NUM_CONSTRAINTS];
         let frame = get_u32sub_test_frame(a, b);
         let result = get_constraint_evaluation(frame);
         assert_eq!(expected, result);
@@ -78,7 +78,7 @@ proptest! {
 
     #[test]
     fn test_u32div_operation(a in any::<u32>(), b in any::<u32>()) {
-        let expected = [Felt::ZERO; NUM_CONSTRAINTS];
+        let expected = [ZERO; NUM_CONSTRAINTS];
         if a != 0 {
             let frame = get_u32div_test_frame(a, b);
             let result = get_constraint_evaluation(frame);
@@ -93,7 +93,7 @@ proptest! {
 
 /// Returns the result of stack operation constraint evaluations on the provided frame.
 fn get_constraint_evaluation(frame: EvaluationFrame<Felt>) -> [Felt; NUM_CONSTRAINTS] {
-    let mut result = [Felt::ZERO; NUM_CONSTRAINTS];
+    let mut result = [ZERO; NUM_CONSTRAINTS];
 
     let op_flag = &OpFlags::new(&frame);
 

--- a/air/src/lib.rs
+++ b/air/src/lib.rs
@@ -133,7 +133,7 @@ impl Air for ProcessorAir {
 
         // --- set assertions for the first step --------------------------------------------------
         // first value of clk is 0
-        result.push(Assertion::single(CLK_COL_IDX, 0, Felt::ZERO));
+        result.push(Assertion::single(CLK_COL_IDX, 0, ZERO));
 
         // first value of fmp is 2^30
         result.push(Assertion::single(FMP_COL_IDX, 0, Felt::new(2u64.pow(30))));

--- a/assembly/src/ast/parsers/constants.rs
+++ b/assembly/src/ast/parsers/constants.rs
@@ -291,8 +291,11 @@ fn compute_statement(
 #[cfg(test)]
 mod tests {
     use super::{Felt, LocalConstMap, Token};
-    use crate::ast::parsers::constants::{
-        build_postfix_expression, evaluate_postfix_expression, Operation,
+    use crate::{
+        ast::parsers::constants::{
+            build_postfix_expression, evaluate_postfix_expression, Operation,
+        },
+        ONE,
     };
     use Operation::*;
 
@@ -318,7 +321,7 @@ mod tests {
             Value(Felt::new(3)),
             Value(Felt::new(3)),
             FeltDiv,
-            Value(Felt::new(1)),
+            Value(ONE),
             Add,
             Sub,
             Add,
@@ -352,7 +355,7 @@ mod tests {
             Value(Felt::new(3)),
             Value(Felt::new(3)),
             FeltDiv,
-            Value(Felt::new(1)),
+            Value(ONE),
             Add,
             Sub,
             Add,

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -7,7 +7,7 @@ extern crate alloc;
 pub mod chiplets;
 pub mod errors;
 
-pub use ::crypto::{Word, ONE, WORD_SIZE, ZERO};
+pub use ::crypto::{Word, EMPTY_WORD, ONE, WORD_SIZE, ZERO};
 pub mod crypto {
     pub mod merkle {
         pub use ::crypto::merkle::{

--- a/core/src/program/blocks/mod.rs
+++ b/core/src/program/blocks/mod.rs
@@ -1,4 +1,4 @@
-use super::{hasher, Box, Digest, Felt, FieldElement, Operation, Vec};
+use super::{hasher, Box, Digest, Felt, Operation, Vec};
 use crate::DecoratorList;
 use core::fmt;
 

--- a/core/src/program/blocks/span_block.rs
+++ b/core/src/program/blocks/span_block.rs
@@ -1,5 +1,5 @@
-use super::{fmt, hasher, Digest, Felt, FieldElement, Operation, Vec};
-use crate::{DecoratorIterator, DecoratorList};
+use super::{fmt, hasher, Digest, Felt, Operation, Vec};
+use crate::{DecoratorIterator, DecoratorList, ZERO};
 use winter_utils::flatten_slice_elements;
 
 // CONSTANTS
@@ -56,7 +56,7 @@ impl Span {
     // CONSTANTS
     // --------------------------------------------------------------------------------------------
     /// The domain of the span block (used for control block hashing).
-    pub const DOMAIN: Felt = Felt::ZERO;
+    pub const DOMAIN: Felt = ZERO;
 
     // CONSTRUCTOR
     // --------------------------------------------------------------------------------------------
@@ -228,7 +228,7 @@ impl OpBatchAccumulator {
     pub fn new() -> Self {
         Self {
             ops: Vec::new(),
-            groups: [Felt::ZERO; BATCH_SIZE],
+            groups: [ZERO; BATCH_SIZE],
             op_counts: [0; BATCH_SIZE],
             group: 0,
             op_idx: 0,
@@ -411,7 +411,8 @@ fn validate_decorators(operations: &[Operation], decorators: &DecoratorList) {
 
 #[cfg(test)]
 mod tests {
-    use super::{hasher, Felt, FieldElement, Operation, BATCH_SIZE};
+    use super::{hasher, Felt, Operation, BATCH_SIZE, ZERO};
+    use crate::ONE;
 
     #[test]
     fn batch_ops() {
@@ -424,7 +425,7 @@ mod tests {
         assert_eq!(ops, batch.ops);
         assert_eq!(1, batch.num_groups());
 
-        let mut batch_groups = [Felt::ZERO; BATCH_SIZE];
+        let mut batch_groups = [ZERO; BATCH_SIZE];
         batch_groups[0] = build_group(&ops);
 
         assert_eq!(batch_groups, batch.groups);
@@ -440,7 +441,7 @@ mod tests {
         assert_eq!(ops, batch.ops);
         assert_eq!(1, batch.num_groups());
 
-        let mut batch_groups = [Felt::ZERO; BATCH_SIZE];
+        let mut batch_groups = [ZERO; BATCH_SIZE];
         batch_groups[0] = build_group(&ops);
 
         assert_eq!(batch_groups, batch.groups);
@@ -456,7 +457,7 @@ mod tests {
         assert_eq!(ops, batch.ops);
         assert_eq!(2, batch.num_groups());
 
-        let mut batch_groups = [Felt::ZERO; BATCH_SIZE];
+        let mut batch_groups = [ZERO; BATCH_SIZE];
         batch_groups[0] = build_group(&ops);
         batch_groups[1] = Felt::new(12345678);
 
@@ -466,7 +467,7 @@ mod tests {
 
         // --- one group with 7 immediate values --------------------------------------------------
         let ops = vec![
-            Operation::Push(Felt::new(1)),
+            Operation::Push(ONE),
             Operation::Push(Felt::new(2)),
             Operation::Push(Felt::new(3)),
             Operation::Push(Felt::new(4)),
@@ -484,7 +485,7 @@ mod tests {
 
         let batch_groups = [
             build_group(&ops),
-            Felt::new(1),
+            ONE,
             Felt::new(2),
             Felt::new(3),
             Felt::new(4),
@@ -501,7 +502,7 @@ mod tests {
         let ops = vec![
             Operation::Add,
             Operation::Mul,
-            Operation::Push(Felt::new(1)),
+            Operation::Push(ONE),
             Operation::Push(Felt::new(2)),
             Operation::Push(Felt::new(3)),
             Operation::Push(Felt::new(4)),
@@ -519,13 +520,13 @@ mod tests {
 
         let batch0_groups = [
             build_group(&ops[..9]),
-            Felt::new(1),
+            ONE,
             Felt::new(2),
             Felt::new(3),
             Felt::new(4),
             Felt::new(5),
             Felt::new(6),
-            Felt::ZERO,
+            ZERO,
         ];
 
         assert_eq!(batch0_groups, batch0.groups);
@@ -535,7 +536,7 @@ mod tests {
         assert_eq!(vec![ops[9]], batch1.ops);
         assert_eq!(2, batch1.num_groups());
 
-        let mut batch1_groups = [Felt::ZERO; BATCH_SIZE];
+        let mut batch1_groups = [ZERO; BATCH_SIZE];
         batch1_groups[0] = build_group(&[ops[9]]);
         batch1_groups[1] = Felt::new(7);
 
@@ -571,10 +572,10 @@ mod tests {
             Felt::new(7),
             Felt::new(11),
             build_group(&ops[9..]),
-            Felt::ZERO,
-            Felt::ZERO,
-            Felt::ZERO,
-            Felt::ZERO,
+            ZERO,
+            ZERO,
+            ZERO,
+            ZERO,
         ];
 
         assert_eq!([9_usize, 0, 0, 1, 0, 0, 0, 0], batch.op_counts);
@@ -604,11 +605,11 @@ mod tests {
             build_group(&ops[..8]),
             build_group(&[ops[8]]),
             Felt::new(11),
-            Felt::ZERO,
-            Felt::ZERO,
-            Felt::ZERO,
-            Felt::ZERO,
-            Felt::ZERO,
+            ZERO,
+            ZERO,
+            ZERO,
+            ZERO,
+            ZERO,
         ];
 
         assert_eq!(batch_groups, batch.groups);
@@ -624,7 +625,7 @@ mod tests {
             Operation::Add,
             Operation::Mul,
             Operation::Mul,
-            Operation::Push(Felt::new(1)),
+            Operation::Push(ONE),
             Operation::Push(Felt::new(2)),
         ];
         let (batches, hash) = super::batch_ops(ops.clone());
@@ -636,13 +637,13 @@ mod tests {
 
         let batch_groups = [
             build_group(&ops[..8]),
-            Felt::new(1),
+            ONE,
             build_group(&[ops[8]]),
             Felt::new(2),
-            Felt::ZERO,
-            Felt::ZERO,
-            Felt::ZERO,
-            Felt::ZERO,
+            ZERO,
+            ZERO,
+            ZERO,
+            ZERO,
         ];
 
         assert_eq!(batch_groups, batch.groups);
@@ -653,7 +654,7 @@ mod tests {
         let ops = vec![
             Operation::Add,
             Operation::Mul,
-            Operation::Push(Felt::new(1)),
+            Operation::Push(ONE),
             Operation::Push(Felt::new(2)),
             Operation::Push(Felt::new(3)),
             Operation::Push(Felt::new(4)),
@@ -681,13 +682,13 @@ mod tests {
 
         let batch0_groups = [
             build_group(&ops[..9]),
-            Felt::new(1),
+            ONE,
             Felt::new(2),
             Felt::new(3),
             Felt::new(4),
             Felt::new(5),
             build_group(&ops[9..17]),
-            Felt::ZERO,
+            ZERO,
         ];
 
         assert_eq!(batch0_groups, batch0.groups);
@@ -697,16 +698,8 @@ mod tests {
         assert_eq!(ops[17..], batch1.ops);
         assert_eq!(2, batch1.num_groups());
 
-        let batch1_groups = [
-            build_group(&ops[17..]),
-            Felt::new(6),
-            Felt::ZERO,
-            Felt::ZERO,
-            Felt::ZERO,
-            Felt::ZERO,
-            Felt::ZERO,
-            Felt::ZERO,
-        ];
+        let batch1_groups =
+            [build_group(&ops[17..]), Felt::new(6), ZERO, ZERO, ZERO, ZERO, ZERO, ZERO];
         assert_eq!(batch1_groups, batch1.groups);
         assert_eq!([2_usize, 0, 0, 0, 0, 0, 0, 0], batch1.op_counts);
 

--- a/core/src/program/mod.rs
+++ b/core/src/program/mod.rs
@@ -4,7 +4,7 @@ use super::{
         collections::{BTreeMap, Vec},
         Box,
     },
-    Felt, FieldElement, Operation,
+    Felt, Operation,
 };
 use core::fmt;
 use winter_utils::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable};

--- a/miden/src/examples/fibonacci.rs
+++ b/miden/src/examples/fibonacci.rs
@@ -1,4 +1,4 @@
-use super::Example;
+use super::{Example, ONE, ZERO};
 use miden::{
     math::{Felt, FieldElement, StarkField},
     Assembler, MemAdviceProvider, Program, StackInputs,
@@ -47,8 +47,8 @@ fn generate_fibonacci_program(n: usize) -> Program {
 
 /// Computes the `n`-th term of Fibonacci sequence
 fn compute_fibonacci(n: usize) -> Felt {
-    let mut t0 = Felt::ZERO;
-    let mut t1 = Felt::ONE;
+    let mut t0 = ZERO;
+    let mut t1 = ONE;
 
     for _ in 0..n {
         t1 = t0 + t1;

--- a/miden/src/examples/mod.rs
+++ b/miden/src/examples/mod.rs
@@ -1,6 +1,6 @@
 use clap::Parser;
 use miden::{AdviceProvider, ExecutionProof, Program, ProgramInfo, ProvingOptions, StackInputs};
-use processor::{ExecutionOptions, ExecutionOptionsError};
+use processor::{ExecutionOptions, ExecutionOptionsError, ONE, ZERO};
 use std::io::Write;
 use std::time::Instant;
 

--- a/miden/src/lib.rs
+++ b/miden/src/lib.rs
@@ -8,7 +8,7 @@ pub use assembly::{Assembler, AssemblyError, ParsingError};
 pub use processor::{
     crypto, execute, execute_iter, utils, AdviceInputs, AdviceProvider, AsmOpInfo, ExecutionError,
     ExecutionTrace, Kernel, MemAdviceProvider, Operation, ProgramInfo, StackInputs, VmState,
-    VmStateIterator,
+    VmStateIterator, ZERO,
 };
 pub use prover::{
     math, prove, Digest, ExecutionProof, FieldExtension, HashFunction, InputError, Program,

--- a/miden/tests/integration/exec_iters.rs
+++ b/miden/tests/integration/exec_iters.rs
@@ -1,5 +1,5 @@
 use processor::{AsmOpInfo, VmState};
-use test_utils::{build_debug_test, Felt, FieldElement, ToElements};
+use test_utils::{build_debug_test, Felt, ToElements, ONE};
 use vm_core::{AssemblyOp, Operation};
 
 // EXEC ITER TESTS
@@ -14,7 +14,7 @@ fn test_exec_iter() {
     let test = build_debug_test!(source, &init_stack);
     let traces = test.execute_iter();
     let fmp = Felt::new(2u64.pow(30));
-    let next_fmp = fmp + Felt::ONE;
+    let next_fmp = fmp + ONE;
     let mem = vec![(1_u64, slice_to_word(&[13, 14, 15, 16]))];
     let expected_states = vec![
         VmState {
@@ -143,7 +143,7 @@ fn test_exec_iter() {
         VmState {
             clk: 11,
             ctx: 0,
-            op: Some(Operation::Push(Felt::new(1))),
+            op: Some(Operation::Push(ONE)),
             asmop: None,
             stack: [1, 17, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0].to_elements(),
             fmp,

--- a/miden/tests/integration/operations/field_ops.rs
+++ b/miden/tests/integration/operations/field_ops.rs
@@ -1,6 +1,6 @@
 use test_utils::{
     build_op_test, prop_randw, proptest::prelude::*, rand::rand_value, Felt, FieldElement,
-    StarkField, TestError, WORD_SIZE,
+    StarkField, TestError, ONE, WORD_SIZE,
 };
 
 // FIELD OPS ASSERTIONS - MANUAL TESTS
@@ -280,7 +280,7 @@ fn inv() {
 
     // --- simple cases ---------------------------------------------------------------------------
     let test = build_op_test!(asm_op, &[1]);
-    test.expect_stack(&[Felt::new(1).inv().as_int()]);
+    test.expect_stack(&[ONE.inv().as_int()]);
 
     let test = build_op_test!(asm_op, &[64]);
     test.expect_stack(&[Felt::new(64).inv().as_int()]);

--- a/processor/src/chiplets/bitwise/tests.rs
+++ b/processor/src/chiplets/bitwise/tests.rs
@@ -210,7 +210,7 @@ fn bitwise_multiple() {
 /// Builds a trace of the specified length and fills it with data from the provided Bitwise instance.
 fn build_trace(bitwise: Bitwise, num_rows: usize) -> (Vec<Vec<Felt>>, ChipletsBus) {
     let mut chiplets_bus = ChipletsBus::default();
-    let mut trace = (0..TRACE_WIDTH).map(|_| vec![Felt::new(0); num_rows]).collect::<Vec<_>>();
+    let mut trace = (0..TRACE_WIDTH).map(|_| vec![ZERO; num_rows]).collect::<Vec<_>>();
     let mut fragment = TraceFragment::trace_to_fragment(&mut trace);
     bitwise.fill_trace(&mut fragment, &mut chiplets_bus, 0);
 

--- a/processor/src/chiplets/hasher/lookups.rs
+++ b/processor/src/chiplets/hasher/lookups.rs
@@ -1,4 +1,4 @@
-use super::{ColMatrix, Felt, FieldElement, LookupTableRow, StarkField, Vec};
+use super::{ColMatrix, Felt, FieldElement, LookupTableRow, StarkField, Vec, ZERO};
 use core::ops::Range;
 use miden_air::trace::chiplets::{
     hasher::{
@@ -180,8 +180,8 @@ fn get_adjacent_hasher_rates(
 ) -> ([Felt; RATE_LEN], [Felt; RATE_LEN]) {
     let row = get_row_from_addr(addr);
 
-    let mut current = [Felt::ZERO; RATE_LEN];
-    let mut next = [Felt::ZERO; RATE_LEN];
+    let mut current = [ZERO; RATE_LEN];
+    let mut next = [ZERO; RATE_LEN];
     for (idx, col_idx) in HASHER_RATE_COL_RANGE.enumerate() {
         let column = main_trace.get_column(col_idx);
         current[idx] = column[row];

--- a/processor/src/chiplets/hasher/tests.rs
+++ b/processor/src/chiplets/hasher/tests.rs
@@ -781,7 +781,7 @@ fn hash_memoization_span_blocks() {
 
     // --- span block with multiple batches -------------------------------------------------------
     let span_block = CodeBlock::new_span(vec![
-        Operation::Push(Felt::new(1)),
+        Operation::Push(ONE),
         Operation::Push(Felt::new(2)),
         Operation::Push(Felt::new(3)),
         Operation::Push(Felt::new(4)),
@@ -1034,7 +1034,7 @@ fn hash_memoization_span_blocks_check(span_block: CodeBlock) {
 /// Builds an execution trace for the provided hasher. The trace must have the number of rows
 /// specified by num_rows.
 fn build_trace(hasher: Hasher, num_rows: usize) -> (Vec<Vec<Felt>>, ChipletsVTableTraceBuilder) {
-    let mut trace = (0..TRACE_WIDTH).map(|_| vec![Felt::new(0); num_rows]).collect::<Vec<_>>();
+    let mut trace = (0..TRACE_WIDTH).map(|_| vec![ZERO; num_rows]).collect::<Vec<_>>();
     let mut fragment = TraceFragment::trace_to_fragment(&mut trace);
     let aux_trace_builder = hasher.fill_trace(&mut fragment);
     (trace, aux_trace_builder)

--- a/processor/src/chiplets/memory/mod.rs
+++ b/processor/src/chiplets/memory/mod.rs
@@ -2,7 +2,7 @@ use super::{
     trace::LookupTableRow,
     utils::{split_element_u32_into_u16, split_u32_into_u16},
     BTreeMap, ChipletsBus, ColMatrix, Felt, FieldElement, RangeChecker, StarkField, TraceFragment,
-    Vec, Word, ONE, ZERO,
+    Vec, Word, EMPTY_WORD, ONE,
 };
 use miden_air::trace::chiplets::memory::{
     ADDR_COL_IDX, CLK_COL_IDX, CTX_COL_IDX, D0_COL_IDX, D1_COL_IDX, D_INV_COL_IDX, V_COL_RANGE,
@@ -18,7 +18,7 @@ mod tests;
 // ================================================================================================
 
 /// Initial value of every memory cell.
-const INIT_MEM_VALUE: Word = [ZERO; 4];
+const INIT_MEM_VALUE: Word = EMPTY_WORD;
 
 // RANDOM ACCESS MEMORY
 // ================================================================================================

--- a/processor/src/chiplets/memory/tests.rs
+++ b/processor/src/chiplets/memory/tests.rs
@@ -1,7 +1,8 @@
 use super::{
     super::aux_trace::{ChipletLookup, ChipletsBusRow},
+    super::ZERO,
     ChipletsBus, Felt, FieldElement, Memory, MemoryLookup, TraceFragment, Vec, ADDR_COL_IDX,
-    CLK_COL_IDX, CTX_COL_IDX, D0_COL_IDX, D1_COL_IDX, D_INV_COL_IDX, ONE, V_COL_RANGE, ZERO,
+    CLK_COL_IDX, CTX_COL_IDX, D0_COL_IDX, D1_COL_IDX, D_INV_COL_IDX, EMPTY_WORD, ONE, V_COL_RANGE,
 };
 use miden_air::trace::chiplets::memory::{
     Selectors, MEMORY_COPY_READ, MEMORY_INIT_READ, MEMORY_READ_LABEL, MEMORY_WRITE,
@@ -22,27 +23,27 @@ fn mem_read() {
     // read a value from address 0; clk = 1
     let addr0 = 0;
     let value = mem.read(0, addr0, 1);
-    assert_eq!([ZERO; 4], value);
+    assert_eq!(EMPTY_WORD, value);
     assert_eq!(1, mem.size());
     assert_eq!(1, mem.trace_len());
 
     // read a value from address 3; clk = 2
     let addr3 = 3;
     let value = mem.read(0, addr3, 2);
-    assert_eq!([ZERO; 4], value);
+    assert_eq!(EMPTY_WORD, value);
     assert_eq!(2, mem.size());
     assert_eq!(2, mem.trace_len());
 
     // read a value from address 0 again; clk = 3
     let value = mem.read(0, addr0, 3);
-    assert_eq!([ZERO; 4], value);
+    assert_eq!(EMPTY_WORD, value);
     assert_eq!(2, mem.size());
     assert_eq!(3, mem.trace_len());
 
     // read a value from address 2; clk = 4
     let addr2 = 2;
     let value = mem.read(0, addr2, 4);
-    assert_eq!([ZERO; 4], value);
+    assert_eq!(EMPTY_WORD, value);
     assert_eq!(3, mem.size());
     assert_eq!(4, mem.trace_len());
 
@@ -52,21 +53,21 @@ fn mem_read() {
 
     // address 0
     let mut prev_row = [ZERO; MEMORY_TRACE_WIDTH];
-    let memory_access = MemoryLookup::from_ints(MEMORY_READ_LABEL, 0, addr0, 1, [ZERO; 4]);
+    let memory_access = MemoryLookup::from_ints(MEMORY_READ_LABEL, 0, addr0, 1, EMPTY_WORD);
     prev_row =
         verify_memory_access(&trace, &chiplets_bus, 0, MEMORY_INIT_READ, &memory_access, prev_row);
 
-    let memory_access = MemoryLookup::from_ints(MEMORY_READ_LABEL, 0, addr0, 3, [ZERO; 4]);
+    let memory_access = MemoryLookup::from_ints(MEMORY_READ_LABEL, 0, addr0, 3, EMPTY_WORD);
     prev_row =
         verify_memory_access(&trace, &chiplets_bus, 1, MEMORY_COPY_READ, &memory_access, prev_row);
 
     // address 2
-    let memory_access = MemoryLookup::from_ints(MEMORY_READ_LABEL, 0, addr2, 4, [ZERO; 4]);
+    let memory_access = MemoryLookup::from_ints(MEMORY_READ_LABEL, 0, addr2, 4, EMPTY_WORD);
     prev_row =
         verify_memory_access(&trace, &chiplets_bus, 2, MEMORY_INIT_READ, &memory_access, prev_row);
 
     // address 3
-    let memory_access = MemoryLookup::from_ints(MEMORY_READ_LABEL, 0, addr3, 2, [ZERO; 4]);
+    let memory_access = MemoryLookup::from_ints(MEMORY_READ_LABEL, 0, addr3, 2, EMPTY_WORD);
     verify_memory_access(&trace, &chiplets_bus, 3, MEMORY_INIT_READ, &memory_access, prev_row);
 }
 
@@ -316,7 +317,7 @@ fn mem_get_state_at() {
 /// Builds a trace of the specified length and fills it with data from the provided Memory instance.
 fn build_trace(mem: Memory, num_rows: usize) -> (Vec<Vec<Felt>>, ChipletsBus) {
     let mut chiplets_bus = ChipletsBus::default();
-    let mut trace = (0..MEMORY_TRACE_WIDTH).map(|_| vec![Felt::ZERO; num_rows]).collect::<Vec<_>>();
+    let mut trace = (0..MEMORY_TRACE_WIDTH).map(|_| vec![ZERO; num_rows]).collect::<Vec<_>>();
     let mut fragment = TraceFragment::trace_to_fragment(&mut trace);
     mem.fill_trace(&mut fragment, &mut chiplets_bus, 0);
 

--- a/processor/src/chiplets/mod.rs
+++ b/processor/src/chiplets/mod.rs
@@ -1,6 +1,7 @@
 use super::{
     crypto::MerklePath, trace, utils, BTreeMap, ChipletsTrace, ColMatrix, ExecutionError, Felt,
-    FieldElement, RangeChecker, StarkField, TraceFragment, Vec, Word, CHIPLETS_WIDTH, ONE, ZERO,
+    FieldElement, RangeChecker, StarkField, TraceFragment, Vec, Word, CHIPLETS_WIDTH, EMPTY_WORD,
+    ONE, ZERO,
 };
 use miden_air::trace::chiplets::{
     bitwise::{BITWISE_AND_LABEL, BITWISE_XOR_LABEL},

--- a/processor/src/decoder/aux_hints.rs
+++ b/processor/src/decoder/aux_hints.rs
@@ -1,6 +1,6 @@
 use super::{
     super::trace::LookupTableRow, get_num_groups_in_next_batch, BlockInfo, ColMatrix, Felt,
-    FieldElement, StarkField, Vec, Word, ONE, ZERO,
+    FieldElement, StarkField, Vec, Word, EMPTY_WORD, ONE, ZERO,
 };
 
 // AUXILIARY TRACE HINTS
@@ -33,7 +33,7 @@ impl AuxTraceHints {
     pub fn new() -> Self {
         // initialize block hash table with an blank entry, this will be replaced with an entry
         // containing the actual program hash at the end of trace generation
-        let block_hash_rows = vec![BlockHashTableRow::from_program_hash([ZERO; 4])];
+        let block_hash_rows = vec![BlockHashTableRow::from_program_hash(EMPTY_WORD)];
 
         Self {
             block_exec_hints: Vec::new(),
@@ -308,7 +308,7 @@ impl BlockStackTableRow {
             parent_id,
             is_loop,
             parent_ctx: 0,
-            parent_fn_hash: [ZERO; 4],
+            parent_fn_hash: EMPTY_WORD,
             parent_fmp: ZERO,
             parent_stack_depth: 0,
             parent_next_overflow_addr: ZERO,

--- a/processor/src/decoder/mod.rs
+++ b/processor/src/decoder/mod.rs
@@ -1,7 +1,7 @@
 use super::{
     AdviceProvider, Call, ColMatrix, ExecutionError, Felt, FieldElement, Join, Loop, OpBatch,
-    Operation, Process, Span, Split, StarkField, Vec, Word, MIN_TRACE_LEN, ONE, OP_BATCH_SIZE,
-    ZERO,
+    Operation, Process, Span, Split, StarkField, Vec, Word, EMPTY_WORD, MIN_TRACE_LEN, ONE,
+    OP_BATCH_SIZE, ZERO,
 };
 use miden_air::trace::{
     chiplets::hasher::DIGEST_LEN,
@@ -125,7 +125,7 @@ where
         let body_hash = block.body().hash().into();
         let addr =
             self.chiplets
-                .hash_control_block(body_hash, [ZERO; 4], Loop::DOMAIN, block.hash());
+                .hash_control_block(body_hash, EMPTY_WORD, Loop::DOMAIN, block.hash());
 
         // start decoding the LOOP block; this appends a row with LOOP operation to the decoder
         // trace, but if the value on the top of the stack is not ONE, the block is not marked
@@ -176,7 +176,7 @@ where
         let fn_hash = block.fn_hash().into();
         let addr =
             self.chiplets
-                .hash_control_block(fn_hash, [ZERO; 4], block.domain(), block.hash());
+                .hash_control_block(fn_hash, EMPTY_WORD, block.domain(), block.hash());
 
         // start new execution context for the operand stack. this has the effect of resetting
         // stack depth to 16.
@@ -449,7 +449,7 @@ impl Decoder {
         let enter_loop = stack_top == ONE;
         let parent_addr = self.block_stack.push(addr, BlockType::Loop(enter_loop), None);
         self.trace
-            .append_block_start(parent_addr, Operation::Loop, loop_body_hash, [ZERO; 4]);
+            .append_block_start(parent_addr, Operation::Loop, loop_body_hash, EMPTY_WORD);
 
         // mark this cycle as the cycle at which a new LOOP block has started (this may affect
         // block hash table). A loop block has a single child only if the body of the loop is
@@ -490,7 +490,7 @@ impl Decoder {
 
         // push CALL block info onto the block stack and append a CALL row to the execution trace
         let parent_addr = self.block_stack.push(addr, BlockType::Call, Some(ctx_info));
-        self.trace.append_block_start(parent_addr, Operation::Call, fn_hash, [ZERO; 4]);
+        self.trace.append_block_start(parent_addr, Operation::Call, fn_hash, EMPTY_WORD);
 
         // mark this cycle as the cycle at which a new CALL block began execution (this affects
         // block stack and block hash tables). A CALL block has only a single child.
@@ -511,7 +511,7 @@ impl Decoder {
         // trace
         let parent_addr = self.block_stack.push(addr, BlockType::SysCall, Some(ctx_info));
         self.trace
-            .append_block_start(parent_addr, Operation::SysCall, fn_hash, [ZERO; 4]);
+            .append_block_start(parent_addr, Operation::SysCall, fn_hash, EMPTY_WORD);
 
         // mark this cycle as the cycle at which a new SYSCALL block began execution (this affects
         // block stack and block hash tables). A SYSCALL block has only a single child.

--- a/processor/src/decoder/tests.rs
+++ b/processor/src/decoder/tests.rs
@@ -20,7 +20,7 @@ use rand_utils::rand_value;
 use vm_core::{
     code_blocks::{CodeBlock, Span, OP_BATCH_SIZE},
     utils::collections::Vec,
-    CodeBlockTable, StarkField, ONE, ZERO,
+    CodeBlockTable, StarkField, EMPTY_WORD, ONE, ZERO,
 };
 
 // CONSTANTS
@@ -468,16 +468,16 @@ fn join_block() {
 
     // at the end of the first SPAN, the hasher state is set to the hash of the first child
     assert_eq!(span1_hash, get_hasher_state1(&trace, 3));
-    assert_eq!([ZERO, ZERO, ZERO, ZERO], get_hasher_state2(&trace, 3));
+    assert_eq!(EMPTY_WORD, get_hasher_state2(&trace, 3));
 
     // at the end of the second SPAN, the hasher state is set to the hash of the second child
     assert_eq!(span2_hash, get_hasher_state1(&trace, 6));
-    assert_eq!([ZERO, ZERO, ZERO, ZERO], get_hasher_state2(&trace, 6));
+    assert_eq!(EMPTY_WORD, get_hasher_state2(&trace, 6));
 
     // at the end of the program, the hasher state is set to the hash of the entire program
     let program_hash: Word = program.hash().into();
     assert_eq!(program_hash, get_hasher_state1(&trace, 7));
-    assert_eq!([ZERO, ZERO, ZERO, ZERO], get_hasher_state2(&trace, 7));
+    assert_eq!(EMPTY_WORD, get_hasher_state2(&trace, 7));
 
     // HALT opcode and program hash gets propagated to the last row
     for i in 9..trace_len {
@@ -550,12 +550,12 @@ fn split_block_true() {
 
     // at the end of the SPAN, the hasher state is set to the hash of the first child
     assert_eq!(span1_hash, get_hasher_state1(&trace, 3));
-    assert_eq!([ZERO, ZERO, ZERO, ZERO], get_hasher_state2(&trace, 3));
+    assert_eq!(EMPTY_WORD, get_hasher_state2(&trace, 3));
 
     // at the end of the program, the hasher state is set to the hash of the entire program
     let program_hash: Word = program.hash().into();
     assert_eq!(program_hash, get_hasher_state1(&trace, 4));
-    assert_eq!([ZERO, ZERO, ZERO, ZERO], get_hasher_state2(&trace, 4));
+    assert_eq!(EMPTY_WORD, get_hasher_state2(&trace, 4));
 
     // HALT opcode and program hash gets propagated to the last row
     for i in 6..trace_len {
@@ -621,12 +621,12 @@ fn split_block_false() {
 
     // at the end of the SPAN, the hasher state is set to the hash of the second child
     assert_eq!(span2_hash, get_hasher_state1(&trace, 3));
-    assert_eq!([ZERO, ZERO, ZERO, ZERO], get_hasher_state2(&trace, 3));
+    assert_eq!(EMPTY_WORD, get_hasher_state2(&trace, 3));
 
     // at the end of the program, the hasher state is set to the hash of the entire program
     let program_hash: Word = program.hash().into();
     assert_eq!(program_hash, get_hasher_state1(&trace, 4));
-    assert_eq!([ZERO, ZERO, ZERO, ZERO], get_hasher_state2(&trace, 4));
+    assert_eq!(EMPTY_WORD, get_hasher_state2(&trace, 4));
 
     // HALT opcode and program hash gets propagated to the last row
     for i in 6..trace_len {
@@ -690,7 +690,7 @@ fn loop_block() {
     // in the first row, the hasher state is set to the hash of the loop's body
     let loop_body_hash: Word = loop_body.hash().into();
     assert_eq!(loop_body_hash, get_hasher_state1(&trace, 0));
-    assert_eq!([ZERO; 4], get_hasher_state2(&trace, 0));
+    assert_eq!(EMPTY_WORD, get_hasher_state2(&trace, 0));
 
     // at the end of the SPAN block, the hasher state is also set to the hash of the loops body,
     // and is_loop_body flag is also set to ONE
@@ -757,13 +757,13 @@ fn loop_block_skip() {
     // in the first row, the hasher state is set to the hash of the loop's body
     let loop_body_hash: Word = loop_body.hash().into();
     assert_eq!(loop_body_hash, get_hasher_state1(&trace, 0));
-    assert_eq!([ZERO; 4], get_hasher_state2(&trace, 0));
+    assert_eq!(EMPTY_WORD, get_hasher_state2(&trace, 0));
 
     // the hash of the program is located in the last END row; is_loop is not set to ONE because
     // we didn't enter the loop's body
     let program_hash: Word = program.hash().into();
     assert_eq!(program_hash, get_hasher_state1(&trace, 1));
-    assert_eq!([ZERO, ZERO, ZERO, ZERO], get_hasher_state2(&trace, 1));
+    assert_eq!(EMPTY_WORD, get_hasher_state2(&trace, 1));
 
     // HALT opcode and program hash gets propagated to the last row
     for i in 3..trace_len {
@@ -822,7 +822,7 @@ fn loop_block_repeat() {
     // in the first row, the hasher state is set to the hash of the loop's body
     let loop_body_hash: Word = loop_body.hash().into();
     assert_eq!(loop_body_hash, get_hasher_state1(&trace, 0));
-    assert_eq!([ZERO; 4], get_hasher_state2(&trace, 0));
+    assert_eq!(EMPTY_WORD, get_hasher_state2(&trace, 0));
 
     // at the end of the first iteration, the hasher state is also set to the hash of the loops
     // body, and is_loop_body flag is also set to ONE
@@ -971,16 +971,16 @@ fn call_block() {
 
     // at the end of the first SPAN, the hasher state is set to the hash of the first child
     assert_eq!(first_span_hash, get_hasher_state1(&dec_trace, 6));
-    assert_eq!([ZERO, ZERO, ZERO, ZERO], get_hasher_state2(&dec_trace, 6));
+    assert_eq!(EMPTY_WORD, get_hasher_state2(&dec_trace, 6));
 
     // in the 7th row, we start the CALL block which hash span2 as its only child
     let foo_root_hash: Word = foo_root.hash().into();
     assert_eq!(foo_root_hash, get_hasher_state1(&dec_trace, 7));
-    assert_eq!([ZERO, ZERO, ZERO, ZERO], get_hasher_state2(&dec_trace, 7));
+    assert_eq!(EMPTY_WORD, get_hasher_state2(&dec_trace, 7));
 
     // span2 ends in the 11th row
     assert_eq!(foo_root_hash, get_hasher_state1(&dec_trace, 11));
-    assert_eq!([ZERO, ZERO, ZERO, ZERO], get_hasher_state2(&dec_trace, 11));
+    assert_eq!(EMPTY_WORD, get_hasher_state2(&dec_trace, 11));
 
     // CALL block ends in the 12th row; the second to last element of the hasher state
     // is set to ONE because we are exiting the CALL block
@@ -989,16 +989,16 @@ fn call_block() {
 
     // internal JOIN block ends in the 13th row
     assert_eq!(join1_hash, get_hasher_state1(&dec_trace, 13));
-    assert_eq!([ZERO, ZERO, ZERO, ZERO], get_hasher_state2(&dec_trace, 13));
+    assert_eq!(EMPTY_WORD, get_hasher_state2(&dec_trace, 13));
 
     // span3 ends in the 14th row
     assert_eq!(last_span_hash, get_hasher_state1(&dec_trace, 16));
-    assert_eq!([ZERO, ZERO, ZERO, ZERO], get_hasher_state2(&dec_trace, 16));
+    assert_eq!(EMPTY_WORD, get_hasher_state2(&dec_trace, 16));
 
     // the program ends in the 17th row
     let program_hash: Word = program.hash().into();
     assert_eq!(program_hash, get_hasher_state1(&dec_trace, 17));
-    assert_eq!([ZERO, ZERO, ZERO, ZERO], get_hasher_state2(&dec_trace, 17));
+    assert_eq!(EMPTY_WORD, get_hasher_state2(&dec_trace, 17));
 
     // HALT opcode and program hash gets propagated to the last row
     for i in 18..trace_len {
@@ -1065,7 +1065,7 @@ fn call_block() {
 
     // before the CALL operation is executed, we are in a root context and thus fn_hash is ZEROs.
     for i in 0..8 {
-        assert_eq!(get_fn_hash(&sys_trace, i), [ZERO; 4]);
+        assert_eq!(get_fn_hash(&sys_trace, i), EMPTY_WORD);
     }
 
     // inside the CALL block fn hash is set to the hash of the foo procedure
@@ -1075,7 +1075,7 @@ fn call_block() {
 
     // after the CALL block is ended, we are back in the root context
     for i in 13..trace_len {
-        assert_eq!(get_fn_hash(&sys_trace, i), [ZERO; 4]);
+        assert_eq!(get_fn_hash(&sys_trace, i), EMPTY_WORD);
     }
 
     // --- check block execution hints ------------------------------------------------------------
@@ -1097,7 +1097,7 @@ fn call_block() {
 
     // --- check block stack table rows -----------------------------------------------------------
     let call_ctx =
-        ExecutionContextInfo::new(0, [ZERO; 4], FMP_MIN + TWO, 17, overflow_addr_after_pad);
+        ExecutionContextInfo::new(0, EMPTY_WORD, FMP_MIN + TWO, 17, overflow_addr_after_pad);
     let expected_rows = vec![
         BlockStackTableRow::new_test(INIT_ADDR, ZERO, false),
         BlockStackTableRow::new_test(join1_addr, INIT_ADDR, false),
@@ -1242,12 +1242,12 @@ fn syscall_block() {
 
     // at the end of the first SPAN, the hasher state is set to the hash of the first child
     assert_eq!(first_span_hash, get_hasher_state1(&dec_trace, 6));
-    assert_eq!([ZERO, ZERO, ZERO, ZERO], get_hasher_state2(&dec_trace, 6));
+    assert_eq!(EMPTY_WORD, get_hasher_state2(&dec_trace, 6));
 
     // in the 7th row, we start the CALL block which has bar_join as its only child
     let bar_root_hash: Word = bar_root.hash().into();
     assert_eq!(bar_root_hash, get_hasher_state1(&dec_trace, 7));
-    assert_eq!([ZERO, ZERO, ZERO, ZERO], get_hasher_state2(&dec_trace, 7));
+    assert_eq!(EMPTY_WORD, get_hasher_state2(&dec_trace, 7));
 
     // in the 8th row, the hasher state is set to hashes of (bar_span, foo_call)
     let bar_span_hash: Word = bar_span.hash().into();
@@ -1257,16 +1257,16 @@ fn syscall_block() {
 
     // at the end of the bar_span, the hasher state is set to the hash of the first child
     assert_eq!(bar_span_hash, get_hasher_state1(&dec_trace, 12));
-    assert_eq!([ZERO, ZERO, ZERO, ZERO], get_hasher_state2(&dec_trace, 12));
+    assert_eq!(EMPTY_WORD, get_hasher_state2(&dec_trace, 12));
 
     // in the 13th row, we start the SYSCALL block which has foo_span as its only child
     let foo_root_hash: Word = foo_root.hash().into();
     assert_eq!(foo_root_hash, get_hasher_state1(&dec_trace, 13));
-    assert_eq!([ZERO, ZERO, ZERO, ZERO], get_hasher_state2(&dec_trace, 13));
+    assert_eq!(EMPTY_WORD, get_hasher_state2(&dec_trace, 13));
 
     // at the end of the foo_span_hash, the hasher state is set to the hash of the first child
     assert_eq!(foo_root_hash, get_hasher_state1(&dec_trace, 17));
-    assert_eq!([ZERO, ZERO, ZERO, ZERO], get_hasher_state2(&dec_trace, 17));
+    assert_eq!(EMPTY_WORD, get_hasher_state2(&dec_trace, 17));
 
     // SYSCALL block ends in the 18th row; the last element of the hasher state
     // is set to ONE because we are exiting a SYSCALL block
@@ -1275,7 +1275,7 @@ fn syscall_block() {
 
     // internal bar_join block ends in the 19th row
     assert_eq!(bar_root_hash, get_hasher_state1(&dec_trace, 19));
-    assert_eq!([ZERO, ZERO, ZERO, ZERO], get_hasher_state2(&dec_trace, 19));
+    assert_eq!(EMPTY_WORD, get_hasher_state2(&dec_trace, 19));
 
     // CALL block ends in the 20th row; the second to last element of the hasher state
     // is set to ONE because we are exiting a CALL block
@@ -1284,16 +1284,16 @@ fn syscall_block() {
 
     // internal JOIN block ends in the 21st row
     assert_eq!(inner_join_hash, get_hasher_state1(&dec_trace, 21));
-    assert_eq!([ZERO, ZERO, ZERO, ZERO], get_hasher_state2(&dec_trace, 21));
+    assert_eq!(EMPTY_WORD, get_hasher_state2(&dec_trace, 21));
 
     // last span ends in the 24th row
     assert_eq!(last_span_hash, get_hasher_state1(&dec_trace, 24));
-    assert_eq!([ZERO, ZERO, ZERO, ZERO], get_hasher_state2(&dec_trace, 24));
+    assert_eq!(EMPTY_WORD, get_hasher_state2(&dec_trace, 24));
 
     // the program ends in the 25th row
     let program_hash: Word = program.hash().into();
     assert_eq!(program_hash, get_hasher_state1(&dec_trace, 25));
-    assert_eq!([ZERO, ZERO, ZERO, ZERO], get_hasher_state2(&dec_trace, 25));
+    assert_eq!(EMPTY_WORD, get_hasher_state2(&dec_trace, 25));
 
     // HALT opcode and program hash gets propagated to the last row
     for i in 26..trace_len {
@@ -1395,7 +1395,7 @@ fn syscall_block() {
 
     // before the CALL operation is executed, we are in a root context and thus fn_hash is ZEROs.
     for i in 0..8 {
-        assert_eq!(get_fn_hash(&sys_trace, i), [ZERO; 4]);
+        assert_eq!(get_fn_hash(&sys_trace, i), EMPTY_WORD);
     }
 
     // inside the CALL block (and the invoked from it SYSCALL block), fn hash is set to the hash
@@ -1406,7 +1406,7 @@ fn syscall_block() {
 
     // after the CALL block is ended, we are back in the root context
     for i in 21..trace_len {
-        assert_eq!(get_fn_hash(&sys_trace, i), [ZERO; 4]);
+        assert_eq!(get_fn_hash(&sys_trace, i), EMPTY_WORD);
     }
 
     // --- check block execution hints ------------------------------------------------------------
@@ -1434,7 +1434,7 @@ fn syscall_block() {
 
     // --- check block stack table rows -----------------------------------------------------------
     let call_ctx =
-        ExecutionContextInfo::new(0, [ZERO; 4], FMP_MIN + ONE, 17, overflow_addr_after_pad);
+        ExecutionContextInfo::new(0, EMPTY_WORD, FMP_MIN + ONE, 17, overflow_addr_after_pad);
     let syscall_ctx = ExecutionContextInfo::new(8, bar_root_hash, FMP_MIN + TWO, 16, ZERO);
     let expected_rows = vec![
         BlockStackTableRow::new_test(INIT_ADDR, ZERO, false),
@@ -1623,7 +1623,7 @@ fn build_op_batch_flags(num_groups: usize) -> [Felt; NUM_OP_BATCH_FLAGS] {
 // ------------------------------------------------------------------------------------------------
 
 fn get_fn_hash(trace: &SystemTrace, row_idx: usize) -> Word {
-    let mut result = [ZERO; 4];
+    let mut result = EMPTY_WORD;
     let trace = &trace[FN_HASH_RANGE];
     for (element, column) in result.iter_mut().zip(trace) {
         *element = column[row_idx];
@@ -1650,7 +1650,7 @@ fn get_hasher_state(trace: &DecoderTrace, row_idx: usize) -> [Felt; NUM_HASHER_C
 }
 
 fn get_hasher_state1(trace: &DecoderTrace, row_idx: usize) -> Word {
-    let mut result = [ZERO; 4];
+    let mut result = EMPTY_WORD;
     for (result, column) in result.iter_mut().zip(trace[HASHER_STATE_RANGE].iter()) {
         *result = column[row_idx];
     }
@@ -1658,7 +1658,7 @@ fn get_hasher_state1(trace: &DecoderTrace, row_idx: usize) -> Word {
 }
 
 fn get_hasher_state2(trace: &DecoderTrace, row_idx: usize) -> Word {
-    let mut result = [ZERO; 4];
+    let mut result = EMPTY_WORD;
     for (result, column) in result.iter_mut().zip(trace[HASHER_STATE_RANGE].iter().skip(4)) {
         *result = column[row_idx];
     }

--- a/processor/src/decorators/adv_map_injectors.rs
+++ b/processor/src/decorators/adv_map_injectors.rs
@@ -2,7 +2,7 @@ use super::{AdviceProvider, ExecutionError, Process};
 use vm_core::{
     crypto::hash::{Rpo256, RpoDigest},
     utils::collections::Vec,
-    Felt, StarkField, WORD_SIZE, ZERO,
+    Felt, StarkField, EMPTY_WORD, WORD_SIZE,
 };
 
 // ADVICE INJECTORS
@@ -36,7 +36,7 @@ where
 
         let mut values = Vec::with_capacity(((end_addr - start_addr) as usize) * WORD_SIZE);
         for addr in start_addr..end_addr {
-            let mem_value = self.chiplets.get_mem_value(ctx, addr).unwrap_or([ZERO; WORD_SIZE]);
+            let mem_value = self.chiplets.get_mem_value(ctx, addr).unwrap_or(EMPTY_WORD);
             values.extend_from_slice(&mem_value);
         }
 

--- a/processor/src/decorators/tests.rs
+++ b/processor/src/decorators/tests.rs
@@ -1,5 +1,5 @@
 use super::{
-    super::{AdviceInputs, ExecutionOptions, Felt, FieldElement, Kernel, Operation, StarkField},
+    super::{AdviceInputs, ExecutionOptions, Felt, Kernel, Operation, StarkField},
     Process,
 };
 use crate::{MemAdviceProvider, StackInputs, Word};
@@ -11,7 +11,7 @@ use vm_core::{
     },
     utils::collections::Vec,
     utils::IntoBytes,
-    AdviceInjector, Decorator, ONE, ZERO,
+    AdviceInjector, Decorator, EMPTY_WORD, ONE, ZERO,
 };
 
 #[test]
@@ -52,7 +52,7 @@ fn push_merkle_node() {
         leaves[1][1],
         leaves[1][0],
         Felt::new(2),
-        Felt::new(1),
+        ONE,
         tree.root()[3],
         tree.root()[2],
         tree.root()[1],
@@ -165,13 +165,13 @@ fn inject_smtpeek() {
     let raw_b = 0b_11111111_11111111_00011111_11111111_10010110_10010011_11100000_00000000_u64;
     let key_b = build_key(raw_b);
     let process = prepare_smt_peek(key_b, &smt);
-    assert_eq!(build_expected(&[ZERO; 4]), process.stack.trace_state());
+    assert_eq!(build_expected(&EMPTY_WORD), process.stack.trace_state());
 
     // peeking another key with the same 16-bit prefix as key_a should return empty word
     let raw_c = 0b_00000000_11111111_10011111_11111111_10010110_10010011_11100000_00000000_u64;
     let key_c = build_key(raw_c);
     let process = prepare_smt_peek(key_c, &smt);
-    assert_eq!(build_expected(&[ZERO; 4]), process.stack.trace_state());
+    assert_eq!(build_expected(&EMPTY_WORD), process.stack.trace_state());
 }
 
 fn prepare_smt_peek(key: Word, smt: &TieredSmt) -> Process<MemAdviceProvider> {
@@ -188,7 +188,7 @@ fn prepare_smt_peek(key: Word, smt: &TieredSmt) -> Process<MemAdviceProvider> {
         .collect::<Vec<_>>();
     let advice_inputs = AdviceInputs::default().with_merkle_store(store).with_map(adv_map);
 
-    let stack_inputs = build_stack_inputs(key, root, [ZERO; 4]);
+    let stack_inputs = build_stack_inputs(key, root, EMPTY_WORD);
     let mut process = build_process(stack_inputs, advice_inputs);
 
     process.execute_op(Operation::Noop).unwrap();
@@ -274,11 +274,11 @@ fn prepare_smt_set(
 // ================================================================================================
 
 fn init_leaf(value: u64) -> Word {
-    [Felt::new(value), Felt::ZERO, Felt::ZERO, Felt::ZERO]
+    [Felt::new(value), ZERO, ZERO, ZERO]
 }
 
 fn build_expected(values: &[Felt]) -> [Felt; 16] {
-    let mut expected = [Felt::ZERO; 16];
+    let mut expected = [ZERO; 16];
     for (&value, result) in values.iter().zip(expected.iter_mut()) {
         *result = value
     }

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -11,7 +11,8 @@ use miden_air::trace::{
 pub use miden_air::{ExecutionOptions, ExecutionOptionsError};
 pub use vm_core::{
     chiplets::hasher::Digest, errors::InputError, utils::DeserializationError, AssemblyOp, Kernel,
-    Operation, Program, ProgramInfo, QuadExtension, StackInputs, StackOutputs, Word,
+    Operation, Program, ProgramInfo, QuadExtension, StackInputs, StackOutputs, Word, EMPTY_WORD,
+    ONE, ZERO,
 };
 use vm_core::{
     code_blocks::{
@@ -19,7 +20,7 @@ use vm_core::{
     },
     utils::collections::{BTreeMap, Vec},
     AdviceInjector, CodeBlockTable, Decorator, DecoratorIterator, Felt, FieldElement,
-    StackTopState, StarkField, ONE, ZERO,
+    StackTopState, StarkField,
 };
 
 use winter_prover::ColMatrix;

--- a/processor/src/operations/crypto_ops.rs
+++ b/processor/src/operations/crypto_ops.rs
@@ -172,10 +172,10 @@ where
 #[cfg(test)]
 mod tests {
     use super::{
-        super::{Felt, FieldElement, Operation, StarkField},
+        super::{Felt, Operation, StarkField},
         Process,
     };
-    use crate::{AdviceInputs, StackInputs, Word};
+    use crate::{AdviceInputs, StackInputs, Word, ZERO};
     use rand_utils::rand_vector;
     use vm_core::{
         chiplets::hasher::{apply_permutation, STATE_WIDTH},
@@ -409,11 +409,11 @@ mod tests {
     }
 
     fn init_node(value: u64) -> Word {
-        [Felt::new(value), Felt::ZERO, Felt::ZERO, Felt::ZERO]
+        [Felt::new(value), ZERO, ZERO, ZERO]
     }
 
     fn build_expected(values: &[Felt]) -> [Felt; 16] {
-        let mut expected = [Felt::ZERO; 16];
+        let mut expected = [ZERO; 16];
         for (&value, result) in values.iter().zip(expected.iter_mut()) {
             *result = value;
         }
@@ -421,7 +421,7 @@ mod tests {
     }
 
     fn build_expected_perm(values: &[u64]) -> [Felt; STATE_WIDTH] {
-        let mut expected = [Felt::ZERO; STATE_WIDTH];
+        let mut expected = [ZERO; STATE_WIDTH];
         for (&value, result) in values.iter().zip(expected.iter_mut()) {
             *result = Felt::new(value);
         }

--- a/processor/src/operations/ext2_ops.rs
+++ b/processor/src/operations/ext2_ops.rs
@@ -34,10 +34,10 @@ where
 mod tests {
     type QuadFelt = QuadExtension<Felt>;
     use super::{
-        super::{Felt, FieldElement, Operation, STACK_TOP_SIZE},
+        super::{Felt, Operation, STACK_TOP_SIZE},
         Process,
     };
-    use crate::StackInputs;
+    use crate::{StackInputs, ZERO};
     use rand_utils::rand_value;
     use vm_core::QuadExtension;
 
@@ -73,7 +73,7 @@ mod tests {
     // --------------------------------------------------------------------------------------------
 
     fn build_expected(values: &[Felt]) -> [Felt; 16] {
-        let mut expected = [Felt::ZERO; 16];
+        let mut expected = [ZERO; 16];
         for (&value, result) in values.iter().zip(expected.iter_mut()) {
             *result = value;
         }

--- a/processor/src/operations/field_ops.rs
+++ b/processor/src/operations/field_ops.rs
@@ -1,5 +1,5 @@
 use super::{utils::assert_binary, AdviceProvider, ExecutionError, Felt, FieldElement, Process};
-use vm_core::{Operation, StarkField, ZERO};
+use vm_core::{Operation, StarkField, ONE, ZERO};
 
 // FIELD OPERATIONS
 // ================================================================================================
@@ -46,7 +46,7 @@ where
     /// Returns an error if the value on the top of the stack is ZERO.
     pub(super) fn op_inv(&mut self) -> Result<(), ExecutionError> {
         let a = self.stack.get(0);
-        if a == Felt::ZERO {
+        if a == ZERO {
             return Err(ExecutionError::DivideByZero(self.system.clk()));
         }
 
@@ -58,7 +58,7 @@ where
     /// Pops an element off the stack, adds ONE to it, and pushes the result back onto the stack.
     pub(super) fn op_incr(&mut self) -> Result<(), ExecutionError> {
         let a = self.stack.get(0);
-        self.stack.set(0, a + Felt::ONE);
+        self.stack.set(0, a + ONE);
         self.stack.copy_state(1);
         Ok(())
     }
@@ -75,10 +75,10 @@ where
     pub(super) fn op_and(&mut self) -> Result<(), ExecutionError> {
         let b = assert_binary(self.stack.get(0))?;
         let a = assert_binary(self.stack.get(1))?;
-        if a == Felt::ONE && b == Felt::ONE {
-            self.stack.set(0, Felt::ONE);
+        if a == ONE && b == ONE {
+            self.stack.set(0, ONE);
         } else {
-            self.stack.set(0, Felt::ZERO);
+            self.stack.set(0, ZERO);
         }
         self.stack.shift_left(2);
         Ok(())
@@ -93,10 +93,10 @@ where
     pub(super) fn op_or(&mut self) -> Result<(), ExecutionError> {
         let b = assert_binary(self.stack.get(0))?;
         let a = assert_binary(self.stack.get(1))?;
-        if a == Felt::ONE || b == Felt::ONE {
-            self.stack.set(0, Felt::ONE);
+        if a == ONE || b == ONE {
+            self.stack.set(0, ONE);
         } else {
-            self.stack.set(0, Felt::ZERO);
+            self.stack.set(0, ZERO);
         }
         self.stack.shift_left(2);
         Ok(())
@@ -109,7 +109,7 @@ where
     /// Returns an error if the value on the top of the stack is not a binary value.
     pub(super) fn op_not(&mut self) -> Result<(), ExecutionError> {
         let a = assert_binary(self.stack.get(0))?;
-        self.stack.set(0, Felt::ONE - a);
+        self.stack.set(0, ONE - a);
         self.stack.copy_state(1);
         Ok(())
     }
@@ -128,9 +128,9 @@ where
         let mut h0 = ZERO;
 
         if a == b {
-            self.stack.set(0, Felt::ONE);
+            self.stack.set(0, ONE);
         } else {
-            self.stack.set(0, Felt::ZERO);
+            self.stack.set(0, ZERO);
             // setting h0 to the inverse of the difference between the top two elements of the stack.
             h0 = (b - a).inv();
         }
@@ -151,12 +151,12 @@ where
         // otherwise set it to the inverse of the top element in the stack.
         let mut h0 = ZERO;
 
-        if a == Felt::ZERO {
-            self.stack.set(0, Felt::ONE);
+        if a == ZERO {
+            self.stack.set(0, ONE);
         } else {
             // setting h0 to the inverse of the top element of the stack.
             h0 = a.inv();
-            self.stack.set(0, Felt::ZERO);
+            self.stack.set(0, ZERO);
         }
 
         // save h0 in the decoder helper register.
@@ -295,7 +295,7 @@ mod tests {
         let mut process = Process::new_dummy(stack);
 
         // invert the top value
-        if b != Felt::ZERO {
+        if b != ZERO {
             process.execute_op(Operation::Inv).unwrap();
             let expected = build_expected(&[a.inv(), b, c]);
 
@@ -318,7 +318,7 @@ mod tests {
 
         // negate the top value
         process.execute_op(Operation::Incr).unwrap();
-        let expected = build_expected(&[a + Felt::ONE, b, c]);
+        let expected = build_expected(&[a + ONE, b, c]);
 
         assert_eq!(STACK_TOP_SIZE, process.stack.depth());
         assert_eq!(2, process.stack.current_clk());
@@ -335,7 +335,7 @@ mod tests {
         let mut process = Process::new_dummy(stack);
 
         process.execute_op(Operation::And).unwrap();
-        let expected = build_expected(&[Felt::ZERO, Felt::new(2)]);
+        let expected = build_expected(&[ZERO, Felt::new(2)]);
         assert_eq!(expected, process.stack.trace_state());
 
         // --- test 1 AND 0 ---------------------------------------------------
@@ -343,7 +343,7 @@ mod tests {
         let mut process = Process::new_dummy(stack);
 
         process.execute_op(Operation::And).unwrap();
-        let expected = build_expected(&[Felt::ZERO, Felt::new(2)]);
+        let expected = build_expected(&[ZERO, Felt::new(2)]);
         assert_eq!(expected, process.stack.trace_state());
 
         // --- test 0 AND 1 ---------------------------------------------------
@@ -351,7 +351,7 @@ mod tests {
         let mut process = Process::new_dummy(stack);
 
         process.execute_op(Operation::And).unwrap();
-        let expected = build_expected(&[Felt::ZERO, Felt::new(2)]);
+        let expected = build_expected(&[ZERO, Felt::new(2)]);
         assert_eq!(expected, process.stack.trace_state());
 
         // --- test 1 AND 1 ---------------------------------------------------
@@ -359,7 +359,7 @@ mod tests {
         let mut process = Process::new_dummy(stack);
 
         process.execute_op(Operation::And).unwrap();
-        let expected = build_expected(&[Felt::ONE, Felt::new(2)]);
+        let expected = build_expected(&[ONE, Felt::new(2)]);
         assert_eq!(expected, process.stack.trace_state());
 
         // --- first operand is not binary ------------------------------------
@@ -384,7 +384,7 @@ mod tests {
         let mut process = Process::new_dummy(stack);
 
         process.execute_op(Operation::Or).unwrap();
-        let expected = build_expected(&[Felt::ZERO, Felt::new(2)]);
+        let expected = build_expected(&[ZERO, Felt::new(2)]);
         assert_eq!(expected, process.stack.trace_state());
 
         // --- test 1 OR 0 ---------------------------------------------------
@@ -392,7 +392,7 @@ mod tests {
         let mut process = Process::new_dummy(stack);
 
         process.execute_op(Operation::Or).unwrap();
-        let expected = build_expected(&[Felt::ONE, Felt::new(2)]);
+        let expected = build_expected(&[ONE, Felt::new(2)]);
         assert_eq!(expected, process.stack.trace_state());
 
         // --- test 0 OR 1 ---------------------------------------------------
@@ -400,7 +400,7 @@ mod tests {
         let mut process = Process::new_dummy(stack);
 
         process.execute_op(Operation::Or).unwrap();
-        let expected = build_expected(&[Felt::ONE, Felt::new(2)]);
+        let expected = build_expected(&[ONE, Felt::new(2)]);
         assert_eq!(expected, process.stack.trace_state());
 
         // --- test 1 OR 0 ---------------------------------------------------
@@ -408,7 +408,7 @@ mod tests {
         let mut process = Process::new_dummy(stack);
 
         process.execute_op(Operation::Or).unwrap();
-        let expected = build_expected(&[Felt::ONE, Felt::new(2)]);
+        let expected = build_expected(&[ONE, Felt::new(2)]);
         assert_eq!(expected, process.stack.trace_state());
 
         // --- first operand is not binary ------------------------------------
@@ -432,14 +432,14 @@ mod tests {
         let stack = StackInputs::try_from_values([2, 0]).unwrap();
         let mut process = Process::new_dummy(stack);
         process.execute_op(Operation::Not).unwrap();
-        let expected = build_expected(&[Felt::ONE, Felt::new(2)]);
+        let expected = build_expected(&[ONE, Felt::new(2)]);
         assert_eq!(expected, process.stack.trace_state());
 
         // --- test NOT 1 ----------------------------------------------------
         let stack = StackInputs::try_from_values([2, 1]).unwrap();
         let mut process = Process::new_dummy(stack);
         process.execute_op(Operation::Not).unwrap();
-        let expected = build_expected(&[Felt::ZERO, Felt::new(2)]);
+        let expected = build_expected(&[ZERO, Felt::new(2)]);
         assert_eq!(expected, process.stack.trace_state());
 
         // --- operand is not binary ------------------------------------------
@@ -460,7 +460,7 @@ mod tests {
             Process::new_dummy_with_inputs_and_decoder_helpers(stack_inputs, advice_inputs);
 
         process.execute_op(Operation::Eq).unwrap();
-        let expected = build_expected(&[Felt::ONE, Felt::new(3)]);
+        let expected = build_expected(&[ONE, Felt::new(3)]);
         assert_eq!(expected, process.stack.trace_state());
 
         // --- test when top two values are not equal -------------------------
@@ -470,7 +470,7 @@ mod tests {
             Process::new_dummy_with_inputs_and_decoder_helpers(stack_inputs, advice_inputs);
 
         process.execute_op(Operation::Eq).unwrap();
-        let expected = build_expected(&[Felt::ZERO, Felt::new(3)]);
+        let expected = build_expected(&[ZERO, Felt::new(3)]);
         assert_eq!(expected, process.stack.trace_state());
 
         // --- calling EQ with a stack of minimum depth is a ok ---------------
@@ -490,7 +490,7 @@ mod tests {
             Process::new_dummy_with_inputs_and_decoder_helpers(stack_inputs, advice_inputs);
 
         process.execute_op(Operation::Eqz).unwrap();
-        let expected = build_expected(&[Felt::ONE, Felt::new(3)]);
+        let expected = build_expected(&[ONE, Felt::new(3)]);
         assert_eq!(expected, process.stack.trace_state());
 
         // --- test when top is not zero --------------------------------------
@@ -500,7 +500,7 @@ mod tests {
             Process::new_dummy_with_inputs_and_decoder_helpers(stack_inputs, advice_inputs);
 
         process.execute_op(Operation::Eqz).unwrap();
-        let expected = build_expected(&[Felt::ZERO, Felt::new(3)]);
+        let expected = build_expected(&[ZERO, Felt::new(3)]);
         assert_eq!(expected, process.stack.trace_state());
     }
 
@@ -567,7 +567,7 @@ mod tests {
     }
 
     fn build_expected(values: &[Felt]) -> [Felt; 16] {
-        let mut expected = [Felt::ZERO; 16];
+        let mut expected = [ZERO; 16];
         for (&value, result) in values.iter().zip(expected.iter_mut()) {
             *result = value;
         }

--- a/processor/src/operations/fri_ops.rs
+++ b/processor/src/operations/fri_ops.rs
@@ -192,7 +192,7 @@ where
 /// Determines tau factor (needed to compute x value) for the specified domain segment.
 fn get_tau_factor(domain_segment: usize) -> Felt {
     match domain_segment {
-        0 => Felt::ONE,
+        0 => ONE,
         1 => TAU_INV,
         2 => TAU2_INV,
         3 => TAU3_INV,

--- a/processor/src/operations/stack_ops.rs
+++ b/processor/src/operations/stack_ops.rs
@@ -1,6 +1,5 @@
-use super::{
-    AdviceProvider, ExecutionError, Felt, FieldElement, Process, StarkField, STACK_TOP_SIZE,
-};
+use super::{AdviceProvider, ExecutionError, Process, StarkField, STACK_TOP_SIZE};
+use crate::ZERO;
 
 impl<A> Process<A>
 where
@@ -10,7 +9,7 @@ where
     // --------------------------------------------------------------------------------------------
     /// Pushes a ZERO onto the stack.
     pub(super) fn op_pad(&mut self) -> Result<(), ExecutionError> {
-        self.stack.set(0, Felt::ZERO);
+        self.stack.set(0, ZERO);
         self.stack.shift_right(0);
         Ok(())
     }
@@ -304,10 +303,10 @@ where
 #[cfg(test)]
 mod tests {
     use super::{
-        super::{FieldElement, Operation, Process},
-        Felt, STACK_TOP_SIZE,
+        super::{Operation, Process},
+        STACK_TOP_SIZE,
     };
-    use crate::StackInputs;
+    use crate::{Felt, StackInputs, ONE, ZERO};
 
     #[test]
     fn op_pad() {
@@ -315,7 +314,7 @@ mod tests {
         let mut process = Process::new_dummy(stack);
 
         // push one item onto the stack
-        process.execute_op(Operation::Push(Felt::ONE)).unwrap();
+        process.execute_op(Operation::Push(ONE)).unwrap();
         let expected = build_expected(&[1]);
         assert_eq!(expected, process.stack.trace_state());
 
@@ -341,7 +340,7 @@ mod tests {
         // push a few items onto the stack
         let stack = StackInputs::default();
         let mut process = Process::new_dummy(stack);
-        process.execute_op(Operation::Push(Felt::ONE)).unwrap();
+        process.execute_op(Operation::Push(ONE)).unwrap();
         process.execute_op(Operation::Push(Felt::new(2))).unwrap();
 
         // drop the first value
@@ -366,7 +365,7 @@ mod tests {
         let mut process = Process::new_dummy(stack);
 
         // push one item onto the stack
-        process.execute_op(Operation::Push(Felt::ONE)).unwrap();
+        process.execute_op(Operation::Push(ONE)).unwrap();
         let expected = build_expected(&[1]);
         assert_eq!(expected, process.stack.trace_state());
 
@@ -381,7 +380,7 @@ mod tests {
         process.execute_op(Operation::Drop).unwrap();
 
         // put 15 more items onto the stack
-        let mut expected = [Felt::ONE; 16];
+        let mut expected = [ONE; 16];
         for i in 2..17 {
             process.execute_op(Operation::Push(Felt::new(i))).unwrap();
             expected[16 - i as usize] = Felt::new(i);
@@ -390,13 +389,13 @@ mod tests {
 
         // duplicate last stack item
         process.execute_op(Operation::Dup15).unwrap();
-        assert_eq!(Felt::ONE, process.stack.trace_state()[0]);
+        assert_eq!(ONE, process.stack.trace_state()[0]);
         assert_eq!(&expected[..15], &process.stack.trace_state()[1..]);
 
         // duplicate 8th stack item
         process.execute_op(Operation::Dup7).unwrap();
         assert_eq!(Felt::new(10), process.stack.trace_state()[0]);
-        assert_eq!(Felt::new(1), process.stack.trace_state()[1]);
+        assert_eq!(ONE, process.stack.trace_state()[1]);
         assert_eq!(&expected[..14], &process.stack.trace_state()[2..]);
 
         // remove 4 items off the stack
@@ -408,8 +407,8 @@ mod tests {
         assert_eq!(STACK_TOP_SIZE + 15, process.stack.depth());
 
         assert_eq!(&expected[2..], &process.stack.trace_state()[..14]);
-        assert_eq!(Felt::ONE, process.stack.trace_state()[14]);
-        assert_eq!(Felt::ZERO, process.stack.trace_state()[15]);
+        assert_eq!(ONE, process.stack.trace_state()[14]);
+        assert_eq!(ZERO, process.stack.trace_state()[15]);
     }
 
     #[test]
@@ -602,7 +601,7 @@ mod tests {
     // --------------------------------------------------------------------------------------------
 
     fn build_expected(values: &[u64]) -> [Felt; 16] {
-        let mut expected = [Felt::ZERO; 16];
+        let mut expected = [ZERO; 16];
         for (&value, result) in values.iter().zip(expected.iter_mut()) {
             *result = Felt::new(value);
         }

--- a/processor/src/operations/sys_ops.rs
+++ b/processor/src/operations/sys_ops.rs
@@ -1,6 +1,9 @@
 use super::{
-    super::system::{FMP_MAX, FMP_MIN},
-    AdviceProvider, ExecutionError, Felt, FieldElement, Process, StarkField,
+    super::{
+        system::{FMP_MAX, FMP_MIN},
+        ONE,
+    },
+    AdviceProvider, ExecutionError, Felt, Process, StarkField,
 };
 
 // SYSTEM OPERATIONS
@@ -15,7 +18,7 @@ where
     /// # Errors
     /// Returns an error if the popped value is not ONE.
     pub(super) fn op_assert(&mut self) -> Result<(), ExecutionError> {
-        if self.stack.get(0) != Felt::ONE {
+        if self.stack.get(0) != ONE {
             return Err(ExecutionError::FailedAssertion(self.system.clk()));
         }
         self.stack.shift_left(1);
@@ -112,10 +115,8 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        super::Operation, super::STACK_TOP_SIZE, Felt, FieldElement, Process, FMP_MAX, FMP_MIN,
-    };
-    use crate::StackInputs;
+    use super::{super::Operation, super::STACK_TOP_SIZE, Felt, Process, FMP_MAX, FMP_MIN};
+    use crate::{StackInputs, ONE, ZERO};
 
     const MAX_PROC_LOCALS: u64 = 2_u64.pow(31) - 1;
 
@@ -123,7 +124,7 @@ mod tests {
     fn op_assert() {
         // calling assert with a minimum stack should be an ok, as long as the top value is ONE
         let mut process = Process::new_dummy_with_empty_stack();
-        process.execute_op(Operation::Push(Felt::ONE)).unwrap();
+        process.execute_op(Operation::Push(ONE)).unwrap();
         process.execute_op(Operation::Swap).unwrap();
         process.execute_op(Operation::Drop).unwrap();
 
@@ -189,7 +190,7 @@ mod tests {
         process.execute_op(Operation::FmpUpdate).unwrap();
 
         // compute address of the first local
-        process.execute_op(Operation::Push(-Felt::new(1))).unwrap();
+        process.execute_op(Operation::Push(-ONE)).unwrap();
         process.execute_op(Operation::FmpAdd).unwrap();
 
         let expected = build_expected_stack(&[FMP_MIN + 1]);
@@ -257,7 +258,7 @@ mod tests {
     // --------------------------------------------------------------------------------------------
 
     fn build_expected_stack(values: &[u64]) -> [Felt; 16] {
-        let mut expected = [Felt::ZERO; 16];
+        let mut expected = [ZERO; 16];
         for (&value, result) in values.iter().zip(expected.iter_mut()) {
             *result = Felt::new(value);
         }

--- a/processor/src/operations/u32_ops.rs
+++ b/processor/src/operations/u32_ops.rs
@@ -2,6 +2,7 @@ use super::{
     super::utils::{split_element, split_u32_into_u16},
     AdviceProvider, ExecutionError, Felt, FieldElement, Operation, Process, StarkField,
 };
+use crate::ZERO;
 
 impl<A> Process<A>
 where
@@ -92,7 +93,7 @@ where
         // Force this operation to consume 4 range checks, even though only `lo` is needed.
         // This is required for making the constraints more uniform and grouping the opcodes of
         // operations requiring range checks under a common degree-4 prefix.
-        self.add_range_checks(Operation::U32sub, c, Felt::ZERO, false);
+        self.add_range_checks(Operation::U32sub, c, ZERO, false);
 
         self.stack.set(0, d);
         self.stack.set(1, c);
@@ -214,7 +215,7 @@ where
 
         // save the range check lookups to the decoder's user operation helper columns.
         let mut helper_values =
-            [Felt::from(t0), Felt::from(t1), Felt::from(t2), Felt::from(t3), Felt::ZERO];
+            [Felt::from(t0), Felt::from(t1), Felt::from(t2), Felt::from(t3), ZERO];
 
         if check_element_validity {
             let m = (Felt::from(u32::MAX) - hi).inv();
@@ -231,10 +232,10 @@ where
 #[cfg(test)]
 mod tests {
     use super::{
-        super::{Felt, FieldElement, Operation},
+        super::{Felt, Operation},
         split_u32_into_u16, Process,
     };
-    use crate::StackInputs;
+    use crate::{StackInputs, ZERO};
     use miden_air::trace::{decoder::NUM_USER_OP_HELPERS, stack::STACK_TOP_SIZE};
     use rand_utils::rand_value;
 
@@ -251,7 +252,7 @@ mod tests {
         let lo = (a as u32) as u64;
 
         process.execute_op(Operation::U32split).unwrap();
-        let mut expected = [Felt::ZERO; 16];
+        let mut expected = [ZERO; 16];
         expected[0] = Felt::new(hi);
         expected[1] = Felt::new(lo);
         assert_eq!(expected, process.stack.trace_state());
@@ -264,7 +265,7 @@ mod tests {
         let lo = (b as u32) as u64;
 
         process.execute_op(Operation::U32split).unwrap();
-        let mut expected = [Felt::ZERO; 16];
+        let mut expected = [ZERO; 16];
         expected[0] = Felt::new(hi);
         expected[1] = Felt::new(lo);
         expected[2] = Felt::new(a);
@@ -455,7 +456,7 @@ mod tests {
     }
 
     fn build_expected(values: &[u32]) -> [Felt; STACK_TOP_SIZE] {
-        let mut expected = [Felt::ZERO; STACK_TOP_SIZE];
+        let mut expected = [ZERO; STACK_TOP_SIZE];
         for (&value, result) in values.iter().zip(expected.iter_mut()) {
             *result = Felt::new(value as u64);
         }
@@ -463,7 +464,7 @@ mod tests {
     }
 
     fn build_expected_helper_registers(values: &[u32]) -> [Felt; NUM_USER_OP_HELPERS] {
-        let mut expected = [Felt::ZERO; NUM_USER_OP_HELPERS];
+        let mut expected = [ZERO; NUM_USER_OP_HELPERS];
         for (&value, result) in values.iter().zip(expected.iter_mut()) {
             *result = Felt::new(value as u64);
         }

--- a/processor/src/operations/utils.rs
+++ b/processor/src/operations/utils.rs
@@ -1,9 +1,10 @@
-use super::{ExecutionError, Felt, FieldElement};
+use super::{ExecutionError, Felt};
+use crate::{ONE, ZERO};
 
 /// TODO: add docs
 #[inline(always)]
 pub fn assert_binary(value: Felt) -> Result<Felt, ExecutionError> {
-    if value != Felt::ZERO && value != Felt::ONE {
+    if value != ZERO && value != ONE {
         Err(ExecutionError::NotBinaryValue(value))
     } else {
         Ok(value)

--- a/processor/src/stack/tests.rs
+++ b/processor/src/stack/tests.rs
@@ -53,7 +53,7 @@ fn initialize_overflow() {
     ];
     let init_addr = Felt::MODULUS - 3;
     let expected_overflow_rows = vec![
-        OverflowTableRow::new(init_addr, Felt::new(1), ZERO),
+        OverflowTableRow::new(init_addr, ONE, ZERO),
         OverflowTableRow::new(init_addr + 1, Felt::new(2), Felt::new(init_addr)),
         OverflowTableRow::new(init_addr + 2, Felt::new(3), Felt::new(init_addr + 1)),
     ];

--- a/processor/src/system/mod.rs
+++ b/processor/src/system/mod.rs
@@ -1,4 +1,6 @@
-use super::{ExecutionError, Felt, FieldElement, StarkField, SysTrace, Vec, Word, ONE, ZERO};
+use super::{
+    ExecutionError, Felt, FieldElement, StarkField, SysTrace, Vec, Word, EMPTY_WORD, ONE, ZERO,
+};
 
 #[cfg(test)]
 mod tests;
@@ -65,7 +67,7 @@ impl System {
             ctx: 0,
             fmp,
             in_syscall: false,
-            fn_hash: [ZERO; 4],
+            fn_hash: EMPTY_WORD,
             clk_trace: Felt::zeroed_vector(init_trace_capacity),
             ctx_trace: Felt::zeroed_vector(init_trace_capacity),
             fmp_trace,
@@ -265,7 +267,7 @@ impl System {
 
         // complete the fn hash columns by filling them with ZEROs as program execution must always
         // end in the root context.
-        debug_assert_eq!(self.fn_hash, [ZERO; 4]);
+        debug_assert_eq!(self.fn_hash, EMPTY_WORD);
         for mut column in self.fn_hash_trace.into_iter() {
             column.resize(trace_len, ZERO);
             trace.push(column);

--- a/processor/src/trace/decoder/tests.rs
+++ b/processor/src/trace/decoder/tests.rs
@@ -620,7 +620,7 @@ fn decoder_p3_trace_one_batch() {
         OpGroupTableRow::new(ONE, Felt::new(3), ONE).to_value(&trace.main_trace, &alphas);
     let g2_value =
         OpGroupTableRow::new(ONE, Felt::new(2), Felt::new(2)).to_value(&trace.main_trace, &alphas);
-    let g3_value = OpGroupTableRow::new(ONE, Felt::new(1), build_op_group(&ops[9..]))
+    let g3_value = OpGroupTableRow::new(ONE, ONE, build_op_group(&ops[9..]))
         .to_value(&trace.main_trace, &alphas);
     let expected_value = g1_value * g2_value * g3_value;
     assert_eq!(expected_value, p3[1]);
@@ -703,8 +703,7 @@ fn decoder_p3_trace_two_batches() {
     let b1_values = [
         OpGroupTableRow::new(batch1_addr, Felt::new(3), iv[7]).to_value(&trace.main_trace, &alphas),
         OpGroupTableRow::new(batch1_addr, Felt::new(2), iv[8]).to_value(&trace.main_trace, &alphas),
-        OpGroupTableRow::new(batch1_addr, Felt::new(1), op_group3)
-            .to_value(&trace.main_trace, &alphas),
+        OpGroupTableRow::new(batch1_addr, ONE, op_group3).to_value(&trace.main_trace, &alphas),
     ];
     let mut expected_value: Felt = b1_values.iter().fold(ONE, |acc, &val| acc * val);
     assert_eq!(expected_value, p3[10]);

--- a/processor/src/trace/mod.rs
+++ b/processor/src/trace/mod.rs
@@ -26,6 +26,8 @@ mod decoder;
 
 #[cfg(test)]
 mod tests;
+#[cfg(test)]
+use super::EMPTY_WORD;
 
 // CONSTANTS
 // ================================================================================================
@@ -180,7 +182,7 @@ impl ExecutionTrace {
     where
         A: AdviceProvider,
     {
-        let rng = RpoRandomCoin::new(&[ZERO; 4]);
+        let rng = RpoRandomCoin::new(&EMPTY_WORD);
         finalize_trace(process, rng)
     }
 }

--- a/processor/src/trace/tests/chiplets/hasher.rs
+++ b/processor/src/trace/tests/chiplets/hasher.rs
@@ -682,7 +682,7 @@ fn extract_control_block_domain_from_trace(trace: &ExecutionTrace, row: usize) -
     if control_block_initializers.contains(&opcode_value) {
         Felt::from(opcode_value)
     } else {
-        Felt::ZERO
+        ZERO
     }
 }
 
@@ -705,5 +705,5 @@ fn init_leaves(values: &[u64]) -> Vec<Word> {
 
 /// Initializes a Merkle tree leaf with the specified value.
 fn init_leaf(value: u64) -> Word {
-    [Felt::new(value), Felt::ZERO, Felt::ZERO, Felt::ZERO]
+    [Felt::new(value), ZERO, ZERO, ZERO]
 }

--- a/processor/src/trace/tests/range.rs
+++ b/processor/src/trace/tests/range.rs
@@ -25,8 +25,8 @@ fn b_range_trace_stack() {
     // --- Check the stack processor's range check lookups. ---------------------------------------
 
     // Before any range checks are executed, the value in b_range should be one.
-    assert_eq!(Felt::ONE, b_range[0]);
-    assert_eq!(Felt::ONE, b_range[1]);
+    assert_eq!(ONE, b_range[0]);
+    assert_eq!(ONE, b_range[1]);
 
     // The first range check lookup from the stack will happen when the add operation is executed,
     // at cycle 1. (The trace begins by executing `span`). It must be subtracted out of `b_range`.
@@ -61,7 +61,7 @@ fn b_range_trace_stack() {
     // --- Check the last value of the b_range column is one. ------------------------------------------
 
     let last_row = b_range.len() - NUM_RAND_ROWS - 1;
-    assert_eq!(Felt::ONE, b_range[last_row]);
+    assert_eq!(ONE, b_range[last_row]);
 }
 
 /// This test checks that range check lookups from memory operations are balanced by the

--- a/prover/src/gpu.rs
+++ b/prover/src/gpu.rs
@@ -12,7 +12,7 @@ use pollster::block_on;
 use processor::{
     crypto::{RandomCoin, Rpo256, RpoDigest},
     math::{fft, Felt},
-    ExecutionTrace,
+    ExecutionTrace, ONE,
 };
 use std::time::Instant;
 use winter_prover::{
@@ -108,7 +108,7 @@ where
                 let rpo_pad_column = num_base_columns % RPO_RATE;
                 rpo_padded_segment = unsafe { page_aligned_uninit_vector(lde_domain_size) };
                 rpo_padded_segment.copy_from_slice(segment);
-                rpo_padded_segment.iter_mut().for_each(|row| row[rpo_pad_column] = Felt::ONE);
+                rpo_padded_segment.iter_mut().for_each(|row| row[rpo_pad_column] = ONE);
                 row_hasher.update(&rpo_padded_segment);
                 assert!(lde_segment_iter.next().is_none(), "padded segment should be the last");
                 break;
@@ -200,7 +200,7 @@ where
                 let rpo_pad_column = num_base_columns % RPO_RATE;
                 rpo_padded_segment = unsafe { page_aligned_uninit_vector(lde_domain_size) };
                 rpo_padded_segment.copy_from_slice(segment);
-                rpo_padded_segment.iter_mut().for_each(|row| row[rpo_pad_column] = Felt::ONE);
+                rpo_padded_segment.iter_mut().for_each(|row| row[rpo_pad_column] = ONE);
                 row_hasher.update(&rpo_padded_segment);
                 assert_eq!(segments.len() - 1, segment_idx, "padded segment should be the last");
                 break;

--- a/stdlib/tests/collections/mmr.rs
+++ b/stdlib/tests/collections/mmr.rs
@@ -3,7 +3,7 @@ use test_utils::{
         init_merkle_leaf, init_merkle_leaves, MerkleError, MerkleStore, MerkleTree, Mmr, NodeIndex,
         RpoDigest,
     },
-    hash_elements, stack_to_ints, Felt, StarkField, Word, ZERO,
+    hash_elements, stack_to_ints, Felt, StarkField, Word, EMPTY_WORD, ONE, ZERO,
 };
 
 // TESTS
@@ -345,23 +345,23 @@ fn test_mmr_unpack() {
     let hash_data: [[Felt; 4]; 16] = [
         // 3 peaks. These hashes are invalid, we can't produce data for any of these peaks (only
         // for testing)
-        [ZERO, ZERO, ZERO, Felt::new(1)],
+        [ZERO, ZERO, ZERO, ONE],
         [ZERO, ZERO, ZERO, Felt::new(2)],
         [ZERO, ZERO, ZERO, Felt::new(3)],
         // Padding, the MMR is padded to a minimum length o 16
-        [ZERO, ZERO, ZERO, ZERO],
-        [ZERO, ZERO, ZERO, ZERO],
-        [ZERO, ZERO, ZERO, ZERO],
-        [ZERO, ZERO, ZERO, ZERO],
-        [ZERO, ZERO, ZERO, ZERO],
-        [ZERO, ZERO, ZERO, ZERO],
-        [ZERO, ZERO, ZERO, ZERO],
-        [ZERO, ZERO, ZERO, ZERO],
-        [ZERO, ZERO, ZERO, ZERO],
-        [ZERO, ZERO, ZERO, ZERO],
-        [ZERO, ZERO, ZERO, ZERO],
-        [ZERO, ZERO, ZERO, ZERO],
-        [ZERO, ZERO, ZERO, ZERO],
+        EMPTY_WORD,
+        EMPTY_WORD,
+        EMPTY_WORD,
+        EMPTY_WORD,
+        EMPTY_WORD,
+        EMPTY_WORD,
+        EMPTY_WORD,
+        EMPTY_WORD,
+        EMPTY_WORD,
+        EMPTY_WORD,
+        EMPTY_WORD,
+        EMPTY_WORD,
+        EMPTY_WORD,
     ];
     let hash = hash_elements(&hash_data.concat());
 
@@ -407,23 +407,23 @@ fn test_mmr_unpack_invalid_hash() {
     let mut hash_data: [[Felt; 4]; 16] = [
         // 3 peaks. These hashes are invalid, we can't produce data for any of these peaks (only
         // for testing)
-        [ZERO, ZERO, ZERO, Felt::new(1)],
+        [ZERO, ZERO, ZERO, ONE],
         [ZERO, ZERO, ZERO, Felt::new(2)],
         [ZERO, ZERO, ZERO, Felt::new(3)],
         // Padding, the MMR is padded to a minimum length o 16
-        [ZERO, ZERO, ZERO, ZERO],
-        [ZERO, ZERO, ZERO, ZERO],
-        [ZERO, ZERO, ZERO, ZERO],
-        [ZERO, ZERO, ZERO, ZERO],
-        [ZERO, ZERO, ZERO, ZERO],
-        [ZERO, ZERO, ZERO, ZERO],
-        [ZERO, ZERO, ZERO, ZERO],
-        [ZERO, ZERO, ZERO, ZERO],
-        [ZERO, ZERO, ZERO, ZERO],
-        [ZERO, ZERO, ZERO, ZERO],
-        [ZERO, ZERO, ZERO, ZERO],
-        [ZERO, ZERO, ZERO, ZERO],
-        [ZERO, ZERO, ZERO, ZERO],
+        EMPTY_WORD,
+        EMPTY_WORD,
+        EMPTY_WORD,
+        EMPTY_WORD,
+        EMPTY_WORD,
+        EMPTY_WORD,
+        EMPTY_WORD,
+        EMPTY_WORD,
+        EMPTY_WORD,
+        EMPTY_WORD,
+        EMPTY_WORD,
+        EMPTY_WORD,
+        EMPTY_WORD,
     ];
     let hash = hash_elements(&hash_data.concat());
 
@@ -438,7 +438,7 @@ fn test_mmr_unpack_invalid_hash() {
     let store = MerkleStore::new();
 
     // corrupt the data, this changes the hash and the commitment check must fail
-    hash_data[0][0] = hash_data[0][0] + Felt::new(1);
+    hash_data[0][0] = hash_data[0][0] + ONE;
 
     let mut map_data: Vec<Felt> = Vec::with_capacity(hash_data.len() + 1);
     map_data.extend_from_slice(&[Felt::new(0b10101), ZERO, ZERO, ZERO]); // 3 peaks, 21 leaves
@@ -467,7 +467,7 @@ fn test_mmr_unpack_large_mmr() {
     let hash_data: [[Felt; 4]; 18] = [
         // These hashes are invalid, we can't produce data for any of these peaks (only for
         // testing)
-        [ZERO, ZERO, ZERO, Felt::new(1)],
+        [ZERO, ZERO, ZERO, ONE],
         [ZERO, ZERO, ZERO, Felt::new(2)],
         [ZERO, ZERO, ZERO, Felt::new(3)],
         [ZERO, ZERO, ZERO, Felt::new(4)],
@@ -485,7 +485,7 @@ fn test_mmr_unpack_large_mmr() {
         [ZERO, ZERO, ZERO, Felt::new(16)],
         // Padding, peaks greater than 16 are padded to an even number
         [ZERO, ZERO, ZERO, Felt::new(17)],
-        [ZERO, ZERO, ZERO, ZERO],
+        EMPTY_WORD,
     ];
     let hash = hash_elements(&hash_data.concat());
 
@@ -617,7 +617,7 @@ fn test_mmr_pack() {
 
     #[rustfmt::skip]
     hash_data.extend_from_slice( &[
-        Felt::new(1), ZERO, ZERO, ZERO, // peak1
+        ONE, ZERO, ZERO, ZERO, // peak1
         Felt::new(2), ZERO, ZERO, ZERO, // peak2
     ]);
     hash_data.resize(16 * 4, ZERO); // padding data
@@ -680,7 +680,7 @@ fn test_mmr_two() {
     );
 
     let mut mmr = Mmr::new();
-    mmr.add([Felt::new(1), Felt::new(2), Felt::new(3), Felt::new(4)].into());
+    mmr.add([ONE, Felt::new(2), Felt::new(3), Felt::new(4)].into());
     mmr.add([Felt::new(5), Felt::new(6), Felt::new(7), Felt::new(8)].into());
 
     let accumulator = mmr.accumulator();
@@ -715,13 +715,13 @@ fn test_mmr_large() {
     );
 
     let mut mmr = Mmr::new();
-    mmr.add([Felt::new(0), Felt::new(0), Felt::new(0), Felt::new(1)].into());
-    mmr.add([Felt::new(0), Felt::new(0), Felt::new(0), Felt::new(2)].into());
-    mmr.add([Felt::new(0), Felt::new(0), Felt::new(0), Felt::new(3)].into());
-    mmr.add([Felt::new(0), Felt::new(0), Felt::new(0), Felt::new(4)].into());
-    mmr.add([Felt::new(0), Felt::new(0), Felt::new(0), Felt::new(5)].into());
-    mmr.add([Felt::new(0), Felt::new(0), Felt::new(0), Felt::new(6)].into());
-    mmr.add([Felt::new(0), Felt::new(0), Felt::new(0), Felt::new(7)].into());
+    mmr.add([ZERO, ZERO, ZERO, ONE].into());
+    mmr.add([ZERO, ZERO, ZERO, Felt::new(2)].into());
+    mmr.add([ZERO, ZERO, ZERO, Felt::new(3)].into());
+    mmr.add([ZERO, ZERO, ZERO, Felt::new(4)].into());
+    mmr.add([ZERO, ZERO, ZERO, Felt::new(5)].into());
+    mmr.add([ZERO, ZERO, ZERO, Felt::new(6)].into());
+    mmr.add([ZERO, ZERO, ZERO, Felt::new(7)].into());
 
     let accumulator = mmr.accumulator();
 
@@ -739,13 +739,13 @@ fn test_mmr_large_add_roundtrip() {
     let mmr_ptr = 1000_u32;
 
     let mut mmr: Mmr = Mmr::from([
-        [Felt::new(0), Felt::new(0), Felt::new(0), Felt::new(1)].into(),
-        [Felt::new(0), Felt::new(0), Felt::new(0), Felt::new(2)].into(),
-        [Felt::new(0), Felt::new(0), Felt::new(0), Felt::new(3)].into(),
-        [Felt::new(0), Felt::new(0), Felt::new(0), Felt::new(4)].into(),
-        [Felt::new(0), Felt::new(0), Felt::new(0), Felt::new(5)].into(),
-        [Felt::new(0), Felt::new(0), Felt::new(0), Felt::new(6)].into(),
-        [Felt::new(0), Felt::new(0), Felt::new(0), Felt::new(7)].into(),
+        [ZERO, ZERO, ZERO, ONE].into(),
+        [ZERO, ZERO, ZERO, Felt::new(2)].into(),
+        [ZERO, ZERO, ZERO, Felt::new(3)].into(),
+        [ZERO, ZERO, ZERO, Felt::new(4)].into(),
+        [ZERO, ZERO, ZERO, Felt::new(5)].into(),
+        [ZERO, ZERO, ZERO, Felt::new(6)].into(),
+        [ZERO, ZERO, ZERO, Felt::new(7)].into(),
     ]);
 
     let old_accumulator = mmr.accumulator();

--- a/stdlib/tests/collections/mod.rs
+++ b/stdlib/tests/collections/mod.rs
@@ -1,6 +1,6 @@
 use test_utils::{
     crypto::{MerkleStore, SimpleSmt},
-    Felt, StarkField, TestError, Word, ONE, ZERO,
+    Felt, StarkField, TestError, Word, EMPTY_WORD, ONE, ZERO,
 };
 
 mod mmr;

--- a/stdlib/tests/collections/smt64.rs
+++ b/stdlib/tests/collections/smt64.rs
@@ -1,4 +1,4 @@
-use super::{Felt, MerkleStore, SimpleSmt, StarkField, TestError, Word, ONE, ZERO};
+use super::{Felt, MerkleStore, SimpleSmt, StarkField, TestError, Word, EMPTY_WORD, ONE, ZERO};
 use crate::build_test;
 
 // TEST DATA
@@ -7,7 +7,7 @@ use crate::build_test;
 const LEAVES: [(u64, Word); 5] = [
     (
         0b00000000_00000000_11111111_11111111_11111111_11111111_11111111_11111111_u64,
-        [Felt::new(1), ZERO, ZERO, ZERO],
+        [ONE, ZERO, ZERO, ZERO],
     ),
     (
         // different from the first key starting from the first bit
@@ -80,7 +80,7 @@ fn insert() {
     build_test!(source, &init_stack, &[], store, vec![]).expect_stack(&final_stack);
 
     // try to insert an invalid value
-    let value = [ZERO; 4];
+    let value = EMPTY_WORD;
     let (init_stack, _, store) = prepare_insert_or_set(index, value, &mut smt);
     build_test!(source, &init_stack, &[], store, vec![])
         .expect_error(TestError::ExecutionError("FailedAssertion"));
@@ -115,7 +115,7 @@ fn set() {
 
     // setting to [ZERO; 4] should return the tree to the prior state
     for (index, old_value) in LEAVES.iter().rev() {
-        let value = [ZERO; 4];
+        let value = EMPTY_WORD;
         let (init_stack, final_stack, store) = prepare_insert_or_set(*index, value, &mut smt);
 
         let expected_final_stack =

--- a/stdlib/tests/crypto/fri/remainder.rs
+++ b/stdlib/tests/crypto/fri/remainder.rs
@@ -1,6 +1,6 @@
 use crate::build_test;
 use test_utils::{
-    math::fft, rand::rand_vector, test_case, Felt, FieldElement, QuadFelt, StarkField,
+    math::fft, rand::rand_vector, test_case, Felt, FieldElement, QuadFelt, StarkField, ONE,
 };
 
 #[test_case(8, 1; "poly_8 |> evaluated_8 |> interpolated_8")]
@@ -62,7 +62,7 @@ fn test_decorator_ext2intt(in_poly_len: usize, blowup: usize) {
 
     let poly = rand_vector::<QuadFelt>(in_poly_len);
     let twiddles = fft::get_twiddles(poly.len());
-    let evals = fft::evaluate_poly_with_offset(&poly, &twiddles, Felt::ONE, blowup);
+    let evals = fft::evaluate_poly_with_offset(&poly, &twiddles, ONE, blowup);
 
     let ifelts = QuadFelt::slice_as_base_elements(&evals);
     let iu64s = ifelts.iter().map(|v| v.as_int()).collect::<Vec<u64>>();

--- a/stdlib/tests/crypto/fri/verifier_fri_e2f4.rs
+++ b/stdlib/tests/crypto/fri/verifier_fri_e2f4.rs
@@ -8,7 +8,7 @@ use test_utils::{
     crypto::{MerklePath, NodeIndex, PartialMerkleTree, Rpo256 as MidenHasher},
     group_vector_elements,
     math::fft,
-    Felt, FieldElement, IntoBytes, QuadFelt as QuadExt, StarkField, ZERO,
+    Felt, FieldElement, IntoBytes, QuadFelt as QuadExt, StarkField, EMPTY_WORD,
 };
 use winter_fri::{
     folding::fold_positions, DefaultProverChannel, FriOptions, FriProof, FriProver, VerifierError,
@@ -446,7 +446,7 @@ impl UnBatch<QuadExt, MidenHasher> for MidenFriVerifierChannel<QuadExt, MidenHas
                 .zip(x.iter())
                 .map(|(a, b)| {
                     let mut value = QuadExt::slice_as_base_elements(b).to_owned();
-                    value.extend([ZERO; 4]);
+                    value.extend(EMPTY_WORD);
                     adv_key_map.push((a.to_owned().into_bytes(), value));
                 })
                 .collect();

--- a/stdlib/tests/crypto/stark/verifier_recursive/channel.rs
+++ b/stdlib/tests/crypto/stark/verifier_recursive/channel.rs
@@ -7,7 +7,7 @@ use test_utils::{
     crypto::{BatchMerkleProof, MerklePath, PartialMerkleTree, Rpo256, RpoDigest},
     group_vector_elements,
     math::{FieldElement, QuadExtension, StarkField},
-    Felt, IntoBytes, VerifierError, ZERO,
+    Felt, IntoBytes, VerifierError, EMPTY_WORD,
 };
 use winter_air::{
     proof::{Queries, StarkProof, Table},
@@ -272,7 +272,7 @@ impl VerifierChannel {
                 .zip(x.iter())
                 .map(|(a, b)| {
                     let mut value = QuadExt::slice_as_base_elements(b).to_owned();
-                    value.extend([ZERO; 4]);
+                    value.extend(EMPTY_WORD);
 
                     adv_key_map.push((a.to_owned().into_bytes(), value));
                 })

--- a/stdlib/tests/math/ecgfp5/base_field.rs
+++ b/stdlib/tests/math/ecgfp5/base_field.rs
@@ -3,7 +3,7 @@ use core::{
     cmp::PartialEq,
     ops::{Add, Div, Mul, Neg, Sub},
 };
-use test_utils::{rand::rand_value, Felt, FieldElement, StarkField};
+use test_utils::{rand::rand_value, Felt, FieldElement, StarkField, ONE, ZERO};
 
 // Given an element v ∈ Z_q | q = 2^64 - 2^32 + 1, this routine raises
 // it to the power 2^n, by means of n successive squarings
@@ -29,16 +29,16 @@ fn legendre(v: Felt) -> Felt {
 }
 
 fn is_zero(a: Felt) -> Felt {
-    Felt::new((a == Felt::ZERO) as u64)
+    Felt::new((a == ZERO) as u64)
 }
 
 fn is_one(a: Felt) -> Felt {
-    Felt::new((a == Felt::ONE) as u64)
+    Felt::new((a == ONE) as u64)
 }
 
 pub fn bv_or(a: Felt, b: Felt) -> Felt {
-    let flg_a = (a == Felt::ZERO) | (a == Felt::ONE);
-    let flg_b = (b == Felt::ZERO) | (b == Felt::ONE);
+    let flg_a = (a == ZERO) | (a == ONE);
+    let flg_b = (b == ZERO) | (b == ONE);
 
     assert_eq!(flg_a & flg_b, true);
 
@@ -122,21 +122,21 @@ impl Ext5 {
 
     pub fn zero() -> Self {
         Self {
-            a0: Felt::new(0),
-            a1: Felt::new(0),
-            a2: Felt::new(0),
-            a3: Felt::new(0),
-            a4: Felt::new(0),
+            a0: ZERO,
+            a1: ZERO,
+            a2: ZERO,
+            a3: ZERO,
+            a4: ZERO,
         }
     }
 
     pub fn from_int(a: u64) -> Self {
         Self {
             a0: Felt::new(a),
-            a1: Felt::new(0),
-            a2: Felt::new(0),
-            a3: Felt::new(0),
-            a4: Felt::new(0),
+            a1: ZERO,
+            a2: ZERO,
+            a3: ZERO,
+            a4: ZERO,
         }
     }
 
@@ -203,9 +203,9 @@ impl Ext5 {
             + Felt::new(3)
                 * (self.a1 * t2.a4 + self.a2 * t2.a3 + self.a3 * t2.a2 + self.a4 * t2.a1);
 
-        let flg = t3 == Felt::new(0);
+        let flg = t3 == ZERO;
         let t3 = t3 + Felt::new(flg as u64);
-        let t4 = Felt::new(1) / t3;
+        let t4 = ONE / t3;
 
         Self {
             a0: t4 * t2.a0,
@@ -259,11 +259,11 @@ impl Ext5 {
     }
 
     pub fn is_zero(self) -> Felt {
-        let flg0 = self.a0 == Felt::ZERO;
-        let flg1 = self.a1 == Felt::ZERO;
-        let flg2 = self.a2 == Felt::ZERO;
-        let flg3 = self.a3 == Felt::ZERO;
-        let flg4 = self.a4 == Felt::ZERO;
+        let flg0 = self.a0 == ZERO;
+        let flg1 = self.a1 == ZERO;
+        let flg2 = self.a2 == ZERO;
+        let flg3 = self.a3 == ZERO;
+        let flg4 = self.a4 == ZERO;
 
         let flg = flg0 & flg1 & flg2 & flg3 & flg4;
         Felt::new(flg as u64)

--- a/stdlib/tests/math/ecgfp5/group.rs
+++ b/stdlib/tests/math/ecgfp5/group.rs
@@ -1,7 +1,7 @@
 use super::base_field::{bv_or, Ext5};
 use crate::build_test;
 use std::ops::Add;
-use test_utils::{test_case, Felt, FieldElement, StarkField};
+use test_utils::{test_case, Felt, StarkField, ONE, ZERO};
 
 #[derive(Copy, Clone, Debug)]
 struct ECExt5 {
@@ -55,7 +55,7 @@ impl ECExt5 {
         Self {
             x: Ext5::zero(),
             y: Ext5::zero(),
-            point_at_infinity: Felt::ONE,
+            point_at_infinity: ONE,
         }
     }
 
@@ -65,7 +65,7 @@ impl ECExt5 {
     pub fn validate(w: Ext5) -> Felt {
         let e = w.square() - Self::a();
         let delta = e.square().subk1(Self::bmul4_1());
-        bv_or(Felt::new((delta.legendre() == Felt::ONE) as u64), w.is_zero())
+        bv_or(Felt::new((delta.legendre() == ONE) as u64), w.is_zero())
     }
 
     // Given an encoded elliptic curve point, this routine attempts to decode it using
@@ -79,10 +79,10 @@ impl ECExt5 {
         let x1 = (e + r) / Ext5::from_int(2);
         let x2 = (e - r) / Ext5::from_int(2);
 
-        let flg = x1.legendre() == Felt::ONE;
+        let flg = x1.legendre() == ONE;
         let x = if flg { x1 } else { x2 };
         let y = -w * x;
-        let inf = Felt::ONE - c;
+        let inf = ONE - c;
         let c = bv_or(c, w.is_zero());
 
         (
@@ -101,7 +101,7 @@ impl ECExt5 {
     // See https://github.com/pornin/ecgfp5/blob/ce059c6/python/ecGFp5.py#L1214-L1216 for reference implementation
     pub fn encode(self) -> Ext5 {
         let w = self.y / (Self::adiv3() - self.x);
-        let flg = self.point_at_infinity == Felt::ONE;
+        let flg = self.point_at_infinity == ONE;
 
         if flg {
             Ext5::zero()
@@ -173,23 +173,23 @@ impl Add for ECExt5 {
         let inf3 = Felt::new((samex & diffy) as u64);
 
         Self {
-            x: if rhs.point_at_infinity == Felt::ONE {
+            x: if rhs.point_at_infinity == ONE {
                 self.x
-            } else if self.point_at_infinity == Felt::ONE {
+            } else if self.point_at_infinity == ONE {
                 rhs.x
             } else {
                 x3
             },
-            y: if rhs.point_at_infinity == Felt::ONE {
+            y: if rhs.point_at_infinity == ONE {
                 self.y
-            } else if self.point_at_infinity == Felt::ONE {
+            } else if self.point_at_infinity == ONE {
                 rhs.y
             } else {
                 y3
             },
-            point_at_infinity: if rhs.point_at_infinity == Felt::ONE {
+            point_at_infinity: if rhs.point_at_infinity == ONE {
                 self.point_at_infinity
-            } else if self.point_at_infinity == Felt::ONE {
+            } else if self.point_at_infinity == ONE {
                 rhs.point_at_infinity
             } else {
                 inf3
@@ -301,7 +301,7 @@ fn test_ec_ext5_point_encode(a0: u64, a1: u64, a2: u64, a3: u64, a4: u64) {
     let w = Ext5::new(a0, a1, a2, a3, a4);
     let (point, flg) = ECExt5::decode(w);
 
-    assert_eq!(flg, Felt::ONE);
+    assert_eq!(flg, ONE);
 
     let w_prime = point.encode();
 
@@ -592,7 +592,7 @@ fn test_ec_ext5_gen_multiplication() {
             0x1e0f15c7fd44c28e,
             0x21fa7ffcc8252211,
         ) * Ext5::from_int(4),
-        point_at_infinity: Felt::ZERO,
+        point_at_infinity: ZERO,
     };
     // = 1067993516717146951041484916571792702745057740581727230159139685185762082554198619328292418486241
     // = N ( See https://github.com/pornin/ecgfp5/blob/ce059c6/python/ecGFp5.py#L922 )

--- a/test-utils/src/crypto.rs
+++ b/test-utils/src/crypto.rs
@@ -1,4 +1,4 @@
-use super::{Felt, FieldElement, Vec, Word};
+use super::{Felt, Vec, Word, ZERO};
 
 // RE-EXPORTS
 // ================================================================================================
@@ -30,5 +30,5 @@ pub fn init_merkle_leaves(values: &[u64]) -> Vec<Word> {
 }
 
 pub fn init_merkle_leaf(value: u64) -> Word {
-    [Felt::new(value), Felt::ZERO, Felt::ZERO, Felt::ZERO]
+    [Felt::new(value), ZERO, ZERO, ZERO]
 }

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -28,7 +28,7 @@ pub use verifier::{ProgramInfo, VerifierError};
 pub use vm_core::{
     stack::STACK_TOP_SIZE,
     utils::{collections, group_slice_elements, group_vector_elements, IntoBytes, ToElements},
-    Felt, FieldElement, Program, StarkField, Word, ONE, WORD_SIZE, ZERO,
+    Felt, FieldElement, Program, StarkField, Word, EMPTY_WORD, ONE, WORD_SIZE, ZERO,
 };
 
 pub mod math {
@@ -175,7 +175,7 @@ impl Test {
         // validate the memory state
         for data in expected_mem.chunks(WORD_SIZE) {
             // Main memory is zeroed by default, use zeros as a fallback when unwrap to make testing easier
-            let mem_state = process.get_memory_value(0, mem_start_addr).unwrap_or([ZERO; 4]);
+            let mem_state = process.get_memory_value(0, mem_start_addr).unwrap_or(EMPTY_WORD);
 
             let mem_state = stack_to_ints(&mem_state);
             assert_eq!(
@@ -321,7 +321,7 @@ pub fn prop_randw<T: Arbitrary>() -> impl Strategy<Value = Vec<T>> {
 ///
 /// Return the result of the permutation in stack order.
 pub fn build_expected_perm(values: &[u64]) -> [Felt; STATE_WIDTH] {
-    let mut expected = [Felt::ZERO; STATE_WIDTH];
+    let mut expected = [ZERO; STATE_WIDTH];
     for (&value, result) in values.iter().zip(expected.iter_mut()) {
         *result = Felt::new(value);
     }


### PR DESCRIPTION
This long but pretty straightforward PR replaces `[ZERO; 4]`, `[ZERO, ZERO, ZERO, ZERO]` and `[ZERO; WORD_SIZE]` with `EMPTY_WORD`, and also replaces `Felt::ZERO` and `Felt::new(0)` with `ZERO`, `Felt::ONE` and `Felt::new(1)` with `ONE`.

This PR closes issue #959 
