### PR TITLE
Add details to reexport proc error

### DIFF
--- a/assembly/src/assembler/mod.rs
+++ b/assembly/src/assembler/mod.rs
@@ -198,7 +198,9 @@ impl Assembler {
         for reexporteed_proc in module.ast.reexported_procs().iter() {
             // make sure the re-exported procedure is loaded into the procedure cache
             let ref_proc_id = reexporteed_proc.proc_id();
-            self.ensure_procedure_is_in_cache(&ref_proc_id, context)?;
+            self.ensure_procedure_is_in_cache(&ref_proc_id, context).map_err(|_| {
+                AssemblyError::ReExportedProcModuleNotFound(reexporteed_proc.clone())
+            })?;
 
             // build procedure ID for the alias, and add it to the procedure cache
             let proc_name = reexporteed_proc.name();

--- a/assembly/src/errors.rs
+++ b/assembly/src/errors.rs
@@ -1,6 +1,6 @@
 use super::{
-    crypto::hash::RpoDigest, tokens::SourceLocation, LibraryNamespace, ProcedureId, String,
-    ToString, Token, Vec,
+    ast::ProcReExport, crypto::hash::RpoDigest, tokens::SourceLocation, LibraryNamespace,
+    ProcedureId, String, ToString, Token, Vec,
 };
 use core::fmt;
 
@@ -20,6 +20,7 @@ pub enum AssemblyError {
     DuplicateProcId(ProcedureId),
     ExportedProcInProgram(String),
     ImportedProcModuleNotFound(ProcedureId),
+    ReExportedProcModuleNotFound(ProcReExport),
     ImportedProcNotFoundInModule(ProcedureId, String),
     InvalidProgramAssemblyContext,
     InvalidCacheLock,
@@ -135,6 +136,7 @@ impl fmt::Display for AssemblyError {
             DuplicateProcId(proc_id) => write!(f, "duplicate proc id {proc_id}"),
             ExportedProcInProgram(proc_name) => write!(f, "exported procedure '{proc_name}' in executable program"),
             ImportedProcModuleNotFound(proc_id) => write!(f, "module for imported procedure {proc_id} not found"),
+            ReExportedProcModuleNotFound(reexport) => write!(f, "re-exported proc {} with id {} not found", reexport.name(), reexport.proc_id()),
             ImportedProcNotFoundInModule(proc_id, module_path) => write!(f, "imported procedure {proc_id} not found in module {module_path}"),
             InvalidProgramAssemblyContext => write!(f, "assembly context improperly initialized for program compilation"),
             InvalidCacheLock => write!(f, "an attempt was made to lock a borrowed procedures cache"),


### PR DESCRIPTION
## Describe your changes

The existing error only prints the procid, so it is hard to figure out which procedure is missing. This change adds the procedure name to the error message as a clarification.

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
