### PR TITLE
Improve cycles output in `analyze` tool

### DIFF
--- a/miden/Cargo.toml
+++ b/miden/Cargo.toml
@@ -64,5 +64,5 @@ escargot = "0.5.7"
 num-bigint = "0.4"
 predicates = "3.0"
 test-utils = { package = "miden-test-utils", path = "../test-utils" }
-vm-core = { package = "miden-core", path = "../core", version = "0.7" }
 winter-fri = { package = "winter-fri", version = "0.6" }
+vm-core = { package = "miden-core", path = "../core", version = "0.7" }

--- a/processor/src/debug.rs
+++ b/processor/src/debug.rs
@@ -1,5 +1,6 @@
 use crate::{
-    Chiplets, Decoder, ExecutionError, Felt, Host, Process, Stack, StarkField, System, Vec,
+    range::RangeChecker, Chiplets, ChipletsLengths, Decoder, ExecutionError, Felt, Host, Process,
+    Stack, StarkField, System, TraceLenSummary, Vec,
 };
 use core::fmt;
 use vm_core::{
@@ -55,6 +56,7 @@ pub struct VmStateIterator {
     clk: u32,
     asmop_idx: usize,
     forward: bool,
+    trace_len_summary: TraceLenSummary,
 }
 
 impl VmStateIterator {
@@ -62,7 +64,9 @@ impl VmStateIterator {
     where
         H: Host,
     {
-        let (system, decoder, stack, _, chiplets, _) = process.into_parts();
+        let (system, decoder, stack, mut range, chiplets, _) = process.into_parts();
+        let trace_len_summary = Self::build_trace_len_summary(&system, &mut range, &chiplets);
+
         Self {
             chiplets,
             decoder,
@@ -72,6 +76,7 @@ impl VmStateIterator {
             clk: 0,
             asmop_idx: 0,
             forward: true,
+            trace_len_summary,
         }
     }
 
@@ -170,6 +175,23 @@ impl VmStateIterator {
 
     pub fn into_parts(self) -> (System, Decoder, Stack, Chiplets, Option<ExecutionError>) {
         (self.system, self.decoder, self.stack, self.chiplets, self.error)
+    }
+
+    pub fn trace_len_summary(&self) -> &TraceLenSummary {
+        &self.trace_len_summary
+    }
+
+    /// Returns an instance of [TraceLenSummary] based on provided data.
+    fn build_trace_len_summary(
+        system: &System,
+        range: &mut RangeChecker,
+        chiplets: &Chiplets,
+    ) -> TraceLenSummary {
+        let clk = system.clk();
+        let range_table_len = range.get_number_range_checker_rows();
+        chiplets.append_range_checks(range);
+
+        TraceLenSummary::new(clk as usize, range_table_len, ChipletsLengths::new(chiplets))
     }
 }
 

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -51,8 +51,8 @@ mod chiplets;
 use chiplets::Chiplets;
 
 mod trace;
-pub use trace::ExecutionTrace;
 use trace::TraceFragment;
+pub use trace::{ChipletsLengths, ExecutionTrace, TraceLenSummary};
 
 mod errors;
 pub use errors::{ExecutionError, Ext2InttError};

--- a/processor/src/trace/utils.rs
+++ b/processor/src/trace/utils.rs
@@ -247,7 +247,7 @@ impl HintCycle for u64 {
 /// - `range_trace_len` contains the length of the range checker trace.
 /// - `chiplets_trace_len` contains the trace lengths of the all chiplets (hash, bitwise, memory,
 /// kernel ROM)
-#[derive(Debug)]
+#[derive(Debug, Default, Eq, PartialEq, Clone, Copy)]
 pub struct TraceLenSummary {
     main_trace_len: usize,
     range_trace_len: usize,
@@ -297,7 +297,7 @@ impl TraceLenSummary {
 
 /// Contains trace lengths of all chilplets: hash, bitwise, memory and kernel ROM trace
 /// lengths.
-#[derive(Clone, Copy, Debug)]
+#[derive(Default, Clone, Copy, Debug, PartialEq, Eq)]
 pub struct ChipletsLengths {
     hash_chiplet_len: usize,
     bitwise_chiplet_len: usize,
@@ -312,6 +312,20 @@ impl ChipletsLengths {
             bitwise_chiplet_len: chiplets.memory_start() - chiplets.bitwise_start(),
             memory_chiplet_len: chiplets.kernel_rom_start() - chiplets.memory_start(),
             kernel_rom_len: chiplets.padding_start() - chiplets.kernel_rom_start(),
+        }
+    }
+
+    pub fn from_parts(
+        hash_len: usize,
+        bitwise_len: usize,
+        memory_len: usize,
+        kernel_len: usize,
+    ) -> Self {
+        ChipletsLengths {
+            hash_chiplet_len: hash_len,
+            bitwise_chiplet_len: bitwise_len,
+            memory_chiplet_len: memory_len,
+            kernel_rom_len: kernel_len,
         }
     }
 


### PR DESCRIPTION
This PR adds extended information about traces lengths of VM components to the `analyze` tool output.
