### PR TITLE
Introduce `Host` no `RefCell`

### DIFF
--- a/stdlib/tests/collections/mmr.rs
+++ b/stdlib/tests/collections/mmr.rs
@@ -631,8 +631,7 @@ fn test_mmr_pack() {
 
     let process = build_test!(source).execute_process().unwrap();
 
-    let host = process.host.borrow_mut();
-    let advice_data = host.advice_provider().map().get(&hash_u8).unwrap();
+    let advice_data = process.host.advice_provider().map().get(&hash_u8).unwrap();
     assert_eq!(stack_to_ints(advice_data), stack_to_ints(&expect_data));
 }
 

--- a/stdlib/tests/collections/smt.rs
+++ b/stdlib/tests/collections/smt.rs
@@ -348,7 +348,7 @@ fn assert_insert(
     assert_eq!(stack, expected_output);
 
     // remove the initial key-value pairs from the advice map
-    let mut new_adv_map = process.host.borrow().advice_provider().map().clone();
+    let mut new_adv_map = process.host.advice_provider().map().clone();
     for (key, value) in adv_map.iter() {
         let init_value = new_adv_map.remove(key).unwrap();
         assert_eq!(value, &init_value);
@@ -639,7 +639,7 @@ fn assert_set(
     assert_eq!(stack, expected_output);
 
     // remove the initial key-value pairs from the advice map
-    let mut new_adv_map = process.host.borrow().advice_provider().map().clone();
+    let mut new_adv_map = process.host.advice_provider().map().clone();
     for (key, value) in adv_map.iter() {
         let init_value = new_adv_map.remove(key).unwrap();
         assert_eq!(value, &init_value);


### PR DESCRIPTION
This PR is a modification to the `Host` implementation which does not require a `RefCell` for the `Host` object. Instead we introduce the `ProcessStateObserver` object which allows the complier to validate compile time borrow rules.