### PR TITLE
Graviton compilation target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,9 +95,6 @@ jobs:
         with:
           command: clippy
           args: --all -- -D clippy::all -D warnings
-        env:
-          # Seems necessary until https://github.com/rust-lang/rust/pull/115819 is merged.
-          CARGO_INCREMENTAL: 0
 
   rustfmt:
     name: rustfmt

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 FEATURES_INTERNALS=--features internals
 FEATURES_CONCURRENT_EXEC=--features concurrent,executable
+FEATURES_GRAVITON_EXEC=--features concurrent,executable,sve
 FEATURES_METAL_EXEC=--features concurrent,executable,metal
 PROFILE_OPTIMIZED=--profile optimized
 PROFILE_TEST=--profile test-release
@@ -12,6 +13,9 @@ exec:
 
 exec-metal:
 	cargo build $(PROFILE_OPTIMIZED) $(FEATURES_METAL_EXEC)
+
+exec-graviton:
+	RUSTFLAGS="-C target-cpu=native" cargo build $(PROFILE_OPTIMIZED) $(FEATURES_GRAVITON_EXEC)
 
 test:
 	cargo test $(PROFILE_TEST) $(FEATURES_INTERNALS)

--- a/air/Cargo.toml
+++ b/air/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/0xPolygonMiden/miden-vm"
 categories = ["cryptography", "no-std"]
 keywords = ["air", "arithmetization", "crypto", "miden"]
 edition = "2021"
-rust-version = "1.67"
+rust-version = "1.73"
 
 [lib]
 bench = false
