### PR TITLE
feat: improve ergonomics of/access to module import info apis

### DIFF
--- a/assembly/src/assembler/context.rs
+++ b/assembly/src/assembler/context.rs
@@ -43,7 +43,8 @@ impl AssemblyContext {
     /// by the program, and thus, will be able to determine names of imported procedures for error
     /// reporting purposes.
     pub fn for_program(program: Option<&ProgramAst>) -> Self {
-        let program_imports = program.map(|p| p.get_imported_procedures_map()).unwrap_or_default();
+        let program_imports =
+            program.map(|p| p.import_info().get_imported_procedures()).unwrap_or_default();
         Self {
             module_stack: vec![ModuleContext::for_program(program_imports)],
             is_kernel: false,
@@ -118,7 +119,7 @@ impl AssemblyContext {
         }
 
         // get the imported procedures map
-        let proc_map = module_ast.get_imported_procedures_map();
+        let proc_map = module_ast.import_info().get_imported_procedures();
 
         // push a new module context onto the module stack and return
         self.module_stack.push(ModuleContext::for_module(module_path, proc_map));

--- a/assembly/src/ast/imports.rs
+++ b/assembly/src/ast/imports.rs
@@ -77,6 +77,16 @@ impl ModuleImports {
     // PUBLIC ACCESSORS
     // --------------------------------------------------------------------------------------------
 
+    /// Returns true if there are no imports in the containing module
+    pub fn is_empty(&self) -> bool {
+        self.imports.is_empty()
+    }
+
+    /// Returns the number of imports contained in this table
+    pub fn len(&self) -> usize {
+        self.imports.len()
+    }
+
     /// Look up the path of the imported module with the given name.
     pub fn get_module_path(&self, module_name: &str) -> Option<&LibraryPath> {
         self.imports.get(&module_name.to_string())
@@ -87,8 +97,13 @@ impl ModuleImports {
         self.imports.values().collect()
     }
 
-    /// Returns a reference to the invoked procedure map which maps procedure IDs to their names.
-    pub fn invoked_procs(&self) -> &InvokedProcsMap {
+    /// Returns a map containing IDs and names of imported procedures.
+    pub fn get_imported_procedures(&self) -> BTreeMap<ProcedureId, ProcedureName> {
+        self.invoked_procs.iter().map(|(id, (name, _))| (*id, name.clone())).collect()
+    }
+
+    /// Returns a reference to the internal invoked procedure map which maps procedure IDs to their names and paths.
+    pub(super) fn invoked_procs(&self) -> &InvokedProcsMap {
         &self.invoked_procs
     }
 
@@ -122,6 +137,12 @@ impl ModuleImports {
             ));
         }
         Ok(proc_id)
+    }
+
+    /// Clears all stored information about imported modules and invoked procedures
+    pub fn clear(&mut self) {
+        self.imports.clear();
+        self.invoked_procs.clear();
     }
 }
 

--- a/assembly/src/ast/imports.rs
+++ b/assembly/src/ast/imports.rs
@@ -92,6 +92,24 @@ impl ModuleImports {
         self.imports.get(&module_name.to_string())
     }
 
+    /// Look up the actual procedure name and module path associated with the given [ProcedureId],
+    /// if that procedure was imported and invoked in the current module.
+    pub fn get_procedure_info(&self, id: &ProcedureId) -> Option<(&ProcedureName, &LibraryPath)> {
+        self.invoked_procs.get(id).map(|(name, path)| (name, path))
+    }
+
+    /// Look up the procedure name associated with the given [ProcedureId],
+    /// if that procedure was imported and invoked in the current module.
+    pub fn get_procedure_name(&self, id: &ProcedureId) -> Option<&ProcedureName> {
+        self.invoked_procs.get(id).map(|(name, _)| name)
+    }
+
+    /// Look up the [LibraryPath] associated with the given [ProcedureId],
+    /// if that procedure was imported and invoked in the current module.
+    pub fn get_procedure_path(&self, id: &ProcedureId) -> Option<&LibraryPath> {
+        self.invoked_procs.get(id).map(|(_, path)| path)
+    }
+
     /// Return the paths of all imported module
     pub fn import_paths(&self) -> Vec<&LibraryPath> {
         self.imports.values().collect()

--- a/assembly/src/library/masl.rs
+++ b/assembly/src/library/masl.rs
@@ -272,7 +272,7 @@ mod use_std {
                     let ast = ModuleAst::parse(&contents)?;
 
                     // add dependencies of this module to the dependencies of this library
-                    for path in ast.import_paths() {
+                    for path in ast.import_info().import_paths() {
                         let ns = LibraryNamespace::new(path.first())?;
                         deps.insert(ns);
                     }


### PR DESCRIPTION
This PR contains two related changes:

1. Changed the `import_info` fields of ProgramAst and ModuleAst to remove the `Option` wrapper.

Wrapping this field in an `Option` does not appear to serve a specific purpose, and actively hinders/complicates access to module import information in the AST. As a result of this, there was a number of places where code to access common import info was duplicated; and a couple of places where a panic would be raised when an empty import table would be a suitable fallback.

After this change, one can access the `ModuleImports` struct directly on both `ProgramAst` and `ModuleAst` via the `import_info` function, which returns a reference to the field. Redundant functions in both structs were removed if they are already provided by `ModuleImports`.

2. Added some new APIs to `ModuleImports` to make accessing some common information about imported procedures more convenient:

* `get_procedure_info`, returns the `ProcedureName` and `LibraryPath` associated with an imported `ProcedureId`
* `get_procedure_name`, is like `get_procedure_info`, but returns just the `ProcedureName`
* `get_procedure_path`, is like `get_procedure_info`, but returns just the `LibraryPath`.
* `get_imported_procedures` replaces the `get_imported_procedures_map` function that was previously attached to `ModuleAst`

---

I needed some of the new APIs I added in the compiler, and ended up doing the small refactoring described above when I realized that things could be simplified quite a bit while I was in there.