### PR TITLE
Fix test program with phantom mast call

### DIFF
--- a/assembly/src/errors.rs
+++ b/assembly/src/errors.rs
@@ -143,7 +143,7 @@ impl fmt::Display for AssemblyError {
             LibraryError(err) | ParsingError(err) | ProcedureNameError(err) => write!(f, "{err}"),
             LocalProcNotFound(proc_idx, module_path) => write!(f, "procedure at index {proc_idx} not found in module {module_path}"),
             ParamOutOfBounds(value, min, max) => write!(f, "parameter value must be greater than or equal to {min} and less than or equal to {max}, but was {value}"),
-            PhantomCallsNotAllowed(mast_root) => write!(f, "cannot call phantom procedure with MAST root 0x{mast_root}: phantom calls not allowed"),
+            PhantomCallsNotAllowed(mast_root) => write!(f, "cannot call phantom procedure with MAST root {mast_root}: phantom calls not allowed"),
             SysCallInKernel(proc_name) => write!(f, "syscall instruction used in kernel procedure '{proc_name}'"),
         }
     }


### PR DESCRIPTION
## Describe your changes

The `miden-core` is configured to run against `miden-crypto` code in the branch `next` [ref](https://github.com/0xPolygonMiden/miden-vm/commit/2e7287997c265666a6b9cacdf7a9ccfb7e38667f#diff-ac4e3071598a47848866c532150a233af5159d2757dab53572781ed09e13fbeeL24). The digest has been updated to format itself including the `0x` [ref](https://github.com/0xPolygonMiden/crypto/commit/8cf5e9fd2c325eb67f8d05150fea3c8d59351056), which broke the test.

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
