### PR TITLE
Writing `ProgramAst` into files 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.7.0 (TBD)
+## 0.7.0 (2023-10-11)
 
 #### Assembly
 - Added ability to attach doc comments to re-exported procedures (#994).
@@ -11,6 +11,9 @@
 - Added `adv.push_smtpeek` decorator (#1056).
 - Added `debug` decorator (#1069).
 - Refactored `push` instruction so now it parses long hex string in little-endian (#1076).
+
+#### CLI
+- Implemented ability to output compiled `.masb` files to disk (#1102).
 
 #### VM Internals
 - Simplified range checker and removed 1 main and 1 auxiliary trace column (#949).
@@ -23,9 +26,11 @@
 - Added `TraceLenSummary` struct which holds information about traces lengths to the `ExecutionTrace` (#1029).
 - Imposed the 2^32 limit for the memory addresses used in the memory chiplet (#1049). 
 - Supported `PartialMerkleTree` as a secret input in `.input` file (#1072).
+- [BREAKING] Refactored `AdviceProvider` interface into [Host] interface (#1082).
 
 #### Stdlib
 - Completed `std::collections::smt` module by implementing `insert` and `set` procedures (#1036, #1038, #1046).
+- Added new module `std::crypto::dsa::rpo_falcon512` to support Falcon signature verification (#1000, #1094)
 
 ## 0.6.1 (2023-06-29)
 

--- a/assembly/src/assembler/mod.rs
+++ b/assembly/src/assembler/mod.rs
@@ -130,9 +130,19 @@ impl Assembler {
         let source = source.as_ref();
         let program = ProgramAst::parse(source)?;
 
+        // compile the program and return
+        self.compile_ast(&program)
+    }
+
+    /// Compiles the provided abstract syntax tree into a [Program]. The resulting program can be
+    /// executed on Miden VM.
+    ///
+    /// # Errors
+    /// Returns an error if the compilation of the specified program fails.
+    pub fn compile_ast(&self, program: &ProgramAst) -> Result<Program, AssemblyError> {
         // compile the program
-        let mut context = AssemblyContext::for_program(Some(&program));
-        let program_root = self.compile_in_context(&program, &mut context)?;
+        let mut context = AssemblyContext::for_program(Some(program));
+        let program_root = self.compile_in_context(program, &mut context)?;
 
         // convert the context into a call block table for the program
         let cb_table = context.into_cb_table(&self.proc_cache.borrow())?;

--- a/assembly/src/ast/mod.rs
+++ b/assembly/src/ast/mod.rs
@@ -10,6 +10,8 @@ use super::{
     MAX_LABEL_LEN,
 };
 use core::{fmt, iter, str::from_utf8};
+#[cfg(feature = "std")]
+use std::{fs, io, path::Path};
 use vm_core::utils::bound_into_included_u64;
 
 pub use super::tokens::SourceLocation;
@@ -335,6 +337,23 @@ impl ProgramAst {
     /// Clear import info from the program
     pub fn clear_imports(&mut self) {
         self.import_info = None;
+    }
+
+    // WRITE TO FILE
+    // --------------------------------------------------------------------------------------------
+    #[cfg(feature = "std")]
+    /// Writes ProgramAst to provided file path
+    pub fn write_to_file<P>(&self, dir_path: P) -> io::Result<()>
+    where
+        P: AsRef<Path>,
+    {
+        fs::create_dir_all(&dir_path)?;
+        let path = dir_path;
+
+        let bytes = self.to_bytes(AstSerdeOptions {
+            serialize_imports: true,
+        });
+        fs::write(path, bytes)
     }
 }
 

--- a/assembly/src/ast/mod.rs
+++ b/assembly/src/ast/mod.rs
@@ -341,14 +341,17 @@ impl ProgramAst {
 
     // WRITE TO FILE
     // --------------------------------------------------------------------------------------------
-    #[cfg(feature = "std")]
+
     /// Writes ProgramAst to provided file path
-    pub fn write_to_file<P>(&self, dir_path: P) -> io::Result<()>
+    #[cfg(feature = "std")]
+    pub fn write_to_file<P>(&self, file_path: P) -> io::Result<()>
     where
         P: AsRef<Path>,
     {
-        fs::create_dir_all(&dir_path)?;
-        let path = dir_path;
+        let path = file_path.as_ref();
+        if let Some(dir) = path.parent() {
+            fs::create_dir_all(dir)?;
+        }
 
         let bytes = self.to_bytes(AstSerdeOptions {
             serialize_imports: true,

--- a/miden/src/cli/compile.rs
+++ b/miden/src/cli/compile.rs
@@ -12,6 +12,9 @@ pub struct CompileCmd {
     /// Paths to .masl library files
     #[clap(short = 'l', long = "libraries", value_parser)]
     library_paths: Vec<PathBuf>,
+    /// Path to output file
+    #[clap(short = 'o', long = "output", value_parser)]
+    output_file: Option<PathBuf>,
 }
 
 impl CompileCmd {
@@ -20,16 +23,20 @@ impl CompileCmd {
         println!("Compile program");
         println!("============================================================");
 
+        // load the program from file and parse it
+        let program = ProgramFile::read(&self.assembly_file)?;
+
         // load libraries from files
         let libraries = Libraries::new(&self.library_paths)?;
 
-        // load program from file and compile
-        let program = ProgramFile::read(&self.assembly_file, &Debug::Off, libraries.libraries)?;
+        // compile the program
+        let compiled_program = program.compile(&Debug::Off, libraries.libraries)?;
 
         // report program hash to user
-        let program_hash: [u8; 32] = program.hash().into();
+        let program_hash: [u8; 32] = compiled_program.hash().into();
         println!("program hash is {}", hex::encode(program_hash));
 
-        Ok(())
+        // write the compiled file
+        program.write(self.output_file.clone())
     }
 }

--- a/miden/src/cli/debug/mod.rs
+++ b/miden/src/cli/debug/mod.rs
@@ -36,7 +36,8 @@ impl DebugCmd {
         let libraries = Libraries::new(&self.library_paths)?;
 
         // load program from file and compile
-        let program = ProgramFile::read(&self.assembly_file, &Debug::On, libraries.libraries)?;
+        let program =
+            ProgramFile::read(&self.assembly_file)?.compile(&Debug::On, libraries.libraries)?;
 
         let program_hash: [u8; 32] = program.hash().into();
         println!("Debugging program with hash {}... ", hex::encode(program_hash));

--- a/miden/src/cli/prove.rs
+++ b/miden/src/cli/prove.rs
@@ -75,7 +75,8 @@ impl ProveCmd {
         let libraries = Libraries::new(&self.library_paths)?;
 
         // load program from file and compile
-        let program = ProgramFile::read(&self.assembly_file, &Debug::Off, libraries.libraries)?;
+        let program =
+            ProgramFile::read(&self.assembly_file)?.compile(&Debug::Off, libraries.libraries)?;
 
         // load input data from file
         let input_data = InputFile::read(&self.input_file, &self.assembly_file)?;

--- a/miden/src/cli/run.rs
+++ b/miden/src/cli/run.rs
@@ -45,7 +45,8 @@ impl RunCmd {
         let libraries = Libraries::new(&self.library_paths)?;
 
         // load program from file and compile
-        let program = ProgramFile::read(&self.assembly_file, &Debug::Off, libraries.libraries)?;
+        let program =
+            ProgramFile::read(&self.assembly_file)?.compile(&Debug::Off, libraries.libraries)?;
 
         // load input data from file
         let input_data = InputFile::read(&self.input_file, &self.assembly_file)?;

--- a/miden/src/lib.rs
+++ b/miden/src/lib.rs
@@ -4,14 +4,17 @@
 // EXPORTS
 // ================================================================================================
 
-pub use assembly::{Assembler, AssemblyError, ParsingError};
+pub use assembly::{
+    ast::{ModuleAst, ProgramAst},
+    Assembler, AssemblyError, ParsingError,
+};
 pub use processor::{
     crypto, execute, execute_iter, utils, AdviceInputs, AdviceProvider, AsmOpInfo, DefaultHost,
-    ExecutionError, ExecutionTrace, Host, Kernel, MemAdviceProvider, Operation, ProgramInfo,
-    StackInputs, VmState, VmStateIterator, ZERO,
+    ExecutionError, ExecutionTrace, Host, Kernel, MemAdviceProvider, Operation, Program,
+    ProgramInfo, StackInputs, VmState, VmStateIterator, ZERO,
 };
 pub use prover::{
-    math, prove, Digest, ExecutionProof, FieldExtension, HashFunction, InputError, Program,
-    ProvingOptions, StackOutputs, StarkProof, Word,
+    math, prove, Digest, ExecutionProof, FieldExtension, HashFunction, InputError, ProvingOptions,
+    StackOutputs, StarkProof, Word,
 };
 pub use verifier::{verify, VerificationError};


### PR DESCRIPTION
## Describe your changes
Closes #1098 

Adds the procedure `write_to_file` into `ProgramAst` Struct to allow reading standard note scripts, e.g., P2ID and P2IDR, see https://github.com/0xPolygonMiden/miden-base/pull/269
