### PR TITLE
Expand capabilities of the `debug` instruction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.8.0 (TBD)
 
+#### Assembly
+- Expanded capabilities of the `debug` decorator. Added `debug.mem` and `debug.local` variations.
+
 #### Stdlib
 - Introduced `std::utils` module with `is_empty_word` procedure.  Refactored `std::collections::smt` 
   and `std::collections::smt64` to use the procedure (#1107).

--- a/assembly/src/ast/mod.rs
+++ b/assembly/src/ast/mod.rs
@@ -174,6 +174,7 @@ impl ProgramAst {
             local_procs: LocalProcMap::default(),
             reexported_procs: ReExportedProcMap::default(),
             local_constants,
+            num_proc_locals: 0,
         };
 
         context.parse_procedures(&mut tokens, false)?;
@@ -456,6 +457,7 @@ impl ModuleAst {
             local_procs: LocalProcMap::default(),
             reexported_procs: ReExportedProcMap::default(),
             local_constants,
+            num_proc_locals: 0,
         };
         context.parse_procedures(&mut tokens, true)?;
 

--- a/assembly/src/ast/parsers/context.rs
+++ b/assembly/src/ast/parsers/context.rs
@@ -15,6 +15,7 @@ pub struct ParserContext<'a> {
     pub local_procs: LocalProcMap,
     pub reexported_procs: ReExportedProcMap,
     pub local_constants: LocalConstMap,
+    pub num_proc_locals: u16,
 }
 
 impl ParserContext<'_> {
@@ -290,8 +291,12 @@ impl ParserContext<'_> {
             None
         };
 
+        self.num_proc_locals = num_locals;
+
         // parse procedure body
         let body = self.parse_body(tokens, false)?;