@@ -33,5 +33,5 @@ winter-air = { package = "winter-air", version = "0.6", default-features = false
 
 [dev-dependencies]
 criterion = "0.5"
-proptest = "1.1"
+proptest = "1.3"
 rand-utils = { package = "winter-rand-utils", version = "0.6" }

--- a/assembly/Cargo.toml
+++ b/assembly/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/0xPolygonMiden/miden-vm"
 categories = ["compilers", "no-std"]
 keywords = ["assembler", "assembly", "language", "miden"]
 edition = "2021"
-rust-version = "1.67"
+rust-version = "1.73"
 
 [lib]
 bench = false
@@ -20,5 +20,5 @@ default = ["std"]
 std = ["vm-core/std"]
 
 [dependencies]
-num_enum = "0.6.1"
+num_enum = "0.7"
 vm-core = { package = "miden-core", path = "../core", version = "0.7", default-features = false }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -17,7 +17,8 @@ doctest = false
 
 [features]
 default = ["std"]
-std = ["math/std", "winter-utils/std", "miden-crypto/std"]
+std = ["miden-crypto/std", "math/std", "winter-utils/std"]
+sve = ["miden-crypto/sve", "std"]
 
 [dependencies]
 math = { package = "winter-math", version = "0.6", default-features = false }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/0xPolygonMiden/miden-vm"
 categories = ["emulators", "no-std"]
 keywords = ["instruction-set", "miden", "program"]
 edition = "2021"
-rust-version = "1.67"
+rust-version = "1.73"
 
 [lib]
 bench = false

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -22,7 +22,7 @@ sve = ["miden-crypto/sve", "std"]
 
 [dependencies]
 math = { package = "winter-math", version = "0.6", default-features = false }
-miden-crypto = {git = "https://github.com/0xPolygonMiden/crypto", branch = "next", default-features = false }
+miden-crypto = { package = "miden-crypto", version = "0.7", default-features = false }
 winter-crypto = { package = "winter-crypto", version = "0.6", default-features = false }
 winter-utils = { package = "winter-utils", version = "0.6", default-features = false }
 

--- a/miden/Cargo.toml
+++ b/miden/Cargo.toml
@@ -39,7 +39,7 @@ path = "tests/integration/main.rs"
 [features]
 concurrent = ["prover/concurrent", "std"]
 default = ["std"]
-executable = ["env_logger", "hex/std", "std", "serde/std", "serde_derive", "serde_json/std", "clap", "rustyline"]
+executable = ["dep:env_logger", "dep:hex", "hex?/std", "std", "dep:serde", "serde?/std", "dep:serde_derive", "dep:serde_json", "serde_json?/std", "dep:clap", "dep:rustyline"]
 std = ["assembly/std", "log/std", "processor/std", "prover/std", "verifier/std"]
 
 [dependencies]
@@ -47,13 +47,13 @@ assembly = { package = "miden-assembly", path = "../assembly", version = "0.7", 
 clap = { version = "4.0", features = ["derive"], optional = true }
 env_logger = { version = "0.10", default-features = false, optional = true }
 hex = { version = "0.4", optional = true }
-log = { version = "0.4", default-features = false }
+log = { version = "0.4", default-features = false, optional = true }
 processor = { package = "miden-processor", path = "../processor", version = "0.7", default-features = false }
 prover = { package = "miden-prover", path = "../prover", version = "0.7", default-features = false }
 rustyline = { version = "12.0", default-features = false, optional = true }
-serde = {version = "1.0.117", optional = true }
-serde_derive = {version = "1.0.117", optional = true }
-serde_json = {version = "1.0.59", optional = true }
+serde = {version = "1.0", optional = true }
+serde_derive = {version = "1.0", optional = true }
+serde_json = {version = "1.0", optional = true }
 stdlib = { package = "miden-stdlib", path = "../stdlib", version = "0.6", default-features = false }
 verifier = { package = "miden-verifier", path = "../verifier", version = "0.7", default-features = false }
 

--- a/miden/Cargo.toml
+++ b/miden/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/0xPolygonMiden/miden-vm"
 categories = ["cryptography", "emulators", "no-std"]
 keywords = ["miden", "stark", "virtual-machine", "zkp"]
 edition = "2021"
-rust-version = "1.67"
+rust-version = "1.73"
 
 [[bin]]
 name = "miden"
@@ -44,7 +44,7 @@ std = ["assembly/std", "log/std", "processor/std", "prover/std", "verifier/std"]
 
 [dependencies]
 assembly = { package = "miden-assembly", path = "../assembly", version = "0.7", default-features = false }
-clap = { version = "4.0", features = ["derive"], optional = true }
+clap = { version = "4.4", features = ["derive"], optional = true }
 env_logger = { version = "0.10", default-features = false, optional = true }
 hex = { version = "0.4", optional = true }
 log = { version = "0.4", default-features = false, optional = true }
@@ -60,7 +60,7 @@ verifier = { package = "miden-verifier", path = "../verifier", version = "0.7", 
 [dev-dependencies]
 assert_cmd = "2.0"
 criterion = "0.5"
-escargot = "0.5.7"
+escargot = "0.5"
 num-bigint = "0.4"
 predicates = "3.0"
 test-utils = { package = "miden-test-utils", path = "../test-utils" }

--- a/miden/Cargo.toml
+++ b/miden/Cargo.toml
@@ -41,6 +41,7 @@ concurrent = ["prover/concurrent", "std"]
 default = ["std"]
 executable = ["dep:env_logger", "dep:hex", "hex?/std", "std", "dep:serde", "serde?/std", "dep:serde_derive", "dep:serde_json", "serde_json?/std", "dep:clap", "dep:rustyline"]
 std = ["assembly/std", "log/std", "processor/std", "prover/std", "verifier/std"]
+sve = ["processor/sve", "prover/sve", "std"]
 
 [dependencies]
 assembly = { package = "miden-assembly", path = "../assembly", version = "0.7", default-features = false }

--- a/processor/Cargo.toml
+++ b/processor/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/0xPolygonMiden/miden-vm"
 categories = ["emulators", "no-std"]
 keywords = ["miden", "virtual-machine"]
 edition = "2021"
-rust-version = "1.67"
+rust-version = "1.73"
 
 [lib]
 bench = false
@@ -22,7 +22,7 @@ internals = []
 std = ["vm-core/std", "winter-prover/std", "log/std"]
 
 [dependencies]
-log = "0.4.14"
+log = "0.4"
 vm-core = { package = "miden-core", path = "../core", version = "0.7", default-features = false }
 miden-air = { package = "miden-air", path = "../air", version = "0.7", default-features = false }
 winter-prover = { package = "winter-prover", version = "0.6", default-features = false }
@@ -30,7 +30,6 @@ winter-prover = { package = "winter-prover", version = "0.6", default-features =
 [dev-dependencies]
 logtest = { version = "2.0", default-features = false  }
 miden-assembly = { package = "miden-assembly", path = "../assembly", version = "0.7", default-features = false }
-rand-utils = { package = "winter-rand-utils", version = "0.6" }
 test-utils = { package = "miden-test-utils", path = "../test-utils" }
 winter-fri = { package = "winter-fri", version = "0.6" }
 winter-utils = { package = "winter-utils", version = "0.6" }

--- a/processor/Cargo.toml
+++ b/processor/Cargo.toml
@@ -16,13 +16,14 @@ bench = false
 doctest = false
 
 [features]
-concurrent = ["winter-prover/concurrent", "std"]
+concurrent = ["std", "winter-prover/concurrent"]
 default = ["std"]
 internals = []
-std = ["vm-core/std", "winter-prover/std", "log/std"]
+std = ["log/std", "vm-core/std", "winter-prover/std"]
+sve = ["std", "vm-core/sve"]
 
 [dependencies]
-log = "0.4"
+log = { version = "0.4", default-features = false, optional = true }
 vm-core = { package = "miden-core", path = "../core", version = "0.7", default-features = false }
 miden-air = { package = "miden-air", path = "../air", version = "0.7", default-features = false }
 winter-prover = { package = "winter-prover", version = "0.6", default-features = false }

--- a/processor/src/chiplets/bitwise/tests.rs
+++ b/processor/src/chiplets/bitwise/tests.rs
@@ -4,7 +4,7 @@ use super::{
     A_COL_RANGE, BITWISE_AND, BITWISE_AND_LABEL, BITWISE_XOR, BITWISE_XOR_LABEL, B_COL_IDX,
     B_COL_RANGE, OP_CYCLE_LEN, OUTPUT_COL_IDX, PREV_OUTPUT_COL_IDX, TRACE_WIDTH,
 };
-use rand_utils::rand_value;
+use test_utils::rand::rand_value;
 use vm_core::ZERO;
 
 #[test]

--- a/processor/src/chiplets/hasher/tests.rs
+++ b/processor/src/chiplets/hasher/tests.rs
@@ -11,7 +11,7 @@ use miden_air::trace::chiplets::hasher::{
     MR_UPDATE_OLD_LABEL, NUM_ROUNDS, NUM_SELECTORS, RETURN_HASH_LABEL, RETURN_STATE_LABEL,
     STATE_COL_RANGE,
 };
-use rand_utils::rand_array;
+use test_utils::rand::rand_array;
 use vm_core::{
     chiplets::hasher,
     code_blocks::CodeBlock,

--- a/processor/src/decoder/tests.rs
+++ b/processor/src/decoder/tests.rs
@@ -17,7 +17,7 @@ use miden_air::trace::{
     CTX_COL_IDX, DECODER_TRACE_RANGE, DECODER_TRACE_WIDTH, FMP_COL_IDX, FN_HASH_RANGE,
     IN_SYSCALL_COL_IDX, SYS_TRACE_RANGE, SYS_TRACE_WIDTH,
 };
-use rand_utils::rand_value;
+use test_utils::rand::rand_value;
 use vm_core::{
     code_blocks::{CodeBlock, Span, OP_BATCH_SIZE},
     utils::collections::Vec,

--- a/processor/src/operations/crypto_ops.rs
+++ b/processor/src/operations/crypto_ops.rs
@@ -179,7 +179,7 @@ mod tests {
         Process,
     };
     use crate::{AdviceInputs, StackInputs, Word, ZERO};
-    use rand_utils::rand_vector;
+    use test_utils::rand::rand_vector;
     use vm_core::{
         chiplets::hasher::{apply_permutation, STATE_WIDTH},
         crypto::merkle::{MerkleStore, MerkleTree, NodeIndex},

--- a/processor/src/operations/ext2_ops.rs
+++ b/processor/src/operations/ext2_ops.rs
@@ -38,7 +38,7 @@ mod tests {
         Process,
     };
     use crate::{StackInputs, ZERO};
-    use rand_utils::rand_value;
+    use test_utils::rand::rand_value;
     use vm_core::QuadExtension;
 
     // ARITHMETIC OPERATIONS

--- a/processor/src/operations/field_ops.rs
+++ b/processor/src/operations/field_ops.rs
@@ -225,7 +225,7 @@ mod tests {
         Process,
     };
     use crate::{AdviceInputs, StackInputs};
-    use rand_utils::rand_value;
+    use test_utils::rand::rand_value;
     use vm_core::{ONE, ZERO};
 
     // ARITHMETIC OPERATIONS

--- a/processor/src/operations/fri_ops.rs
+++ b/processor/src/operations/fri_ops.rs
@@ -243,7 +243,7 @@ mod tests {
     use super::{
         ExtensionOf, Felt, FieldElement, Operation, Process, QuadFelt, StarkField, TWO, TWO_INV,
     };
-    use rand_utils::{rand_array, rand_value, rand_vector};
+    use test_utils::rand::{rand_array, rand_value, rand_vector};
     use vm_core::{utils::collections::Vec, StackInputs};
     use winter_prover::math::{fft, get_power_series_with_offset};
     use winter_utils::transpose_slice;

--- a/processor/src/operations/u32_ops.rs
+++ b/processor/src/operations/u32_ops.rs
@@ -238,7 +238,7 @@ mod tests {
     };
     use crate::{StackInputs, ZERO};
     use miden_air::trace::{decoder::NUM_USER_OP_HELPERS, stack::STACK_TOP_SIZE};
-    use rand_utils::rand_value;
+    use test_utils::rand::rand_value;
 
     // CASTING OPERATIONS
     // --------------------------------------------------------------------------------------------

--- a/processor/src/range/tests.rs
+++ b/processor/src/range/tests.rs
@@ -1,6 +1,6 @@
 use super::{BTreeMap, Felt, RangeChecker, Vec, ZERO};
 use crate::{utils::get_trace_len, RangeCheckTrace};
-use rand_utils::rand_array;
+use test_utils::rand::rand_array;
 use vm_core::{utils::ToElements, StarkField};
 
 #[test]

--- a/processor/src/trace/decoder/tests.rs
+++ b/processor/src/trace/decoder/tests.rs
@@ -11,7 +11,7 @@ use miden_air::trace::{
     decoder::{P1_COL_IDX, P2_COL_IDX, P3_COL_IDX},
     AUX_TRACE_RAND_ELEMENTS,
 };
-use rand_utils::rand_array;
+use test_utils::rand::rand_array;
 use vm_core::{code_blocks::CodeBlock, FieldElement, Operation, ONE, ZERO};
 
 // BLOCK STACK TABLE TESTS

--- a/processor/src/trace/tests/chiplets/mod.rs
+++ b/processor/src/trace/tests/chiplets/mod.rs
@@ -7,7 +7,7 @@ use super::{
 use miden_air::trace::{
     chiplets::hasher::HASH_CYCLE_LEN, AUX_TRACE_RAND_ELEMENTS, CHIPLETS_AUX_TRACE_OFFSET,
 };
-use rand_utils::rand_value;
+use test_utils::rand::rand_value;
 
 mod bitwise;
 mod hasher;

--- a/processor/src/trace/tests/mod.rs
+++ b/processor/src/trace/tests/mod.rs
@@ -3,7 +3,7 @@ use super::{
     Process, Trace, Vec, NUM_RAND_ROWS,
 };
 use crate::{AdviceInputs, DefaultHost, ExecutionOptions, MemAdviceProvider, StackInputs};
-use rand_utils::rand_array;
+use test_utils::rand::rand_array;
 use vm_core::{
     code_blocks::CodeBlock, CodeBlockTable, Kernel, Operation, StackOutputs, Word, ONE, ZERO,
 };

--- a/processor/src/trace/tests/range.rs
+++ b/processor/src/trace/tests/range.rs
@@ -2,7 +2,7 @@ use super::{build_trace_from_ops, Felt, FieldElement, Trace, NUM_RAND_ROWS, ONE,
 use miden_air::trace::{
     chiplets::hasher::HASH_CYCLE_LEN, range::B_RANGE_COL_IDX, AUX_TRACE_RAND_ELEMENTS,
 };
-use rand_utils::rand_array;
+use test_utils::rand::rand_array;
 use vm_core::{ExtensionOf, Operation};
 
 /// This test checks that range check lookups from stack operations are balanced by the range checks

--- a/prover/Cargo.toml
+++ b/prover/Cargo.toml
@@ -16,6 +16,7 @@ concurrent = ["processor/concurrent", "std", "winter-prover/concurrent"]
 default = ["std"]
 metal = ["dep:ministark-gpu", "dep:elsa", "dep:pollster", "concurrent", "std"]
 std = ["air/std", "processor/std", "log/std", "winter-prover/std"]
+sve = ["processor/sve", "std"]
 
 [dependencies]
 air = { package = "miden-air", path = "../air", version = "0.7", default-features = false }

--- a/prover/Cargo.toml
+++ b/prover/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/0xPolygonMiden/miden-vm"
 categories = ["cryptography", "emulators", "no-std"]
 keywords = ["miden", "prover", "stark", "zkp"]
 edition = "2021"
-rust-version = "1.67"
+rust-version = "1.73"
 
 [features]
 concurrent = ["processor/concurrent", "std", "winter-prover/concurrent"]
@@ -25,5 +25,5 @@ winter-prover = { package = "winter-prover", version = "0.6", default-features =
 
 [target.'cfg(all(target_arch = "aarch64", target_os = "macos"))'.dependencies]
 ministark-gpu = { version = "0.1", features = [ "winterfell" ], optional = true }
-elsa = { version = "1.7", optional = true }
+elsa = { version = "1.9", optional = true }
 pollster = { version = "0.3", optional = true }

--- a/stdlib/Cargo.toml
+++ b/stdlib/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/0xPolygonMiden/miden-vm"
 categories = ["cryptography", "mathematics"]
 keywords = ["miden", "program", "stdlib"]
 edition = "2021"
-rust-version = "1.67"
+rust-version = "1.73"
 
 [lib]
 bench = false
@@ -27,7 +27,7 @@ std = ["test-utils/std"]
 assembly = { package = "miden-assembly", default-features = false, path = "../assembly", version = "0.7" }
 
 [dev-dependencies]
-blake3 = "1.4"
+blake3 = "1.5"
 miden-air = { package = "miden-air", path = "../air", version = "0.7", default-features = false }
 num-bigint = "0.4"
 processor = { package = "miden-processor", path = "../processor", version = "0.7", features = ["internals"], default-features = false }

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/0xPolygonMiden/miden-vm"
 categories = ["development-tools::testing", "no-std"]
 keywords = ["miden", "test", "virtual-machine"]
 edition = "2021"
-rust-version = "1.67"
+rust-version = "1.73"
 
 [features]
 default = ["std"]
@@ -19,11 +19,11 @@ std = ["assembly/std", "processor/std", "prover/std", "verifier/std", "vm-core/s
 assembly = { package = "miden-assembly", path = "../assembly", version = "0.7", default-features = false }
 processor = { package = "miden-processor", path = "../processor", version = "0.7", features = ["internals"], default-features = false }
 prover = { package = "miden-prover", path = "../prover", version = "0.7", default-features = false }
-test-case = "3.0.0"
+test-case = "3.2"
 verifier = { package = "miden-verifier", path = "../verifier", version = "0.7", default-features = false }
 vm-core = { package = "miden-core", path = "../core", version = "0.7", default-features = false }
 winter-prover = { package = "winter-prover", version = "0.6", default-features = false }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
-proptest = { version = "1.1"  }
+proptest = { version = "1.3"  }
 rand-utils = { package = "winter-rand-utils", version = "0.6" }


### PR DESCRIPTION
This PR adds Graviton compilation target to the makefile. When compiling to this target we enable `sve` feature on `miden-crypto` recently introduced in https://github.com/0xPolygonMiden/crypto/pull/190.

I also bumped up minimum `rustc` version to 1.73 (this should address #917) and generally cleaned up `.toml` files a bit.

### Performance impact
The time it takes to generate a proof for a program taking $2^{20}$ cycles on a 64-core Graviton3 instance:

| Hash function used | SVE acceleration | Time (seconds)  | Implied frequency | Baseline multiple |
| ------------------ | :--------------: | :-------------: | :---------------: | :---------------: |
| BLAKE3             | No               | 3.9             | 268 KHz           | 1x                |
| RPO256             | No               | 22.1            | 47 Khz            | 5.7x              |
| RPO256             | Yes              | 15.2            | 69 Khz            | 3.9x              |