### PR TITLE
feat(assembly): allow creation of masl libraries via api

### DIFF
--- a/assembly/src/library/masl.rs
+++ b/assembly/src/library/masl.rs
@@ -73,7 +73,7 @@ impl MaslLibrary {
     /// # Errors
     /// Returns an error if the provided `modules` vector is empty or contains more than
     /// [u16::MAX] elements.
-    pub(super) fn new(
+    pub fn new(
         namespace: LibraryNamespace,
         version: Version,
         has_source_locations: bool,


### PR DESCRIPTION
This PR exposes `MaslLibrary::new` to consumers of the `miden-assembly` crate. In particular, I plan to use this from the compiler to emit multi-module libraries to disk. I didn't observe any particular reason why this function was kept crate-local, since it is a safe API to call, so just assumed there hadn't been a need for it yet.