+
+        self.num_proc_locals = 0;
 
         // consume the 'end' token
         match tokens.read() {
@@ -623,7 +628,7 @@ impl ParserContext<'_> {
 
             // ----- debug decorators -------------------------------------------------------------
             "breakpoint" => simple_instruction(op, Breakpoint),
-            "debug" => debug::parse_debug(op),
+            "debug" => debug::parse_debug(op, self.num_proc_locals),
 
             // ----- catch all --------------------------------------------------------------------
             _ => Err(ParsingError::invalid_op(op)),

--- a/assembly/src/ast/parsers/debug.rs
+++ b/assembly/src/ast/parsers/debug.rs
@@ -14,7 +14,7 @@ use vm_core::DebugOptions;
 /// # Errors
 /// Returns an error if the instruction token contains a wrong number of parameters, or if
 /// the provided parameters are not valid.
-pub fn parse_debug(op: &Token) -> Result<Node, ParsingError> {
+pub fn parse_debug(op: &Token, num_proc_locals: u16) -> Result<Node, ParsingError> {
     debug_assert_eq!(op.parts()[0], "debug");
     if op.num_parts() < 2 {
         return Err(ParsingError::missing_param(op, "debug.stack.<debug_params?>"));
@@ -26,6 +26,38 @@ pub fn parse_debug(op: &Token) -> Result<Node, ParsingError> {
             3 => {
                 let n: u16 = parse_checked_param(op, 2, 1..=u16::MAX)?;
                 DebugOptions::StackTop(n)
+            }
+            _ => return Err(ParsingError::extra_param(op)),
+        },
+        "mem" => match op.num_parts() {
+            2 => DebugOptions::MemAll,
+            3 => {
+                let n: u32 = parse_checked_param(op, 2, 1..=u32::MAX)?;
+                DebugOptions::MemInterval(n, n)
+            }
+            4 => {
+                let n: u32 = parse_checked_param(op, 2, 0..=u32::MAX)?;
+                let m: u32 = parse_checked_param(op, 3, 0..=u32::MAX)?;
+                if m < n {
+                    return Err(ParsingError::invalid_param_with_reason(op, 3, "the index of the end of the interval must be greater than the index of its beginning"));
+                }
+                DebugOptions::MemInterval(n, m)
+            }
+            _ => return Err(ParsingError::extra_param(op)),
+        },
+        "local" => match op.num_parts() {
+            2 => DebugOptions::LocalInterval(0, u16::MAX, num_proc_locals),
+            3 => {
+                let n: u16 = parse_checked_param(op, 2, 0..=u16::MAX)?;
+                DebugOptions::LocalInterval(n, n, num_proc_locals)
+            }
+            4 => {
+                let n: u16 = parse_checked_param(op, 2, 0..=u16::MAX)?;
+                let m: u16 = parse_checked_param(op, 3, 0..=u16::MAX)?;
+                if m < n {
+                    return Err(ParsingError::invalid_param_with_reason(op, 3, "the index of the end of the interval must be greater than the index of its beginning"));
+                }
+                DebugOptions::LocalInterval(n, m, num_proc_locals)
             }
             _ => return Err(ParsingError::extra_param(op)),
         },

--- a/core/src/operations/decorators/debug.rs
+++ b/core/src/operations/decorators/debug.rs
@@ -13,6 +13,19 @@ pub enum DebugOptions {
     StackAll,
     /// Prints out the top n items of the stack for the current context.
     StackTop(u16),
+    /// Prints out the entire contents of RAM.
+    MemAll,
+    /// Prints out the contents of memory stored in the provided interval. Interval boundaries are
+    /// both inclusive.
+    ///
+    /// First parameter specifies the interval starting address, second -- the ending address.
+    MemInterval(u32, u32),
+    /// Prints out locals stored in the provided interval of the currently executing procedure.
+    /// Interval boundaries are both inclusive.
+    ///
+    /// First parameter specifies the starting address, second -- the ending address, and the third
+    /// specifies the overall number of locals.
+    LocalInterval(u16, u16, u16),
 }
 
 impl fmt::Display for DebugOptions {
@@ -20,6 +33,11 @@ impl fmt::Display for DebugOptions {
         match self {
             Self::StackAll => write!(f, "stack"),
             Self::StackTop(n) => write!(f, "stack.{n}"),
+            Self::MemAll => write!(f, "mem"),
+            Self::MemInterval(n, m) => write!(f, "mem.{n}.{m}"),
+            Self::LocalInterval(start, end, _) => {
+                write!(f, "local.{start}.{end}")
+            }
         }
     }
 }

--- a/docs/src/user_docs/assembly/debugging.md
+++ b/docs/src/user_docs/assembly/debugging.md
@@ -4,6 +4,12 @@ To support basic debugging capabilities, Miden assembly provides a `debug` instr
 
 - `debug.stack` prints out the entire contents of the stack.
 - `debug.stack.<n>` prints out the top $n$ items of the stack. $n$ must be an integer greater than $0$ and smaller than $256$.
+- `debug.mem` prints out the entire contents of RAM.
+- `debug.mem.<n>` prints out contents of memory at address $n$.
+- `debug.mem.<n>.<m>` prints out the contents of memory starting at address $n$ and ending at address $m$ (both inclusive). $m$ must be greater or equal to $n$.
+- `debug.local` prints out the whole local memory of the currently executing procedure.
+- `debug.local.<n>` prints out contents of the local memory at index $n$ for the currently executing procedure. $n$ must be greater or equal to $0$ and smaller than $65536$.
+- `debug.local.<n>.<m>` prints out contents of the local memory starting at index $n$ and ending at index $m$ (both inclusive). $m$ must be greater or equal to $n$. $n$ and $m$ must be greater or equal to $0$ and smaller than $65536$.
 
 Debug instructions do not affect the VM state and do not change the program hash.
 

--- a/miden/examples/debug/debug.inputs
+++ b/miden/examples/debug/debug.inputs
@@ -1,0 +1,3 @@
+{
+    "operand_stack": []
+}

--- a/miden/examples/debug/debug.masm
+++ b/miden/examples/debug/debug.masm
@@ -1,0 +1,42 @@
+proc.foo.3
+    push.11
+    loc_store.0
+    push.101
+    loc_store.1
+
+    debug.local
+    debug.local.1
+    debug.local.0.1
+    debug.local.1.5
+    # will fail: debug.local.0.65536
+    # will fail: debug.local.1.65540
+end
+
+proc.bar.4
+    push.21
+    loc_store.0
+    push.121
+    loc_store.1
+    debug.local
+    debug.local.2
+end
+
+begin 
+    push.13.2
+    mem_store
+    debug.mem.2
+    push.104467440737.1
+    mem_store
+    push.1044674407370.10446744073.10446744073709.10446744073709.1000
+    mem_storew
+
+    debug.mem.1000
+    debug.mem.1001
+    debug.mem.999.1002
+    debug.mem
+
+    debug.stack.8
+
+    exec.foo
+    exec.bar
+end

--- a/processor/src/host/debug.rs
+++ b/processor/src/host/debug.rs
@@ -1,22 +1,28 @@
-use super::{Felt, ProcessState};
+use super::ProcessState;
 use crate::Vec;
-use vm_core::DebugOptions;
+use vm_core::{DebugOptions, StarkField, Word};
 
 // DEBUG HANDLER
 // ================================================================================================
 
 /// Prints the info about the VM state specified by the provided options to stdout.
 pub fn print_debug_info<S: ProcessState>(process: &S, options: &DebugOptions) {
-    let clk = process.clk();
+    let printer = Printer::new(process.clk(), process.ctx(), process.fmp());
     match options {
         DebugOptions::StackAll => {
-            let stack = process.get_stack_state();
-            let n = stack.len();
-            print_vm_stack(clk, stack, n);
+            printer.print_vm_stack(process, None);
         }
         DebugOptions::StackTop(n) => {
-            let stack = process.get_stack_state();
-            print_vm_stack(clk, stack, *n as usize);
+            printer.print_vm_stack(process, Some(*n as usize));
+        }
+        DebugOptions::MemAll => {
+            printer.print_mem_all(process);
+        }
+        DebugOptions::MemInterval(n, m) => {
+            printer.print_mem_interval(process, *n, *m);
+        }
+        DebugOptions::LocalInterval(n, m, num_locals) => {
+            printer.print_local_interval(process, (*n as u32, *m as u32), *num_locals as u32);
         }
     }
 }
@@ -24,29 +30,202 @@ pub fn print_debug_info<S: ProcessState>(process: &S, options: &DebugOptions) {
 // HELPER FUNCTIONS
 // ================================================================================================
 
-#[cfg(feature = "std")]
-fn print_vm_stack(clk: u32, stack: Vec<Felt>, n: usize) {
-    // determine how many items to print out
-    let num_items = core::cmp::min(stack.len(), n);
+struct Printer {
+    clk: u32,
+    ctx: u32,
+    fmp: u32,
+}
 
-    // print all items except for the last one
-    println!("Stack state before step {clk}:");
-    for (i, element) in stack.iter().take(num_items - 1).enumerate() {
-        println!("├── {i:>2}: {element}");
+impl Printer {
+    fn new(clk: u32, ctx: u32, fmp: u64) -> Self {
+        Self {
+            clk,
+            ctx,
+            fmp: fmp as u32,
+        }
     }
 
-    // print the last item, and in case the stack has more items, print the total number of
-    // un-printed items
-    let i = num_items - 1;
-    if num_items == stack.len() {
-        println!("└── {i:>2}: {}", stack[i]);
-    } else {
-        println!("├── {i:>2}: {}", stack[i]);
-        println!("└── ({} more items)", stack.len() - num_items);
+    fn print_vm_stack<S: ProcessState>(&self, process: &S, n: Option<usize>) {
+        let stack = process.get_stack_state();
+
+        // determine how many items to print out
+        let num_items = core::cmp::min(stack.len(), n.unwrap_or(stack.len()));
+
+        // print all items except for the last one
+        println!("Stack state before step {}:", self.clk);
+        for (i, element) in stack.iter().take(num_items - 1).enumerate() {
+            println!("├── {i:>2}: {element}");
+        }
+
+        // print the last item, and in case the stack has more items, print the total number of
+        // un-printed items
+        let i = num_items - 1;
+        if num_items == stack.len() {
+            println!("└── {i:>2}: {}\n", stack[i]);
+        } else {
+            println!("├── {i:>2}: {}", stack[i]);
+            println!("└── ({} more items)\n", stack.len() - num_items);
+        }
+    }
+
+    /// Prints the whole memory state at the cycle `clk` in context `ctx`.
+    fn print_mem_all<S: ProcessState>(&self, process: &S) {
+        let mem = process.get_mem_state(self.ctx);
+        let padding =
+            mem.iter().fold(0, |max, value| word_elem_max_len(Some(value.1)).max(max)) as usize;
+
+        println!("Memory state before step {} for the context {}:", self.clk, self.ctx);
+
+        // print the main part of the memory (wihtout the last value)
+        for (addr, value) in mem.iter().take(mem.len() - 1) {
+            print_mem_address(*addr as u32, Some(*value), false, false, padding);
+        }
+
+        // print the last memory value
+        if let Some((addr, value)) = mem.last() {
+            print_mem_address(*addr as u32, Some(*value), true, false, padding);
+        }
+    }
+
+    /// Prints memory values in the provided addresses interval.
+    fn print_mem_interval<S: ProcessState>(&self, process: &S, n: u32, m: u32) {
+        let mut mem_interval = Vec::new();
+        for addr in n..m + 1 {
+            mem_interval.push((addr, process.get_mem_value(self.ctx, addr)));
+        }
+
+        if n == m {
+            println!(
+                "Memory state before step {} for the context {} at address {}:",
+                self.clk, self.ctx, n
+            )
+        } else {
+            println!(
+                "Memory state before step {} for the context {} in the interval [{}, {}]:",
+                self.clk, self.ctx, n, m
+            )
+        };
+
+        print_interval(mem_interval, false);
+    }
+
+    /// Prints locals in provided indexes interval.
+    fn print_local_interval<S: ProcessState>(
+        &self,
+        process: &S,
+        interval: (u32, u32),
+        num_locals: u32,
+    ) {
+        let mut local_mem_interval = Vec::new();
+        let local_memory_offset = self.fmp - num_locals + 1;
+
+        // in case start index is 0 and end index is 2^16, we should print all available locals.
+        let (start, end) = if interval.0 == 0 && interval.1 == u16::MAX as u32 {
+            (0, num_locals - 1)
+        } else {
+            interval
+        };
+        for index in start..end + 1 {
+            local_mem_interval
+                .push((index, process.get_mem_value(self.ctx, index + local_memory_offset)))
+        }
+
+        if interval.0 == 0 && interval.1 == u16::MAX as u32 {
+            println!("State of procedure locals before step {}:", self.clk)
+        } else if interval.0 == interval.1 {
+            println!("State of procedure local at index {} before step {}:", interval.0, self.clk,)
+        } else {
+            println!(
+                "State of procedure locals [{}, {}] before step {}:",
+                interval.0, interval.1, self.clk,
+            )
+        };
+
+        print_interval(local_mem_interval, true);
     }
 }
 
-#[cfg(not(feature = "std"))]
-fn print_vm_stack(_clk: u32, _stack: Vec<Felt>, _n: usize) {
-    // in no_std environments, this is a NOOP
+// HELPER FUNCTIONS
+// ================================================================================================
+
+/// Prints the provided memory interval.
+///
+/// If `is_local` is true, the output addresses are formatted as decimal values, otherwise as hex
+/// strings.
+fn print_interval(mem_interval: Vec<(u32, Option<Word>)>, is_local: bool) {
+    let padding =
+        mem_interval.iter().fold(0, |max, value| word_elem_max_len(value.1).max(max)) as usize;
+
+    // print the main part of the memory (wihtout the last value)
+    for (addr, value) in mem_interval.iter().take(mem_interval.len() - 1) {
+        print_mem_address(*addr, *value, false, is_local, padding)
+    }
+
+    // print the last memory value
+    if let Some((addr, value)) = mem_interval.last() {
+        print_mem_address(*addr, *value, true, is_local, padding);
+    }
+}
+
+/// Prints single memory value with its address.
+///
+/// If `is_local` is true, the output address is formatted as decimal value, otherwise as hex
+/// string.
+fn print_mem_address(
+    addr: u32,
+    value: Option<Word>,
+    is_last: bool,
+    is_local: bool,
+    padding: usize,
+) {
+    if let Some(value) = value {
+        if is_last {
+            if is_local {
+                print!("└── {addr:>5}: ");
+            } else {
+                print!("└── {addr:#010x}: ");
+            }
+            print_word(value, padding);
+            println!();
+        } else {
+            if is_local {
+                print!("├── {addr:>5}: ");
+            } else {
+                print!("├── {addr:#010x}: ");
+            }
+            print_word(value, padding);
+        }
+    } else if is_last {
+        if is_local {
+            println!("└── {addr:>5}: EMPTY\n");
+        } else {
+            println!("└── {addr:#010x}: EMPTY\n");
+        }
+    } else if is_local {
+        println!("├── {addr:>5}: EMPTY");
+    } else {
+        println!("├── {addr:#010x}: EMPTY");
+    }
+}
+
+/// Prints the provided Word with specified padding.
+fn print_word(value: Word, padding: usize) {
+    println!(
+        "[{:>width$}, {:>width$}, {:>width$}, {:>width$}]",
+        value[0].as_int(),
+        value[1].as_int(),
+        value[2].as_int(),
+        value[3].as_int(),
+        width = padding
+    )
+}
+
+/// Returns the maximum length among the word elements.
+fn word_elem_max_len(word: Option<Word>) -> u32 {
+    if let Some(word) = word {
+        word.iter()
+            .fold(0, |max, value| (value.as_int().checked_ilog10().unwrap_or(1) + 1).max(max))
+    } else {
+        0
+    }
 }

--- a/processor/src/host/mod.rs
+++ b/processor/src/host/mod.rs
@@ -5,6 +5,7 @@ use vm_core::{crypto::merkle::MerklePath, AdviceInjector, DebugOptions, Word};
 pub(super) mod advice;
 use advice::{AdviceExtractor, AdviceProvider};
 
+#[cfg(feature = "std")]
 mod debug;
 
 // HOST TRAIT
@@ -60,6 +61,7 @@ pub trait Host {
         process: &S,
         options: &DebugOptions,
     ) -> Result<HostResponse, ExecutionError> {
+        #[cfg(feature = "std")]
         debug::print_debug_info(process, options);
         Ok(HostResponse::None)
     }

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -387,7 +387,7 @@ where
         // can happen for decorators appearing after all operations in a block. these decorators
         // are executed after SPAN block is closed to make sure the VM clock cycle advances beyond
         // the last clock cycle of the SPAN block ops.
-        if let Some(decorator) = decorators.next() {
+        for decorator in decorators {
             self.execute_decorator(decorator)?;
         }
 
@@ -529,6 +529,9 @@ pub trait ProcessState {
     /// Returns the current execution context ID.
     fn ctx(&self) -> u32;
 
+    /// Returns the current value of the free memory pointer.
+    fn fmp(&self) -> u64;
+
     /// Returns the value located at the specified position on the stack at the current clock cycle.
     fn get_stack_item(&self, pos: usize) -> Felt;
 
@@ -551,6 +554,13 @@ pub trait ProcessState {
     /// Returns a word located at the specified context/address, or None if the address hasn't
     /// been accessed previously.
     fn get_mem_value(&self, ctx: u32, addr: u32) -> Option<Word>;
+
+    /// Returns the entire memory state for the specified execution context at the current clock
+    /// cycle.
+    ///
+    /// The state is returned as a vector of (address, value) tuples, and includes addresses which
+    /// have been accessed at least once.
+    fn get_mem_state(&self, ctx: u32) -> Vec<(u64, Word)>;
 }
 
 impl<H: Host> ProcessState for Process<H> {
@@ -560,6 +570,10 @@ impl<H: Host> ProcessState for Process<H> {
 
     fn ctx(&self) -> u32 {
         self.system.ctx()
+    }
+
+    fn fmp(&self) -> u64 {
+        self.system.fmp().as_int()
     }
 
     fn get_stack_item(&self, pos: usize) -> Felt {
@@ -576,6 +590,10 @@ impl<H: Host> ProcessState for Process<H> {
 
     fn get_mem_value(&self, ctx: u32, addr: u32) -> Option<Word> {
         self.chiplets.get_mem_value(ctx, addr)
+    }
+
+    fn get_mem_state(&self, ctx: u32) -> Vec<(u64, Word)> {
+        self.chiplets.get_mem_state_at(ctx, self.system.clk())
     }
 }
 

--- a/stdlib/docs/utils.md
+++ b/stdlib/docs/utils.md
@@ -2,4 +2,4 @@
 ## std::utils
 | Procedure | Description |
 | ----------- | ------------- |
-| is_empty_word | Returns a boolean indicating whether the input word is an empty word.<br /><br />Inputs: [INPUT_WORD]<br /><br />Outputs: [is_empty_word, INPUT_WORD]<br /><br />- INPUT_WORD is the word whose emptiness is to be determined.<br /><br />- is_empty_word is a boolean indicating whether INPUT_WORD is empty. |
+| is_empty_word | Returns a boolean indicating whether the input word is an empty word.<br /><br />Inputs: [INPUT_WORD]<br /><br />Outputs: [is_empty_word, INPUT_WORD]<br /><br />- INPUT_WORD is the word whose emptiness is to be determined.<br /><br />- is_empty_word is a boolean indicating whether INPUT_WORD is empty.<br /><br />Cycles: 11 |


### PR DESCRIPTION
This PR expands the capabilities of the `debug` instruction by printing information about memory and procedure locals, namely:
- `debug.mem` prints out the entire contents of RAM.
- `debug.mem.<n>` prints out contents of memory at address `n`.
- `debug.mem.<n>.<m>` prints out the contents of memory starting at address `n` and ending at address `m` (both inclusive). `m` must be greater than `n`.
- `debug.local` prints out all locals of the currently executing procedure.
- `debug.local.<n>` prints out contents of the local at index `n` for the currently executing procedure.
- `debug.local.<n>.<m>` prints out contents of the local starting at index `n` and ending at index `m` (both inclusive). `m` must be greater than `n`.

TODO:
- [ ] Update docs and changelog
