### PR TITLE
Fix the Merkle Store example

### DIFF
--- a/miden/examples/merkle_store/merkle_store.masm
+++ b/miden/examples/merkle_store/merkle_store.masm
@@ -6,10 +6,9 @@ begin
     push.0.2
     mtree_get
     # check that returned value is equal to 20
-    push.20
-    assert_eq
+    push.20.0.0.0
+    assert_eqw
 
-    swapw
     dropw
     
     # push the root of the Sparse Merkle Tree on the stack
@@ -19,10 +18,9 @@ begin
     push.1.64
     mtree_get
     # check that returned value is equal to 21
-    push.21
-    assert_eq
+    push.21.0.0.0
+    assert_eqw
 
-    swapw
     dropw
     
     # push the root of the Merkle Tree on the stack
@@ -32,10 +30,9 @@ begin
     push.2.2
     mtree_get
     # check that returned value is equal to 22
-    push.22
-    assert_eq
+    push.22.0.0.0
+    assert_eqw
 
-    swapw
     dropw
 
 end


### PR DESCRIPTION
It turns out that after some PRs merged this example stops working properly. After the investigation I couldn't figure out how it even worked before, because it wasn't supposed to — `assert_eq` operation was used incorrectly and also the order of elements on the stack was incorrect (as if `mtree_get` was putting a word on the stack in a different order). I am sure that it was working, but now I can't neither remember, nor understand how. 

Anyway, this small PR fixed this example, so now it works fine. 
