### PR TITLE
Make `push` instruction parse hex strings in little-endian

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Added `adv.insert_hperm` decorator (#1042).
 - Added `adv.push_smtpeek` decorator (#1056).
 - Added `debug` decorator (#1069).
+- Refactored `push` instruction so now it parses long hex string in little-endian (#1076).
 
 #### VM Internals
 - Simplified range checker and removed 1 main and 1 auxiliary trace column (#949).

--- a/docs/src/user_docs/assembly/io_operations.md
+++ b/docs/src/user_docs/assembly/io_operations.md
@@ -12,11 +12,12 @@ Miden assembly provides a set of instructions for moving data between the operan
 | ------------------------------------------------------------------------- | ----------- | ------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | push.*a* <br> - *(1-2 cycles)* <br> push.*a*.*b* <br> push.*a*.*b*.*c*... | [ ... ]     | [a, ... ] <br> [b, a, ... ] <br> [c, b, a, ... ] | Pushes values $a$, $b$, $c$ etc. onto the stack. Up to $16$ values can be specified. All values must be valid field elements in decimal (e.g., $123$) or hexadecimal (e.g., $0x7b$) representation. |
 
-When specifying values in hexadecimal format, it is possible to omit the periods between individual values as long as total number of specified bytes is a multiple of $8$. That is, the following are semantically equivalent:
+The value can be specified in hexadecimal form without periods between individual values as long as it describes a full word ($4$ field elements or $32$ bytes). Note that hexadecimal values separated by periods (short hexadecimal strings) are assumed to be in big-endian order, while the strings specifying whole words (long hexadecimal strings) are assumed to be in little-endian order. That is, the following are semantically equivalent:
 
 ```
-push.0x1234.0xabcd
-push.0x0000000000001234000000000000abcd
+push.0x00001234.0x00005678.0x00009012.0x0000abcd
+push.0x341200000000000078560000000000001290000000000000cdab000000000000
+push.4660.22136.36882.43981
 ```
 In both case the values must still encode valid field elements.
 

--- a/miden/tests/integration/operations/io_ops/constant_ops.rs
+++ b/miden/tests/integration/operations/io_ops/constant_ops.rs
@@ -65,20 +65,15 @@ fn push_many() {
 
 #[test]
 fn push_without_separator() {
-    let base_op = "push";
-
-    // --- multiple values as a hexadecimal string ------------------------------------------------
-    let asm_op = format!("{base_op}.0x0000000000004321000000000000dcba");
-
-    let test = build_op_test!(asm_op);
-    test.expect_stack(&[56506, 17185]);
-
-    // --- push the maximum number of hexadecimal values without separators (16) ------------------
-    let asm_op =    format!("{base_op}.0x0000000000000000000000000000000100000000000000020000000000000003000000000000000400000000000000050000000000000006000000000000000700000000000000080000000000000009000000000000000A000000000000000B000000000000000C000000000000000D000000000000000E000000000000000F");
-    let mut expected = Vec::with_capacity(16);
-    for i in (0..16).rev() {
-        expected.push(i);
-    }
+    // --- push the maximum allowed number of hexadecimal values without separators (4) ------------------
+    let asm_op = format!(
+        "push.0x\
+    0000000000000000\
+    0100000000000000\
+    0200000000000000\
+    0300000000000000"
+    );
+    let expected = vec![3, 2, 1, 0];
 
     let test = build_op_test!(asm_op);
     test.expect_stack(&expected);


### PR DESCRIPTION
This PR changes how `push.*` instruction is parsing long hex strings. Earlier hex string was parsed as if it was created from big-endian bytes, but now we assume that it was created from little-endian bytes (since it was actually created like that).

This change fixes an [issue](https://github.com/0xPolygonMiden/miden-vm/issues/993#issuecomment-1721673702) when  hex strings were created form little-endian bytes array, but were parsed as string created from big-endian bytes, making unavailable to use printed he strings as inputs to the VM.

Todo:
- [x] Update docs
- [x] Update changelog
