### PR TITLE
Improve error `ImportedProcModuleNotFound`

### DIFF
--- a/assembly/src/ast/mod.rs
+++ b/assembly/src/ast/mod.rs
@@ -152,6 +152,15 @@ impl ProgramAst {
         &self.body
     }
 
+    /// Returns a map containing IDs and names of imported procedures.
+    pub fn get_imported_procedures_map(&self) -> BTreeMap<ProcedureId, ProcedureName> {
+        if let Some(info) = &self.import_info {
+            info.invoked_procs().iter().map(|(&id, (name, _))| (id, name.clone())).collect()
+        } else {
+            BTreeMap::new()
+        }
+    }
+
     // PARSER
     // --------------------------------------------------------------------------------------------
     /// Parses the provided source into a [ProgramAst].
@@ -489,6 +498,15 @@ impl ModuleAst {
         match &self.import_info {
             Some(info) => info.import_paths(),
             None => Vec::<&LibraryPath>::new(),
+        }
+    }
+
+    /// Returns a map containing IDs and names of imported procedures.
+    pub fn get_imported_procedures_map(&self) -> BTreeMap<ProcedureId, ProcedureName> {
+        if let Some(info) = &self.import_info {
+            info.invoked_procs().iter().map(|(&id, (name, _))| (id, name.clone())).collect()
+        } else {
+            BTreeMap::new()
         }
     }
 

--- a/assembly/src/lib.rs
+++ b/assembly/src/lib.rs
@@ -32,7 +32,7 @@ mod errors;
 pub use errors::{AssemblyError, LabelError, LibraryError, ParsingError, PathError};
 
 mod assembler;
-pub use assembler::{Assembler, AssemblyContext, AssemblyContextType};
+pub use assembler::{Assembler, AssemblyContext};
 
 #[cfg(test)]
 mod tests;

--- a/miden/src/examples/fibonacci.rs
+++ b/miden/src/examples/fibonacci.rs
@@ -1,6 +1,6 @@
 use super::{Example, ONE, ZERO};
 use miden::{
-    math::{Felt, FieldElement, StarkField},
+    math::{Felt, StarkField},
     Assembler, MemAdviceProvider, Program, StackInputs,
 };
 


### PR DESCRIPTION
This PR adds procedure name to the `ImportedProcModuleNotFound` error, so now it will look like so: 
```
ImportedProcModuleNotFound(
    ProcedureName { name: "foo" }, 
    ProcedureId([76, 6, 174, 102, 136, 197, 185, 191, 0, 2, 63, 207, 185, 182, 172, 255, 235, 226, 6, 56])
)
```
