### PR TITLE
Memory: Create newtype `ContextId`

### DIFF
--- a/miden/src/repl/mod.rs
+++ b/miden/src/repl/mod.rs
@@ -3,6 +3,7 @@ use miden::{
     math::{Felt, StarkField},
     DefaultHost, StackInputs, Word,
 };
+use processor::ContextId;
 use rustyline::{error::ReadlineError, DefaultEditor};
 
 /// This work is in continuation to the amazing work done by team `Scribe`
@@ -276,7 +277,7 @@ fn execute(program: String) -> Result<(Vec<(u64, Word)>, Vec<Felt>), ProgramErro
     }
 
     // loads the memory at the latest clock cycle.
-    let mem_state = chiplets.get_mem_state_at(0, system.clk());
+    let mem_state = chiplets.get_mem_state_at(ContextId::root(), system.clk());
     // loads the stack along with the overflow values at the latest clock cycle.
     let stack_state = stack.get_state_at(system.clk());
 

--- a/miden/tests/integration/exec_iters.rs
+++ b/miden/tests/integration/exec_iters.rs
@@ -1,4 +1,4 @@
-use processor::{AsmOpInfo, VmState};
+use processor::{AsmOpInfo, VmState, MemoryContextId};
 use test_utils::{build_debug_test, Felt, ToElements, ONE};
 use vm_core::{AssemblyOp, Operation};
 
@@ -19,7 +19,7 @@ fn test_exec_iter() {
     let expected_states = vec![
         VmState {
             clk: 0,
-            ctx: 0,
+            ctx: MemoryContextId::root(),
             op: None,
             asmop: None,
             stack: [16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1].to_elements(),
@@ -28,7 +28,7 @@ fn test_exec_iter() {
         },
         VmState {
             clk: 1,
-            ctx: 0,
+            ctx: MemoryContextId::root(),
             op: Some(Operation::Span),
             asmop: None,
             stack: [16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 1].to_elements(),
@@ -37,7 +37,7 @@ fn test_exec_iter() {
         },
         VmState {
             clk: 2,
-            ctx: 0,
+            ctx: MemoryContextId::root(),
             op: Some(Operation::Pad),
             asmop: Some(AsmOpInfo::new(
                 AssemblyOp::new("#main".to_string(), 3, "mem_storew.1".to_string(), false),
@@ -49,7 +49,7 @@ fn test_exec_iter() {
         },
         VmState {
             clk: 3,
-            ctx: 0,
+            ctx: MemoryContextId::root(),
             op: Some(Operation::Incr),
             asmop: Some(AsmOpInfo::new(
                 AssemblyOp::new("#main".to_string(), 3, "mem_storew.1".to_string(), false),
@@ -61,7 +61,7 @@ fn test_exec_iter() {
         },
         VmState {
             clk: 4,
-            ctx: 0,
+            ctx: MemoryContextId::root(),
             op: Some(Operation::MStoreW),
             asmop: Some(AsmOpInfo::new(
                 AssemblyOp::new("#main".to_string(), 3, "mem_storew.1".to_string(), false),
@@ -73,7 +73,7 @@ fn test_exec_iter() {
         },
         VmState {
             clk: 5,
-            ctx: 0,
+            ctx: MemoryContextId::root(),
             op: Some(Operation::Drop),
             asmop: Some(AsmOpInfo::new(
                 AssemblyOp::new("#main".to_string(), 4, "dropw".to_string(), false),
@@ -85,7 +85,7 @@ fn test_exec_iter() {
         },
         VmState {
             clk: 6,
-            ctx: 0,
+            ctx: MemoryContextId::root(),
             op: Some(Operation::Drop),
             asmop: Some(AsmOpInfo::new(
                 AssemblyOp::new("#main".to_string(), 4, "dropw".to_string(), false),
@@ -97,7 +97,7 @@ fn test_exec_iter() {
         },
         VmState {
             clk: 7,
-            ctx: 0,
+            ctx: MemoryContextId::root(),
             op: Some(Operation::Drop),
             asmop: Some(AsmOpInfo::new(
                 AssemblyOp::new("#main".to_string(), 4, "dropw".to_string(), false),
@@ -109,7 +109,7 @@ fn test_exec_iter() {
         },
         VmState {
             clk: 8,
-            ctx: 0,
+            ctx: MemoryContextId::root(),
             op: Some(Operation::Drop),
             asmop: Some(AsmOpInfo::new(
                 AssemblyOp::new("#main".to_string(), 4, "dropw".to_string(), false),
@@ -121,7 +121,7 @@ fn test_exec_iter() {
         },
         VmState {
             clk: 9,
-            ctx: 0,
+            ctx: MemoryContextId::root(),
             op: Some(Operation::Push(Felt::new(17))),
             asmop: Some(AsmOpInfo::new(
                 AssemblyOp::new("#main".to_string(), 1, "push.17".to_string(), false),
@@ -133,7 +133,7 @@ fn test_exec_iter() {
         },
         VmState {
             clk: 10,
-            ctx: 0,
+            ctx: MemoryContextId::root(),
             op: Some(Operation::Noop),
             asmop: None,
             stack: [17, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0].to_elements(),
@@ -142,7 +142,7 @@ fn test_exec_iter() {
         },
         VmState {
             clk: 11,
-            ctx: 0,
+            ctx: MemoryContextId::root(),
             op: Some(Operation::Push(ONE)),
             asmop: None,
             stack: [1, 17, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0].to_elements(),
@@ -151,7 +151,7 @@ fn test_exec_iter() {
         },
         VmState {
             clk: 12,
-            ctx: 0,
+            ctx: MemoryContextId::root(),
             op: Some(Operation::FmpUpdate),
             asmop: None,
             stack: [17, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0].to_elements(),
@@ -160,7 +160,7 @@ fn test_exec_iter() {
         },
         VmState {
             clk: 13,
-            ctx: 0,
+            ctx: MemoryContextId::root(),
             op: Some(Operation::Pad),
             asmop: Some(AsmOpInfo::new(
                 AssemblyOp::new("foo".to_string(), 4, "loc_store.0".to_string(), false),
@@ -172,7 +172,7 @@ fn test_exec_iter() {
         },
         VmState {
             clk: 14,
-            ctx: 0,
+            ctx: MemoryContextId::root(),
             op: Some(Operation::FmpAdd),
             asmop: Some(AsmOpInfo::new(
                 AssemblyOp::new("foo".to_string(), 4, "loc_store.0".to_string(), false),
@@ -185,7 +185,7 @@ fn test_exec_iter() {
         },
         VmState {
             clk: 15,
-            ctx: 0,
+            ctx: MemoryContextId::root(),
             op: Some(Operation::MStore),
             asmop: Some(AsmOpInfo::new(
                 AssemblyOp::new("foo".to_string(), 4, "loc_store.0".to_string(), false),
@@ -200,7 +200,7 @@ fn test_exec_iter() {
         },
         VmState {
             clk: 16,
-            ctx: 0,
+            ctx: MemoryContextId::root(),
             op: Some(Operation::Drop),
             asmop: Some(AsmOpInfo::new(
                 AssemblyOp::new("foo".to_string(), 4, "loc_store.0".to_string(), false),

--- a/miden/tests/integration/exec_iters.rs
+++ b/miden/tests/integration/exec_iters.rs
@@ -1,4 +1,4 @@
-use processor::{AsmOpInfo, VmState, MemoryContextId};
+use processor::{AsmOpInfo, VmState, ContextId};
 use test_utils::{build_debug_test, Felt, ToElements, ONE};
 use vm_core::{AssemblyOp, Operation};
 
@@ -19,7 +19,7 @@ fn test_exec_iter() {
     let expected_states = vec![
         VmState {
             clk: 0,
-            ctx: MemoryContextId::root(),
+            ctx: ContextId::root(),
             op: None,
             asmop: None,
             stack: [16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1].to_elements(),
@@ -28,7 +28,7 @@ fn test_exec_iter() {
         },
         VmState {
             clk: 1,
-            ctx: MemoryContextId::root(),
+            ctx: ContextId::root(),
             op: Some(Operation::Span),
             asmop: None,
             stack: [16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 1].to_elements(),
@@ -37,7 +37,7 @@ fn test_exec_iter() {
         },
         VmState {
             clk: 2,
-            ctx: MemoryContextId::root(),
+            ctx: ContextId::root(),
             op: Some(Operation::Pad),
             asmop: Some(AsmOpInfo::new(
                 AssemblyOp::new("#main".to_string(), 3, "mem_storew.1".to_string(), false),
@@ -49,7 +49,7 @@ fn test_exec_iter() {
         },
         VmState {
             clk: 3,
-            ctx: MemoryContextId::root(),
+            ctx: ContextId::root(),
             op: Some(Operation::Incr),
             asmop: Some(AsmOpInfo::new(
                 AssemblyOp::new("#main".to_string(), 3, "mem_storew.1".to_string(), false),
@@ -61,7 +61,7 @@ fn test_exec_iter() {
         },
         VmState {
             clk: 4,
-            ctx: MemoryContextId::root(),
+            ctx: ContextId::root(),
             op: Some(Operation::MStoreW),
             asmop: Some(AsmOpInfo::new(
                 AssemblyOp::new("#main".to_string(), 3, "mem_storew.1".to_string(), false),
@@ -73,7 +73,7 @@ fn test_exec_iter() {
         },
         VmState {
             clk: 5,
-            ctx: MemoryContextId::root(),
+            ctx: ContextId::root(),
             op: Some(Operation::Drop),
             asmop: Some(AsmOpInfo::new(
                 AssemblyOp::new("#main".to_string(), 4, "dropw".to_string(), false),
@@ -85,7 +85,7 @@ fn test_exec_iter() {
         },
         VmState {
             clk: 6,
-            ctx: MemoryContextId::root(),
+            ctx: ContextId::root(),
             op: Some(Operation::Drop),
             asmop: Some(AsmOpInfo::new(
                 AssemblyOp::new("#main".to_string(), 4, "dropw".to_string(), false),
@@ -97,7 +97,7 @@ fn test_exec_iter() {
         },
         VmState {
             clk: 7,
-            ctx: MemoryContextId::root(),
+            ctx: ContextId::root(),
             op: Some(Operation::Drop),
             asmop: Some(AsmOpInfo::new(
                 AssemblyOp::new("#main".to_string(), 4, "dropw".to_string(), false),
@@ -109,7 +109,7 @@ fn test_exec_iter() {
         },
         VmState {
             clk: 8,
-            ctx: MemoryContextId::root(),
+            ctx: ContextId::root(),
             op: Some(Operation::Drop),
             asmop: Some(AsmOpInfo::new(
                 AssemblyOp::new("#main".to_string(), 4, "dropw".to_string(), false),
@@ -121,7 +121,7 @@ fn test_exec_iter() {
         },
         VmState {
             clk: 9,
-            ctx: MemoryContextId::root(),
+            ctx: ContextId::root(),
             op: Some(Operation::Push(Felt::new(17))),
             asmop: Some(AsmOpInfo::new(
                 AssemblyOp::new("#main".to_string(), 1, "push.17".to_string(), false),
@@ -133,7 +133,7 @@ fn test_exec_iter() {
         },
         VmState {
             clk: 10,
-            ctx: MemoryContextId::root(),
+            ctx: ContextId::root(),
             op: Some(Operation::Noop),
             asmop: None,
             stack: [17, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0].to_elements(),
@@ -142,7 +142,7 @@ fn test_exec_iter() {
         },
         VmState {
             clk: 11,
-            ctx: MemoryContextId::root(),
+            ctx: ContextId::root(),
             op: Some(Operation::Push(ONE)),
             asmop: None,
             stack: [1, 17, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0].to_elements(),
@@ -151,7 +151,7 @@ fn test_exec_iter() {
         },
         VmState {
             clk: 12,
-            ctx: MemoryContextId::root(),
+            ctx: ContextId::root(),
             op: Some(Operation::FmpUpdate),
             asmop: None,
             stack: [17, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0].to_elements(),
@@ -160,7 +160,7 @@ fn test_exec_iter() {
         },
         VmState {
             clk: 13,
-            ctx: MemoryContextId::root(),
+            ctx: ContextId::root(),
             op: Some(Operation::Pad),
             asmop: Some(AsmOpInfo::new(
                 AssemblyOp::new("foo".to_string(), 4, "loc_store.0".to_string(), false),
@@ -172,7 +172,7 @@ fn test_exec_iter() {
         },
         VmState {
             clk: 14,
-            ctx: MemoryContextId::root(),
+            ctx: ContextId::root(),
             op: Some(Operation::FmpAdd),
             asmop: Some(AsmOpInfo::new(
                 AssemblyOp::new("foo".to_string(), 4, "loc_store.0".to_string(), false),
@@ -185,7 +185,7 @@ fn test_exec_iter() {
         },
         VmState {
             clk: 15,
-            ctx: MemoryContextId::root(),
+            ctx: ContextId::root(),
             op: Some(Operation::MStore),
             asmop: Some(AsmOpInfo::new(
                 AssemblyOp::new("foo".to_string(), 4, "loc_store.0".to_string(), false),
@@ -200,7 +200,7 @@ fn test_exec_iter() {
         },
         VmState {
             clk: 16,
-            ctx: MemoryContextId::root(),
+            ctx: ContextId::root(),
             op: Some(Operation::Drop),
             asmop: Some(AsmOpInfo::new(
                 AssemblyOp::new("foo".to_string(), 4, "loc_store.0".to_string(), false),

--- a/miden/tests/integration/exec_iters.rs
+++ b/miden/tests/integration/exec_iters.rs
@@ -1,4 +1,4 @@
-use processor::{AsmOpInfo, VmState, ContextId};
+use processor::{AsmOpInfo, ContextId, VmState};
 use test_utils::{build_debug_test, Felt, ToElements, ONE};
 use vm_core::{AssemblyOp, Operation};
 

--- a/processor/Cargo.toml
+++ b/processor/Cargo.toml
@@ -28,13 +28,6 @@ log = { version = "0.4", default-features = false, optional = true }
 vm-core = { package = "miden-core", path = "../core", version = "0.8", default-features = false }
 miden-air = { package = "miden-air", path = "../air", version = "0.8", default-features = false }
 winter-prover = { package = "winter-prover", version = "0.6", default-features = false }
-derive_more = { version = "0.99", default-features = false, features = [
-    "add",
-    "add_assign",
-    "display",
-    "from",
-    "into",
-] }
 
 [dev-dependencies]
 logtest = { version = "2.0", default-features = false }

--- a/processor/Cargo.toml
+++ b/processor/Cargo.toml
@@ -28,9 +28,16 @@ log = { version = "0.4", default-features = false, optional = true }
 vm-core = { package = "miden-core", path = "../core", version = "0.8", default-features = false }
 miden-air = { package = "miden-air", path = "../air", version = "0.8", default-features = false }
 winter-prover = { package = "winter-prover", version = "0.6", default-features = false }
+derive_more = { version = "0.99", default-features = false, features = [
+    "add",
+    "add_assign",
+    "display",
+    "from",
+    "into",
+] }
 
 [dev-dependencies]
-logtest = { version = "2.0", default-features = false  }
+logtest = { version = "2.0", default-features = false }
 miden-assembly = { package = "miden-assembly", path = "../assembly", version = "0.8", default-features = false }
 test-utils = { package = "miden-test-utils", path = "../test-utils" }
 winter-fri = { package = "winter-fri", version = "0.6" }

--- a/processor/src/chiplets/memory/mod.rs
+++ b/processor/src/chiplets/memory/mod.rs
@@ -1,10 +1,11 @@
+use crate::system::ContextId;
+
 use super::{
     trace::LookupTableRow,
     utils::{split_element_u32_into_u16, split_u32_into_u16},
     BTreeMap, ChipletsBus, ColMatrix, Felt, FieldElement, RangeChecker, StarkField, TraceFragment,
     Vec, Word, EMPTY_WORD, ONE,
 };
-use derive_more::{Add, AddAssign, Display, From, Into, Sub, SubAssign};
 use miden_air::trace::chiplets::memory::{
     ADDR_COL_IDX, CLK_COL_IDX, CTX_COL_IDX, D0_COL_IDX, D1_COL_IDX, D_INV_COL_IDX, V_COL_RANGE,
 };
@@ -23,49 +24,6 @@ const INIT_MEM_VALUE: Word = EMPTY_WORD;
 
 // RANDOM ACCESS MEMORY
 // ================================================================================================
-
-#[derive(
-    Add,
-    AddAssign,
-    Clone,
-    Copy,
-    Debug,
-    Default,
-    Display,
-    Eq,
-    From,
-    Into,
-    Ord,
-    PartialEq,
-    PartialOrd,
-    Sub,
-    SubAssign,
-)]
-pub struct ContextId(u32);
-
-impl ContextId {
-    /// Returns the root context ID
-    pub fn root() -> Self {
-        Self(0)
-    }
-
-    /// Returns true if the context ID represents the root context
-    pub fn is_root(&self) -> bool {
-        self.0 == 0
-    }
-}
-
-impl From<ContextId> for u64 {
-    fn from(context_id: ContextId) -> Self {
-        context_id.0.into()
-    }
-}
-
-impl From<ContextId> for Felt {
-    fn from(context_id: ContextId) -> Self {
-        u64::from(context_id).into()
-    }
-}
 
 /// Memory controller for the VM.
 ///

--- a/processor/src/chiplets/memory/mod.rs
+++ b/processor/src/chiplets/memory/mod.rs
@@ -23,6 +23,21 @@ const INIT_MEM_VALUE: Word = EMPTY_WORD;
 // RANDOM ACCESS MEMORY
 // ================================================================================================
 
+#[derive(Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]
+pub struct ContextId(u32);
+
+impl From<u32> for ContextId {
+    fn from(num: u32) -> Self {
+        Self(num)
+    }
+}
+
+impl From<ContextId> for u32 {
+    fn from(context_id: ContextId) -> Self {
+        context_id.0
+    }
+}
+
 /// Memory controller for the VM.
 ///
 /// This component is responsible for tracking current memory state of the VM, as well as for

--- a/processor/src/chiplets/memory/mod.rs
+++ b/processor/src/chiplets/memory/mod.rs
@@ -1,10 +1,10 @@
-use crate::system::ContextId;
 use super::{
     trace::LookupTableRow,
     utils::{split_element_u32_into_u16, split_u32_into_u16},
     BTreeMap, ChipletsBus, ColMatrix, Felt, FieldElement, RangeChecker, StarkField, TraceFragment,
     Vec, Word, EMPTY_WORD, ONE,
 };
+use crate::system::ContextId;
 use miden_air::trace::chiplets::memory::{
     ADDR_COL_IDX, CLK_COL_IDX, CTX_COL_IDX, D0_COL_IDX, D1_COL_IDX, D_INV_COL_IDX, V_COL_RANGE,
 };
@@ -169,7 +169,7 @@ impl Memory {
 
                     // compute delta as difference between context IDs, addresses, or clock cycles
                     let delta = if prev_ctx != ctx {
-                        (ctx - prev_ctx).into()
+                        (u32::from(ctx) - u32::from(prev_ctx)).into()
                     } else if prev_addr != addr {
                         (addr - prev_addr) as u64
                     } else {

--- a/processor/src/chiplets/memory/mod.rs
+++ b/processor/src/chiplets/memory/mod.rs
@@ -1,5 +1,4 @@
 use crate::system::ContextId;
-
 use super::{
     trace::LookupTableRow,
     utils::{split_element_u32_into_u16, split_u32_into_u16},

--- a/processor/src/chiplets/memory/tests.rs
+++ b/processor/src/chiplets/memory/tests.rs
@@ -1,4 +1,4 @@
-use crate::MemoryContextId;
+use crate::ContextId;
 
 use super::{
     super::aux_trace::{ChipletLookup, ChipletsBusRow},
@@ -24,27 +24,27 @@ fn mem_read() {
 
     // read a value from address 0; clk = 1
     let addr0 = 0;
-    let value = mem.read(MemoryContextId::root(), addr0, 1);
+    let value = mem.read(ContextId::root(), addr0, 1);
     assert_eq!(EMPTY_WORD, value);
     assert_eq!(1, mem.size());
     assert_eq!(1, mem.trace_len());
 
     // read a value from address 3; clk = 2
     let addr3 = 3;
-    let value = mem.read(MemoryContextId::root(), addr3, 2);
+    let value = mem.read(ContextId::root(), addr3, 2);
     assert_eq!(EMPTY_WORD, value);
     assert_eq!(2, mem.size());
     assert_eq!(2, mem.trace_len());
 
     // read a value from address 0 again; clk = 3
-    let value = mem.read(MemoryContextId::root(), addr0, 3);
+    let value = mem.read(ContextId::root(), addr0, 3);
     assert_eq!(EMPTY_WORD, value);
     assert_eq!(2, mem.size());
     assert_eq!(3, mem.trace_len());
 
     // read a value from address 2; clk = 4
     let addr2 = 2;
-    let value = mem.read(MemoryContextId::root(), addr2, 4);
+    let value = mem.read(ContextId::root(), addr2, 4);
     assert_eq!(EMPTY_WORD, value);
     assert_eq!(3, mem.size());
     assert_eq!(4, mem.trace_len());
@@ -56,24 +56,24 @@ fn mem_read() {
     // address 0
     let mut prev_row = [ZERO; MEMORY_TRACE_WIDTH];
     let memory_access =
-        MemoryLookup::from_ints(MEMORY_READ_LABEL, MemoryContextId::root(), addr0, 1, EMPTY_WORD);
+        MemoryLookup::from_ints(MEMORY_READ_LABEL, ContextId::root(), addr0, 1, EMPTY_WORD);
     prev_row =
         verify_memory_access(&trace, &chiplets_bus, 0, MEMORY_INIT_READ, &memory_access, prev_row);
 
     let memory_access =
-        MemoryLookup::from_ints(MEMORY_READ_LABEL, MemoryContextId::root(), addr0, 3, EMPTY_WORD);
+        MemoryLookup::from_ints(MEMORY_READ_LABEL, ContextId::root(), addr0, 3, EMPTY_WORD);
     prev_row =
         verify_memory_access(&trace, &chiplets_bus, 1, MEMORY_COPY_READ, &memory_access, prev_row);
 
     // address 2
     let memory_access =
-        MemoryLookup::from_ints(MEMORY_READ_LABEL, MemoryContextId::root(), addr2, 4, EMPTY_WORD);
+        MemoryLookup::from_ints(MEMORY_READ_LABEL, ContextId::root(), addr2, 4, EMPTY_WORD);
     prev_row =
         verify_memory_access(&trace, &chiplets_bus, 2, MEMORY_INIT_READ, &memory_access, prev_row);
 
     // address 3
     let memory_access =
-        MemoryLookup::from_ints(MEMORY_READ_LABEL, MemoryContextId::root(), addr3, 2, EMPTY_WORD);
+        MemoryLookup::from_ints(MEMORY_READ_LABEL, ContextId::root(), addr3, 2, EMPTY_WORD);
     verify_memory_access(&trace, &chiplets_bus, 3, MEMORY_INIT_READ, &memory_access, prev_row);
 }
 
@@ -84,31 +84,31 @@ fn mem_write() {
     // write a value into address 0; clk = 1
     let addr0 = 0;
     let value1 = [ONE, ZERO, ZERO, ZERO];
-    mem.write(MemoryContextId::root(), addr0, 1, value1);
-    assert_eq!(value1, mem.get_value(MemoryContextId::root(), addr0).unwrap());
+    mem.write(ContextId::root(), addr0, 1, value1);
+    assert_eq!(value1, mem.get_value(ContextId::root(), addr0).unwrap());
     assert_eq!(1, mem.size());
     assert_eq!(1, mem.trace_len());
 
     // write a value into address 2; clk = 2
     let addr2 = 2;
     let value5 = [Felt::new(5), ZERO, ZERO, ZERO];
-    mem.write(MemoryContextId::root(), addr2, 2, value5);
-    assert_eq!(value5, mem.get_value(MemoryContextId::root(), addr2).unwrap());
+    mem.write(ContextId::root(), addr2, 2, value5);
+    assert_eq!(value5, mem.get_value(ContextId::root(), addr2).unwrap());
     assert_eq!(2, mem.size());
     assert_eq!(2, mem.trace_len());
 
     // write a value into address 1; clk = 3
     let addr1 = 1;
     let value7 = [Felt::new(7), ZERO, ZERO, ZERO];
-    mem.write(MemoryContextId::root(), addr1, 3, value7);
-    assert_eq!(value7, mem.get_value(MemoryContextId::root(), addr1).unwrap());
+    mem.write(ContextId::root(), addr1, 3, value7);
+    assert_eq!(value7, mem.get_value(ContextId::root(), addr1).unwrap());
     assert_eq!(3, mem.size());
     assert_eq!(3, mem.trace_len());
 
     // write a value into address 0; clk = 4
     let value9 = [Felt::new(9), ZERO, ZERO, ZERO];
-    mem.write(MemoryContextId::root(), addr0, 4, value9);
-    assert_eq!(value7, mem.get_value(MemoryContextId::root(), addr1).unwrap());
+    mem.write(ContextId::root(), addr0, 4, value9);
+    assert_eq!(value7, mem.get_value(ContextId::root(), addr1).unwrap());
     assert_eq!(3, mem.size());
     assert_eq!(4, mem.trace_len());
 
@@ -119,24 +119,24 @@ fn mem_write() {
     // address 0
     let mut prev_row = [ZERO; MEMORY_TRACE_WIDTH];
     let memory_access =
-        MemoryLookup::from_ints(MEMORY_WRITE_LABEL, MemoryContextId::root(), addr0, 1, value1);
+        MemoryLookup::from_ints(MEMORY_WRITE_LABEL, ContextId::root(), addr0, 1, value1);
     prev_row =
         verify_memory_access(&trace, &chiplets_bus, 0, MEMORY_WRITE, &memory_access, prev_row);
 
     let memory_access =
-        MemoryLookup::from_ints(MEMORY_WRITE_LABEL, MemoryContextId::root(), addr0, 4, value9);
+        MemoryLookup::from_ints(MEMORY_WRITE_LABEL, ContextId::root(), addr0, 4, value9);
     prev_row =
         verify_memory_access(&trace, &chiplets_bus, 1, MEMORY_WRITE, &memory_access, prev_row);
 
     // address 1
     let memory_access =
-        MemoryLookup::from_ints(MEMORY_WRITE_LABEL, MemoryContextId::root(), addr1, 3, value7);
+        MemoryLookup::from_ints(MEMORY_WRITE_LABEL, ContextId::root(), addr1, 3, value7);
     prev_row =
         verify_memory_access(&trace, &chiplets_bus, 2, MEMORY_WRITE, &memory_access, prev_row);
 
     // address 2
     let memory_access =
-        MemoryLookup::from_ints(MEMORY_WRITE_LABEL, MemoryContextId::root(), addr2, 2, value5);
+        MemoryLookup::from_ints(MEMORY_WRITE_LABEL, ContextId::root(), addr2, 2, value5);
     verify_memory_access(&trace, &chiplets_bus, 3, MEMORY_WRITE, &memory_access, prev_row);
 }
 
@@ -147,35 +147,35 @@ fn mem_write_read() {
     // write 1 into address 5; clk = 1
     let addr5 = 5;
     let value1 = [ONE, ZERO, ZERO, ZERO];
-    mem.write(MemoryContextId::root(), addr5, 1, value1);
+    mem.write(ContextId::root(), addr5, 1, value1);
 
     // write 4 into address 2; clk = 2
     let addr2 = 2;
     let value4 = [Felt::new(4), ZERO, ZERO, ZERO];
-    mem.write(MemoryContextId::root(), addr2, 2, value4);
+    mem.write(ContextId::root(), addr2, 2, value4);
 
     // read a value from address 5; clk = 3
-    mem.read(MemoryContextId::root(), addr5, 3);
+    mem.read(ContextId::root(), addr5, 3);
 
     // write 2 into address 5; clk = 4
     let value2 = [Felt::new(2), ZERO, ZERO, ZERO];
-    mem.write(MemoryContextId::root(), addr5, 4, value2);
+    mem.write(ContextId::root(), addr5, 4, value2);
 
     // read a value from address 2; clk = 5
-    mem.read(MemoryContextId::root(), addr2, 5);
+    mem.read(ContextId::root(), addr2, 5);
 
     // write 7 into address 2; clk = 6
     let value7 = [Felt::new(7), ZERO, ZERO, ZERO];
-    mem.write(MemoryContextId::root(), addr2, 6, value7);
+    mem.write(ContextId::root(), addr2, 6, value7);
 
     // read a value from address 5; clk = 7
-    mem.read(MemoryContextId::root(), addr5, 7);
+    mem.read(ContextId::root(), addr5, 7);
 
     // read a value from address 2; clk = 8
-    mem.read(MemoryContextId::root(), addr2, 8);
+    mem.read(ContextId::root(), addr2, 8);
 
     // read a value from address 5; clk = 9
-    mem.read(MemoryContextId::root(), addr5, 9);
+    mem.read(ContextId::root(), addr5, 9);
 
     // check generated trace and memory data provided to the ChipletsBus; rows should be sorted by
     // address and then clock cycle
@@ -184,48 +184,48 @@ fn mem_write_read() {
     // address 2
     let mut prev_row = [ZERO; MEMORY_TRACE_WIDTH];
     let memory_access =
-        MemoryLookup::from_ints(MEMORY_WRITE_LABEL, MemoryContextId::root(), addr2, 2, value4);
+        MemoryLookup::from_ints(MEMORY_WRITE_LABEL, ContextId::root(), addr2, 2, value4);
     prev_row =
         verify_memory_access(&trace, &chiplets_bus, 0, MEMORY_WRITE, &memory_access, prev_row);
 
     let memory_access =
-        MemoryLookup::from_ints(MEMORY_READ_LABEL, MemoryContextId::root(), addr2, 5, value4);
+        MemoryLookup::from_ints(MEMORY_READ_LABEL, ContextId::root(), addr2, 5, value4);
     prev_row =
         verify_memory_access(&trace, &chiplets_bus, 1, MEMORY_COPY_READ, &memory_access, prev_row);
 
     let memory_access =
-        MemoryLookup::from_ints(MEMORY_WRITE_LABEL, MemoryContextId::root(), addr2, 6, value7);
+        MemoryLookup::from_ints(MEMORY_WRITE_LABEL, ContextId::root(), addr2, 6, value7);
     prev_row =
         verify_memory_access(&trace, &chiplets_bus, 2, MEMORY_WRITE, &memory_access, prev_row);
 
     let memory_access =
-        MemoryLookup::from_ints(MEMORY_READ_LABEL, MemoryContextId::root(), addr2, 8, value7);
+        MemoryLookup::from_ints(MEMORY_READ_LABEL, ContextId::root(), addr2, 8, value7);
     prev_row =
         verify_memory_access(&trace, &chiplets_bus, 3, MEMORY_COPY_READ, &memory_access, prev_row);
 
     // address 5
     let memory_access =
-        MemoryLookup::from_ints(MEMORY_WRITE_LABEL, MemoryContextId::root(), addr5, 1, value1);
+        MemoryLookup::from_ints(MEMORY_WRITE_LABEL, ContextId::root(), addr5, 1, value1);
     prev_row =
         verify_memory_access(&trace, &chiplets_bus, 4, MEMORY_WRITE, &memory_access, prev_row);
 
     let memory_access =
-        MemoryLookup::from_ints(MEMORY_READ_LABEL, MemoryContextId::root(), addr5, 3, value1);
+        MemoryLookup::from_ints(MEMORY_READ_LABEL, ContextId::root(), addr5, 3, value1);
     prev_row =
         verify_memory_access(&trace, &chiplets_bus, 5, MEMORY_COPY_READ, &memory_access, prev_row);
 
     let memory_access =
-        MemoryLookup::from_ints(MEMORY_WRITE_LABEL, MemoryContextId::root(), addr5, 4, value2);
+        MemoryLookup::from_ints(MEMORY_WRITE_LABEL, ContextId::root(), addr5, 4, value2);
     prev_row =
         verify_memory_access(&trace, &chiplets_bus, 6, MEMORY_WRITE, &memory_access, prev_row);
 
     let memory_access =
-        MemoryLookup::from_ints(MEMORY_READ_LABEL, MemoryContextId::root(), addr5, 7, value2);
+        MemoryLookup::from_ints(MEMORY_READ_LABEL, ContextId::root(), addr5, 7, value2);
     prev_row =
         verify_memory_access(&trace, &chiplets_bus, 7, MEMORY_COPY_READ, &memory_access, prev_row);
 
     let memory_access =
-        MemoryLookup::from_ints(MEMORY_READ_LABEL, MemoryContextId::root(), addr5, 9, value2);
+        MemoryLookup::from_ints(MEMORY_READ_LABEL, ContextId::root(), addr5, 9, value2);
     verify_memory_access(&trace, &chiplets_bus, 8, MEMORY_COPY_READ, &memory_access, prev_row);
 }
 
@@ -233,10 +233,10 @@ fn mem_write_read() {
 fn mem_multi_context() {
     let mut mem = Memory::default();
 
-    // write a value into ctx = MemoryContextId::root(), addr = 0; clk = 1
+    // write a value into ctx = ContextId::root(), addr = 0; clk = 1
     let value1 = [ONE, ZERO, ZERO, ZERO];
-    mem.write(MemoryContextId::root(), 0, 1, value1);
-    assert_eq!(value1, mem.get_value(MemoryContextId::root(), 0).unwrap());
+    mem.write(ContextId::root(), 0, 1, value1);
+    assert_eq!(value1, mem.get_value(ContextId::root(), 0).unwrap());
     assert_eq!(1, mem.size());
     assert_eq!(1, mem.trace_len());
 
@@ -261,7 +261,7 @@ fn mem_multi_context() {
     assert_eq!(4, mem.trace_len());
 
     // read a value from ctx = 0, addr = 0; clk = 9
-    let value = mem.read(MemoryContextId::root(), 0, 9);
+    let value = mem.read(ContextId::root(), 0, 9);
     assert_eq!(value1, value);
     assert_eq!(3, mem.size());
     assert_eq!(5, mem.trace_len());
@@ -273,12 +273,12 @@ fn mem_multi_context() {
     // ctx = 0, addr = 0
     let mut prev_row = [ZERO; MEMORY_TRACE_WIDTH];
     let memory_access =
-        MemoryLookup::from_ints(MEMORY_WRITE_LABEL, MemoryContextId::root(), 0, 1, value1);
+        MemoryLookup::from_ints(MEMORY_WRITE_LABEL, ContextId::root(), 0, 1, value1);
     prev_row =
         verify_memory_access(&trace, &chiplets_bus, 0, MEMORY_WRITE, &memory_access, prev_row);
 
     let memory_access =
-        MemoryLookup::from_ints(MEMORY_READ_LABEL, MemoryContextId::root(), 0, 9, value1);
+        MemoryLookup::from_ints(MEMORY_READ_LABEL, ContextId::root(), 0, 9, value1);
     prev_row =
         verify_memory_access(&trace, &chiplets_bus, 1, MEMORY_COPY_READ, &memory_access, prev_row);
 
@@ -303,12 +303,12 @@ fn mem_get_state_at() {
     // Write 1 into (ctx = 0, addr = 5) at clk = 1.
     // This means that mem[5] = 1 at the beginning of clk = 2
     let value1 = [ONE, ZERO, ZERO, ZERO];
-    mem.write(MemoryContextId::root(), 5, 1, value1);
+    mem.write(ContextId::root(), 5, 1, value1);
 
     // Write 4 into (ctx = 0, addr = 2) at clk = 2.
     // This means that mem[2] = 4 at the beginning of clk = 3
     let value4 = [Felt::new(4), ZERO, ZERO, ZERO];
-    mem.write(MemoryContextId::root(), 2, 2, value4);
+    mem.write(ContextId::root(), 2, 2, value4);
 
     // write 7 into (ctx = 3, addr = 3) at clk = 4
     // This means that mem[3] = 7 at the beginning of clk = 4
@@ -316,19 +316,19 @@ fn mem_get_state_at() {
     mem.write(3.into(), 3, 4, value7);
 
     // Check memory state at clk = 2
-    assert_eq!(mem.get_state_at(MemoryContextId::root(), 2), vec![(5, value1)]);
+    assert_eq!(mem.get_state_at(ContextId::root(), 2), vec![(5, value1)]);
     assert_eq!(mem.get_state_at(3.into(), 2), vec![]);
 
     // Check memory state at clk = 3
-    assert_eq!(mem.get_state_at(MemoryContextId::root(), 3), vec![(2, value4), (5, value1)]);
+    assert_eq!(mem.get_state_at(ContextId::root(), 3), vec![(2, value4), (5, value1)]);
     assert_eq!(mem.get_state_at(3.into(), 3), vec![]);
 
     // Check memory state at clk = 4
-    assert_eq!(mem.get_state_at(MemoryContextId::root(), 4), vec![(2, value4), (5, value1)]);
+    assert_eq!(mem.get_state_at(ContextId::root(), 4), vec![(2, value4), (5, value1)]);
     assert_eq!(mem.get_state_at(3.into(), 4), vec![]);
 
     // Check memory state at clk = 5
-    assert_eq!(mem.get_state_at(MemoryContextId::root(), 5), vec![(2, value4), (5, value1)]);
+    assert_eq!(mem.get_state_at(ContextId::root(), 5), vec![(2, value4), (5, value1)]);
     assert_eq!(mem.get_state_at(3.into(), 5), vec![(3, value7)]);
 }
 

--- a/processor/src/chiplets/memory/tests.rs
+++ b/processor/src/chiplets/memory/tests.rs
@@ -277,8 +277,7 @@ fn mem_multi_context() {
     prev_row =
         verify_memory_access(&trace, &chiplets_bus, 0, MEMORY_WRITE, &memory_access, prev_row);
 
-    let memory_access =
-        MemoryLookup::from_ints(MEMORY_READ_LABEL, ContextId::root(), 0, 9, value1);
+    let memory_access = MemoryLookup::from_ints(MEMORY_READ_LABEL, ContextId::root(), 0, 9, value1);
     prev_row =
         verify_memory_access(&trace, &chiplets_bus, 1, MEMORY_COPY_READ, &memory_access, prev_row);
 

--- a/processor/src/chiplets/memory/tests.rs
+++ b/processor/src/chiplets/memory/tests.rs
@@ -1,3 +1,5 @@
+use crate::MemoryContextId;
+
 use super::{
     super::aux_trace::{ChipletLookup, ChipletsBusRow},
     super::ZERO,
@@ -22,27 +24,27 @@ fn mem_read() {
 
     // read a value from address 0; clk = 1
     let addr0 = 0;
-    let value = mem.read(0, addr0, 1);
+    let value = mem.read(MemoryContextId::root(), addr0, 1);
     assert_eq!(EMPTY_WORD, value);
     assert_eq!(1, mem.size());
     assert_eq!(1, mem.trace_len());
 
     // read a value from address 3; clk = 2
     let addr3 = 3;
-    let value = mem.read(0, addr3, 2);
+    let value = mem.read(MemoryContextId::root(), addr3, 2);
     assert_eq!(EMPTY_WORD, value);
     assert_eq!(2, mem.size());
     assert_eq!(2, mem.trace_len());
 
     // read a value from address 0 again; clk = 3
-    let value = mem.read(0, addr0, 3);
+    let value = mem.read(MemoryContextId::root(), addr0, 3);
     assert_eq!(EMPTY_WORD, value);
     assert_eq!(2, mem.size());
     assert_eq!(3, mem.trace_len());
 
     // read a value from address 2; clk = 4
     let addr2 = 2;
-    let value = mem.read(0, addr2, 4);
+    let value = mem.read(MemoryContextId::root(), addr2, 4);
     assert_eq!(EMPTY_WORD, value);
     assert_eq!(3, mem.size());
     assert_eq!(4, mem.trace_len());
@@ -53,21 +55,25 @@ fn mem_read() {
 
     // address 0
     let mut prev_row = [ZERO; MEMORY_TRACE_WIDTH];
-    let memory_access = MemoryLookup::from_ints(MEMORY_READ_LABEL, 0, addr0, 1, EMPTY_WORD);
+    let memory_access =
+        MemoryLookup::from_ints(MEMORY_READ_LABEL, MemoryContextId::root(), addr0, 1, EMPTY_WORD);
     prev_row =
         verify_memory_access(&trace, &chiplets_bus, 0, MEMORY_INIT_READ, &memory_access, prev_row);
 
-    let memory_access = MemoryLookup::from_ints(MEMORY_READ_LABEL, 0, addr0, 3, EMPTY_WORD);
+    let memory_access =
+        MemoryLookup::from_ints(MEMORY_READ_LABEL, MemoryContextId::root(), addr0, 3, EMPTY_WORD);
     prev_row =
         verify_memory_access(&trace, &chiplets_bus, 1, MEMORY_COPY_READ, &memory_access, prev_row);
 
     // address 2
-    let memory_access = MemoryLookup::from_ints(MEMORY_READ_LABEL, 0, addr2, 4, EMPTY_WORD);
+    let memory_access =
+        MemoryLookup::from_ints(MEMORY_READ_LABEL, MemoryContextId::root(), addr2, 4, EMPTY_WORD);
     prev_row =
         verify_memory_access(&trace, &chiplets_bus, 2, MEMORY_INIT_READ, &memory_access, prev_row);
 
     // address 3
-    let memory_access = MemoryLookup::from_ints(MEMORY_READ_LABEL, 0, addr3, 2, EMPTY_WORD);
+    let memory_access =
+        MemoryLookup::from_ints(MEMORY_READ_LABEL, MemoryContextId::root(), addr3, 2, EMPTY_WORD);
     verify_memory_access(&trace, &chiplets_bus, 3, MEMORY_INIT_READ, &memory_access, prev_row);
 }
 
@@ -78,31 +84,31 @@ fn mem_write() {
     // write a value into address 0; clk = 1
     let addr0 = 0;
     let value1 = [ONE, ZERO, ZERO, ZERO];
-    mem.write(0, addr0, 1, value1);
-    assert_eq!(value1, mem.get_value(0, addr0).unwrap());
+    mem.write(MemoryContextId::root(), addr0, 1, value1);
+    assert_eq!(value1, mem.get_value(MemoryContextId::root(), addr0).unwrap());
     assert_eq!(1, mem.size());
     assert_eq!(1, mem.trace_len());
 
     // write a value into address 2; clk = 2
     let addr2 = 2;
     let value5 = [Felt::new(5), ZERO, ZERO, ZERO];
-    mem.write(0, addr2, 2, value5);
-    assert_eq!(value5, mem.get_value(0, addr2).unwrap());
+    mem.write(MemoryContextId::root(), addr2, 2, value5);
+    assert_eq!(value5, mem.get_value(MemoryContextId::root(), addr2).unwrap());
     assert_eq!(2, mem.size());
     assert_eq!(2, mem.trace_len());
 
     // write a value into address 1; clk = 3
     let addr1 = 1;
     let value7 = [Felt::new(7), ZERO, ZERO, ZERO];
-    mem.write(0, addr1, 3, value7);
-    assert_eq!(value7, mem.get_value(0, addr1).unwrap());
+    mem.write(MemoryContextId::root(), addr1, 3, value7);
+    assert_eq!(value7, mem.get_value(MemoryContextId::root(), addr1).unwrap());
     assert_eq!(3, mem.size());
     assert_eq!(3, mem.trace_len());
 
     // write a value into address 0; clk = 4
     let value9 = [Felt::new(9), ZERO, ZERO, ZERO];
-    mem.write(0, addr0, 4, value9);
-    assert_eq!(value7, mem.get_value(0, addr1).unwrap());
+    mem.write(MemoryContextId::root(), addr0, 4, value9);
+    assert_eq!(value7, mem.get_value(MemoryContextId::root(), addr1).unwrap());
     assert_eq!(3, mem.size());
     assert_eq!(4, mem.trace_len());
 
@@ -112,21 +118,25 @@ fn mem_write() {
 
     // address 0
     let mut prev_row = [ZERO; MEMORY_TRACE_WIDTH];
-    let memory_access = MemoryLookup::from_ints(MEMORY_WRITE_LABEL, 0, addr0, 1, value1);
+    let memory_access =
+        MemoryLookup::from_ints(MEMORY_WRITE_LABEL, MemoryContextId::root(), addr0, 1, value1);
     prev_row =
         verify_memory_access(&trace, &chiplets_bus, 0, MEMORY_WRITE, &memory_access, prev_row);
 
-    let memory_access = MemoryLookup::from_ints(MEMORY_WRITE_LABEL, 0, addr0, 4, value9);
+    let memory_access =
+        MemoryLookup::from_ints(MEMORY_WRITE_LABEL, MemoryContextId::root(), addr0, 4, value9);
     prev_row =
         verify_memory_access(&trace, &chiplets_bus, 1, MEMORY_WRITE, &memory_access, prev_row);
 
     // address 1
-    let memory_access = MemoryLookup::from_ints(MEMORY_WRITE_LABEL, 0, addr1, 3, value7);
+    let memory_access =
+        MemoryLookup::from_ints(MEMORY_WRITE_LABEL, MemoryContextId::root(), addr1, 3, value7);
     prev_row =
         verify_memory_access(&trace, &chiplets_bus, 2, MEMORY_WRITE, &memory_access, prev_row);
 
     // address 2
-    let memory_access = MemoryLookup::from_ints(MEMORY_WRITE_LABEL, 0, addr2, 2, value5);
+    let memory_access =
+        MemoryLookup::from_ints(MEMORY_WRITE_LABEL, MemoryContextId::root(), addr2, 2, value5);
     verify_memory_access(&trace, &chiplets_bus, 3, MEMORY_WRITE, &memory_access, prev_row);
 }
 
@@ -137,35 +147,35 @@ fn mem_write_read() {
     // write 1 into address 5; clk = 1
     let addr5 = 5;
     let value1 = [ONE, ZERO, ZERO, ZERO];
-    mem.write(0, addr5, 1, value1);
+    mem.write(MemoryContextId::root(), addr5, 1, value1);
 
     // write 4 into address 2; clk = 2
     let addr2 = 2;
     let value4 = [Felt::new(4), ZERO, ZERO, ZERO];
-    mem.write(0, addr2, 2, value4);
+    mem.write(MemoryContextId::root(), addr2, 2, value4);
 
     // read a value from address 5; clk = 3
-    mem.read(0, addr5, 3);
+    mem.read(MemoryContextId::root(), addr5, 3);
 
     // write 2 into address 5; clk = 4
     let value2 = [Felt::new(2), ZERO, ZERO, ZERO];
-    mem.write(0, addr5, 4, value2);
+    mem.write(MemoryContextId::root(), addr5, 4, value2);
 
     // read a value from address 2; clk = 5
-    mem.read(0, addr2, 5);
+    mem.read(MemoryContextId::root(), addr2, 5);
 
     // write 7 into address 2; clk = 6
     let value7 = [Felt::new(7), ZERO, ZERO, ZERO];
-    mem.write(0, addr2, 6, value7);
+    mem.write(MemoryContextId::root(), addr2, 6, value7);
 
     // read a value from address 5; clk = 7
-    mem.read(0, addr5, 7);
+    mem.read(MemoryContextId::root(), addr5, 7);
 
     // read a value from address 2; clk = 8
-    mem.read(0, addr2, 8);
+    mem.read(MemoryContextId::root(), addr2, 8);
 
     // read a value from address 5; clk = 9
-    mem.read(0, addr5, 9);
+    mem.read(MemoryContextId::root(), addr5, 9);
 
     // check generated trace and memory data provided to the ChipletsBus; rows should be sorted by
     // address and then clock cycle
@@ -173,40 +183,49 @@ fn mem_write_read() {
 
     // address 2
     let mut prev_row = [ZERO; MEMORY_TRACE_WIDTH];
-    let memory_access = MemoryLookup::from_ints(MEMORY_WRITE_LABEL, 0, addr2, 2, value4);
+    let memory_access =
+        MemoryLookup::from_ints(MEMORY_WRITE_LABEL, MemoryContextId::root(), addr2, 2, value4);
     prev_row =
         verify_memory_access(&trace, &chiplets_bus, 0, MEMORY_WRITE, &memory_access, prev_row);
 
-    let memory_access = MemoryLookup::from_ints(MEMORY_READ_LABEL, 0, addr2, 5, value4);
+    let memory_access =
+        MemoryLookup::from_ints(MEMORY_READ_LABEL, MemoryContextId::root(), addr2, 5, value4);
     prev_row =
         verify_memory_access(&trace, &chiplets_bus, 1, MEMORY_COPY_READ, &memory_access, prev_row);
 
-    let memory_access = MemoryLookup::from_ints(MEMORY_WRITE_LABEL, 0, addr2, 6, value7);
+    let memory_access =
+        MemoryLookup::from_ints(MEMORY_WRITE_LABEL, MemoryContextId::root(), addr2, 6, value7);
     prev_row =
         verify_memory_access(&trace, &chiplets_bus, 2, MEMORY_WRITE, &memory_access, prev_row);
 
-    let memory_access = MemoryLookup::from_ints(MEMORY_READ_LABEL, 0, addr2, 8, value7);
+    let memory_access =
+        MemoryLookup::from_ints(MEMORY_READ_LABEL, MemoryContextId::root(), addr2, 8, value7);
     prev_row =
         verify_memory_access(&trace, &chiplets_bus, 3, MEMORY_COPY_READ, &memory_access, prev_row);
 
     // address 5
-    let memory_access = MemoryLookup::from_ints(MEMORY_WRITE_LABEL, 0, addr5, 1, value1);
+    let memory_access =
+        MemoryLookup::from_ints(MEMORY_WRITE_LABEL, MemoryContextId::root(), addr5, 1, value1);
     prev_row =
         verify_memory_access(&trace, &chiplets_bus, 4, MEMORY_WRITE, &memory_access, prev_row);
 
-    let memory_access = MemoryLookup::from_ints(MEMORY_READ_LABEL, 0, addr5, 3, value1);
+    let memory_access =
+        MemoryLookup::from_ints(MEMORY_READ_LABEL, MemoryContextId::root(), addr5, 3, value1);
     prev_row =
         verify_memory_access(&trace, &chiplets_bus, 5, MEMORY_COPY_READ, &memory_access, prev_row);
 
-    let memory_access = MemoryLookup::from_ints(MEMORY_WRITE_LABEL, 0, addr5, 4, value2);
+    let memory_access =
+        MemoryLookup::from_ints(MEMORY_WRITE_LABEL, MemoryContextId::root(), addr5, 4, value2);
     prev_row =
         verify_memory_access(&trace, &chiplets_bus, 6, MEMORY_WRITE, &memory_access, prev_row);
 
-    let memory_access = MemoryLookup::from_ints(MEMORY_READ_LABEL, 0, addr5, 7, value2);
+    let memory_access =
+        MemoryLookup::from_ints(MEMORY_READ_LABEL, MemoryContextId::root(), addr5, 7, value2);
     prev_row =
         verify_memory_access(&trace, &chiplets_bus, 7, MEMORY_COPY_READ, &memory_access, prev_row);
 
-    let memory_access = MemoryLookup::from_ints(MEMORY_READ_LABEL, 0, addr5, 9, value2);
+    let memory_access =
+        MemoryLookup::from_ints(MEMORY_READ_LABEL, MemoryContextId::root(), addr5, 9, value2);
     verify_memory_access(&trace, &chiplets_bus, 8, MEMORY_COPY_READ, &memory_access, prev_row);
 }
 
@@ -214,35 +233,35 @@ fn mem_write_read() {
 fn mem_multi_context() {
     let mut mem = Memory::default();
 
-    // write a value into ctx = 0, addr = 0; clk = 1
+    // write a value into ctx = MemoryContextId::root(), addr = 0; clk = 1
     let value1 = [ONE, ZERO, ZERO, ZERO];
-    mem.write(0, 0, 1, value1);
-    assert_eq!(value1, mem.get_value(0, 0).unwrap());
+    mem.write(MemoryContextId::root(), 0, 1, value1);
+    assert_eq!(value1, mem.get_value(MemoryContextId::root(), 0).unwrap());
     assert_eq!(1, mem.size());
     assert_eq!(1, mem.trace_len());
 
     // write a value into ctx = 3, addr = 1; clk = 4
     let value2 = [ZERO, ONE, ZERO, ZERO];
-    mem.write(3, 1, 4, value2);
-    assert_eq!(value2, mem.get_value(3, 1).unwrap());
+    mem.write(3.into(), 1, 4, value2);
+    assert_eq!(value2, mem.get_value(3.into(), 1).unwrap());
     assert_eq!(2, mem.size());
     assert_eq!(2, mem.trace_len());
 
     // read a value from ctx = 3, addr = 1; clk = 6
-    let value = mem.read(3, 1, 6);
+    let value = mem.read(3.into(), 1, 6);
     assert_eq!(value2, value);
     assert_eq!(2, mem.size());
     assert_eq!(3, mem.trace_len());
 
     // write a value into ctx = 3, addr = 0; clk = 7
     let value3 = [ZERO, ZERO, ONE, ZERO];
-    mem.write(3, 0, 7, value3);
-    assert_eq!(value3, mem.get_value(3, 0).unwrap());
+    mem.write(3.into(), 0, 7, value3);
+    assert_eq!(value3, mem.get_value(3.into(), 0).unwrap());
     assert_eq!(3, mem.size());
     assert_eq!(4, mem.trace_len());
 
     // read a value from ctx = 0, addr = 0; clk = 9
-    let value = mem.read(0, 0, 9);
+    let value = mem.read(MemoryContextId::root(), 0, 9);
     assert_eq!(value1, value);
     assert_eq!(3, mem.size());
     assert_eq!(5, mem.trace_len());
@@ -253,25 +272,27 @@ fn mem_multi_context() {
 
     // ctx = 0, addr = 0
     let mut prev_row = [ZERO; MEMORY_TRACE_WIDTH];
-    let memory_access = MemoryLookup::from_ints(MEMORY_WRITE_LABEL, 0, 0, 1, value1);
+    let memory_access =
+        MemoryLookup::from_ints(MEMORY_WRITE_LABEL, MemoryContextId::root(), 0, 1, value1);
     prev_row =
         verify_memory_access(&trace, &chiplets_bus, 0, MEMORY_WRITE, &memory_access, prev_row);
 
-    let memory_access = MemoryLookup::from_ints(MEMORY_READ_LABEL, 0, 0, 9, value1);
+    let memory_access =
+        MemoryLookup::from_ints(MEMORY_READ_LABEL, MemoryContextId::root(), 0, 9, value1);
     prev_row =
         verify_memory_access(&trace, &chiplets_bus, 1, MEMORY_COPY_READ, &memory_access, prev_row);
 
     // ctx = 3, addr = 0
-    let memory_access = MemoryLookup::from_ints(MEMORY_WRITE_LABEL, 3, 0, 7, value3);
+    let memory_access = MemoryLookup::from_ints(MEMORY_WRITE_LABEL, 3.into(), 0, 7, value3);
     prev_row =
         verify_memory_access(&trace, &chiplets_bus, 2, MEMORY_WRITE, &memory_access, prev_row);
 
     // ctx = 3, addr = 1
-    let memory_access = MemoryLookup::from_ints(MEMORY_WRITE_LABEL, 3, 1, 4, value2);
+    let memory_access = MemoryLookup::from_ints(MEMORY_WRITE_LABEL, 3.into(), 1, 4, value2);
     prev_row =
         verify_memory_access(&trace, &chiplets_bus, 3, MEMORY_WRITE, &memory_access, prev_row);
 
-    let memory_access = MemoryLookup::from_ints(MEMORY_READ_LABEL, 3, 1, 6, value2);
+    let memory_access = MemoryLookup::from_ints(MEMORY_READ_LABEL, 3.into(), 1, 6, value2);
     verify_memory_access(&trace, &chiplets_bus, 4, MEMORY_COPY_READ, &memory_access, prev_row);
 }
 
@@ -282,33 +303,33 @@ fn mem_get_state_at() {
     // Write 1 into (ctx = 0, addr = 5) at clk = 1.
     // This means that mem[5] = 1 at the beginning of clk = 2
     let value1 = [ONE, ZERO, ZERO, ZERO];
-    mem.write(0, 5, 1, value1);
+    mem.write(MemoryContextId::root(), 5, 1, value1);
 
     // Write 4 into (ctx = 0, addr = 2) at clk = 2.
     // This means that mem[2] = 4 at the beginning of clk = 3
     let value4 = [Felt::new(4), ZERO, ZERO, ZERO];
-    mem.write(0, 2, 2, value4);
+    mem.write(MemoryContextId::root(), 2, 2, value4);
 
     // write 7 into (ctx = 3, addr = 3) at clk = 4
     // This means that mem[3] = 7 at the beginning of clk = 4
     let value7 = [Felt::new(7), ZERO, ZERO, ZERO];
-    mem.write(3, 3, 4, value7);
+    mem.write(3.into(), 3, 4, value7);
 
     // Check memory state at clk = 2
-    assert_eq!(mem.get_state_at(0, 2), vec![(5, value1)]);
-    assert_eq!(mem.get_state_at(3, 2), vec![]);
+    assert_eq!(mem.get_state_at(MemoryContextId::root(), 2), vec![(5, value1)]);
+    assert_eq!(mem.get_state_at(3.into(), 2), vec![]);
 
     // Check memory state at clk = 3
-    assert_eq!(mem.get_state_at(0, 3), vec![(2, value4), (5, value1)]);
-    assert_eq!(mem.get_state_at(3, 3), vec![]);
+    assert_eq!(mem.get_state_at(MemoryContextId::root(), 3), vec![(2, value4), (5, value1)]);
+    assert_eq!(mem.get_state_at(3.into(), 3), vec![]);
 
     // Check memory state at clk = 4
-    assert_eq!(mem.get_state_at(0, 4), vec![(2, value4), (5, value1)]);
-    assert_eq!(mem.get_state_at(3, 4), vec![]);
+    assert_eq!(mem.get_state_at(MemoryContextId::root(), 4), vec![(2, value4), (5, value1)]);
+    assert_eq!(mem.get_state_at(3.into(), 4), vec![]);
 
     // Check memory state at clk = 5
-    assert_eq!(mem.get_state_at(0, 5), vec![(2, value4), (5, value1)]);
-    assert_eq!(mem.get_state_at(3, 5), vec![(3, value7)]);
+    assert_eq!(mem.get_state_at(MemoryContextId::root(), 5), vec![(2, value4), (5, value1)]);
+    assert_eq!(mem.get_state_at(3.into(), 5), vec![(3, value7)]);
 }
 
 // HELPER STRUCT & FUNCTIONS

--- a/processor/src/chiplets/mod.rs
+++ b/processor/src/chiplets/mod.rs
@@ -18,7 +18,9 @@ pub use hasher::init_state_from_words;
 use hasher::Hasher;
 
 mod memory;
-use memory::{Memory, MemoryLookup};
+use memory::{ContextId, Memory, MemoryLookup};
+
+pub type MemoryContextId = memory::ContextId;
 
 mod kernel_rom;
 use kernel_rom::{KernelProcLookup, KernelRom};
@@ -349,7 +351,7 @@ impl Chiplets {
     ///
     /// If the specified address hasn't been previously written to, four ZERO elements are
     /// returned. This effectively implies that memory is initialized to ZERO.
-    pub fn read_mem(&mut self, ctx: u32, addr: u32) -> Word {
+    pub fn read_mem(&mut self, ctx: ContextId, addr: u32) -> Word {
         // read the word from memory
         let value = self.memory.read(ctx, addr, self.clk);
 
@@ -365,7 +367,7 @@ impl Chiplets {
     ///
     /// If either of the accessed addresses hasn't been previously written to, ZERO elements are
     /// returned. This effectively implies that memory is initialized to ZERO.
-    pub fn read_mem_double(&mut self, ctx: u32, addr: u32) -> [Word; 2] {
+    pub fn read_mem_double(&mut self, ctx: ContextId, addr: u32) -> [Word; 2] {
         // read two words from memory: from addr and from addr + 1
         let addr2 = addr + 1;
         let words = [self.memory.read(ctx, addr, self.clk), self.memory.read(ctx, addr2, self.clk)];
@@ -384,7 +386,7 @@ impl Chiplets {
     /// Writes the provided word at the specified context/address.
     ///
     /// This also modifies the memory access trace and sends a memory lookup request to the bus.
-    pub fn write_mem(&mut self, ctx: u32, addr: u32, word: Word) {
+    pub fn write_mem(&mut self, ctx: ContextId, addr: u32, word: Word) {
         self.memory.write(ctx, addr, self.clk, word);
 
         // send the memory write request to the bus
@@ -396,7 +398,7 @@ impl Chiplets {
     /// elements of the word previously stored at that address unchanged.
     ///
     /// This also modifies the memory access trace and sends a memory lookup request to the bus.
-    pub fn write_mem_element(&mut self, ctx: u32, addr: u32, value: Felt) -> Word {
+    pub fn write_mem_element(&mut self, ctx: ContextId, addr: u32, value: Felt) -> Word {
         let old_word = self.memory.get_old_value(ctx, addr);
         let new_word = [value, old_word[1], old_word[2], old_word[3]];
 
@@ -413,7 +415,7 @@ impl Chiplets {
     /// context, starting at the specified address.
     ///
     /// This also modifies the memory access trace and sends two memory lookup requests to the bus.
-    pub fn write_mem_double(&mut self, ctx: u32, addr: u32, words: [Word; 2]) {
+    pub fn write_mem_double(&mut self, ctx: ContextId, addr: u32, words: [Word; 2]) {
         let addr2 = addr + 1;
         // write two words to memory at addr and addr + 1
         self.memory.write(ctx, addr, self.clk, words[0]);
@@ -434,14 +436,14 @@ impl Chiplets {
     ///
     /// Unlike mem_read() which modifies the memory access trace, this method returns the value at
     /// the specified address (if one exists) without altering the memory access trace.
-    pub fn get_mem_value(&self, ctx: u32, addr: u32) -> Option<Word> {
+    pub fn get_mem_value(&self, ctx: ContextId, addr: u32) -> Option<Word> {
         self.memory.get_value(ctx, addr)
     }
 
     /// Returns the entire memory state for the specified execution context at the specified cycle.
     /// The state is returned as a vector of (address, value) tuples, and includes addresses which
     /// have been accessed at least once.
-    pub fn get_mem_state_at(&self, ctx: u32, clk: u32) -> Vec<(u64, Word)> {
+    pub fn get_mem_state_at(&self, ctx: ContextId, clk: u32) -> Vec<(u64, Word)> {
         self.memory.get_state_at(ctx, clk)
     }
 

--- a/processor/src/chiplets/mod.rs
+++ b/processor/src/chiplets/mod.rs
@@ -1,3 +1,5 @@
+use crate::system::ContextId;
+
 use super::{
     crypto::MerklePath, trace, utils, BTreeMap, ChipletsTrace, ColMatrix, ExecutionError, Felt,
     FieldElement, RangeChecker, StarkField, TraceFragment, Vec, Word, CHIPLETS_WIDTH, EMPTY_WORD,
@@ -19,8 +21,6 @@ use hasher::Hasher;
 
 mod memory;
 use memory::{Memory, MemoryLookup};
-
-pub use memory::ContextId;
 
 mod kernel_rom;
 use kernel_rom::{KernelProcLookup, KernelRom};

--- a/processor/src/chiplets/mod.rs
+++ b/processor/src/chiplets/mod.rs
@@ -18,9 +18,9 @@ pub use hasher::init_state_from_words;
 use hasher::Hasher;
 
 mod memory;
-use memory::{ContextId, Memory, MemoryLookup};
+use memory::{Memory, MemoryLookup};
 
-pub type MemoryContextId = memory::ContextId;
+pub use memory::ContextId;
 
 mod kernel_rom;
 use kernel_rom::{KernelProcLookup, KernelRom};

--- a/processor/src/debug.rs
+++ b/processor/src/debug.rs
@@ -1,6 +1,6 @@
 use crate::{
-    range::RangeChecker, Chiplets, ChipletsLengths, Decoder, ExecutionError, Felt, Host, Process,
-    Stack, StarkField, System, TraceLenSummary, Vec,
+    chiplets::MemoryContextId, range::RangeChecker, Chiplets, ChipletsLengths, Decoder,
+    ExecutionError, Felt, Host, Process, Stack, StarkField, System, TraceLenSummary, Vec,
 };
 use core::fmt;
 use vm_core::{
@@ -12,7 +12,7 @@ use vm_core::{
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct VmState {
     pub clk: u32,
-    pub ctx: u32,
+    pub ctx: MemoryContextId,
     pub op: Option<Operation>,
     pub asmop: Option<AsmOpInfo>,
     pub fmp: Felt,

--- a/processor/src/debug.rs
+++ b/processor/src/debug.rs
@@ -1,6 +1,6 @@
 use crate::{
-    chiplets::ContextId, range::RangeChecker, Chiplets, ChipletsLengths, Decoder,
-    ExecutionError, Felt, Host, Process, Stack, StarkField, System, TraceLenSummary, Vec,
+    range::RangeChecker, system::ContextId, Chiplets, ChipletsLengths, Decoder, ExecutionError,
+    Felt, Host, Process, Stack, StarkField, System, TraceLenSummary, Vec,
 };
 use core::fmt;
 use vm_core::{

--- a/processor/src/debug.rs
+++ b/processor/src/debug.rs
@@ -1,5 +1,5 @@
 use crate::{
-    chiplets::MemoryContextId, range::RangeChecker, Chiplets, ChipletsLengths, Decoder,
+    chiplets::ContextId, range::RangeChecker, Chiplets, ChipletsLengths, Decoder,
     ExecutionError, Felt, Host, Process, Stack, StarkField, System, TraceLenSummary, Vec,
 };
 use core::fmt;
@@ -12,7 +12,7 @@ use vm_core::{
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct VmState {
     pub clk: u32,
-    pub ctx: MemoryContextId,
+    pub ctx: ContextId,
     pub op: Option<Operation>,
     pub asmop: Option<AsmOpInfo>,
     pub fmp: Felt,

--- a/processor/src/decoder/aux_hints.rs
+++ b/processor/src/decoder/aux_hints.rs
@@ -1,4 +1,4 @@
-use crate::chiplets::MemoryContextId;
+use crate::chiplets::ContextId;
 
 use super::{
     super::trace::LookupTableRow, get_num_groups_in_next_batch, BlockInfo, ColMatrix, Felt,
@@ -278,7 +278,7 @@ pub struct BlockStackTableRow {
     block_id: Felt,
     parent_id: Felt,
     is_loop: bool,
-    parent_ctx: MemoryContextId,
+    parent_ctx: ContextId,
     parent_fn_hash: Word,
     parent_fmp: Felt,
     parent_stack_depth: u32,
@@ -309,7 +309,7 @@ impl BlockStackTableRow {
             block_id,
             parent_id,
             is_loop,
-            parent_ctx: MemoryContextId::root(),
+            parent_ctx: ContextId::root(),
             parent_fn_hash: EMPTY_WORD,
             parent_fmp: ZERO,
             parent_stack_depth: 0,

--- a/processor/src/decoder/aux_hints.rs
+++ b/processor/src/decoder/aux_hints.rs
@@ -1,4 +1,4 @@
-use crate::chiplets::ContextId;
+use crate::system::ContextId;
 
 use super::{
     super::trace::LookupTableRow, get_num_groups_in_next_batch, BlockInfo, ColMatrix, Felt,

--- a/processor/src/decoder/aux_hints.rs
+++ b/processor/src/decoder/aux_hints.rs
@@ -1,3 +1,5 @@
+use crate::chiplets::MemoryContextId;
+
 use super::{
     super::trace::LookupTableRow, get_num_groups_in_next_batch, BlockInfo, ColMatrix, Felt,
     FieldElement, StarkField, Vec, Word, EMPTY_WORD, ONE, ZERO,
@@ -276,7 +278,7 @@ pub struct BlockStackTableRow {
     block_id: Felt,
     parent_id: Felt,
     is_loop: bool,
-    parent_ctx: u32,
+    parent_ctx: MemoryContextId,
     parent_fn_hash: Word,
     parent_fmp: Felt,
     parent_stack_depth: u32,

--- a/processor/src/decoder/aux_hints.rs
+++ b/processor/src/decoder/aux_hints.rs
@@ -309,7 +309,7 @@ impl BlockStackTableRow {
             block_id,
             parent_id,
             is_loop,
-            parent_ctx: 0,
+            parent_ctx: MemoryContextId::root(),
             parent_fn_hash: EMPTY_WORD,
             parent_fmp: ZERO,
             parent_stack_depth: 0,

--- a/processor/src/decoder/block_stack.rs
+++ b/processor/src/decoder/block_stack.rs
@@ -1,5 +1,5 @@
-use crate::system::ContextId;
 use super::{Felt, Vec, Word, ONE, ZERO};
+use crate::system::ContextId;
 
 // BLOCK STACK
 // ================================================================================================

--- a/processor/src/decoder/block_stack.rs
+++ b/processor/src/decoder/block_stack.rs
@@ -1,4 +1,4 @@
-use crate::chiplets::ContextId;
+use crate::system::ContextId;
 
 use super::{Felt, Vec, Word, ONE, ZERO};
 

--- a/processor/src/decoder/block_stack.rs
+++ b/processor/src/decoder/block_stack.rs
@@ -1,4 +1,4 @@
-use crate::chiplets::MemoryContextId;
+use crate::chiplets::ContextId;
 
 use super::{Felt, Vec, Word, ONE, ZERO};
 
@@ -164,7 +164,7 @@ impl BlockInfo {
 #[derive(Debug, Default, Clone, Copy)]
 pub struct ExecutionContextInfo {
     /// Context ID of the block's parent.
-    pub parent_ctx: MemoryContextId,
+    pub parent_ctx: ContextId,
     /// Hash of the function which initiated execution of the block's parent. If the parent is a
     /// root context, this will be set to [ZERO; 4].
     pub parent_fn_hash: Word,
@@ -179,7 +179,7 @@ pub struct ExecutionContextInfo {
 impl ExecutionContextInfo {
     /// Returns an new [ExecutionContextInfo] instantiated with the specified parameters.
     pub fn new(
-        parent_ctx: MemoryContextId,
+        parent_ctx: ContextId,
         parent_fn_hash: Word,
         parent_fmp: Felt,
         parent_stack_depth: u32,

--- a/processor/src/decoder/block_stack.rs
+++ b/processor/src/decoder/block_stack.rs
@@ -1,5 +1,4 @@
 use crate::system::ContextId;
-
 use super::{Felt, Vec, Word, ONE, ZERO};
 
 // BLOCK STACK

--- a/processor/src/decoder/block_stack.rs
+++ b/processor/src/decoder/block_stack.rs
@@ -1,3 +1,5 @@
+use crate::chiplets::MemoryContextId;
+
 use super::{Felt, Vec, Word, ONE, ZERO};
 
 // BLOCK STACK
@@ -162,7 +164,7 @@ impl BlockInfo {
 #[derive(Debug, Default, Clone, Copy)]
 pub struct ExecutionContextInfo {
     /// Context ID of the block's parent.
-    pub parent_ctx: u32,
+    pub parent_ctx: MemoryContextId,
     /// Hash of the function which initiated execution of the block's parent. If the parent is a
     /// root context, this will be set to [ZERO; 4].
     pub parent_fn_hash: Word,
@@ -177,7 +179,7 @@ pub struct ExecutionContextInfo {
 impl ExecutionContextInfo {
     /// Returns an new [ExecutionContextInfo] instantiated with the specified parameters.
     pub fn new(
-        parent_ctx: u32,
+        parent_ctx: MemoryContextId,
         parent_fn_hash: Word,
         parent_fmp: Felt,
         parent_stack_depth: u32,

--- a/processor/src/decoder/tests.rs
+++ b/processor/src/decoder/tests.rs
@@ -6,7 +6,7 @@ use super::{
     build_op_group, AuxTraceHints, BlockHashTableRow, BlockStackTableRow, BlockTableUpdate,
     ExecutionContextInfo, OpGroupTableRow, OpGroupTableUpdate,
 };
-use crate::{DefaultHost, MemoryContextId};
+use crate::{DefaultHost, ContextId};
 use miden_air::trace::{
     decoder::{
         ADDR_COL_IDX, GROUP_COUNT_COL_IDX, HASHER_STATE_RANGE, IN_SPAN_COL_IDX, NUM_HASHER_COLUMNS,
@@ -1098,7 +1098,7 @@ fn call_block() {
 
     // --- check block stack table rows -----------------------------------------------------------
     let call_ctx =
-        ExecutionContextInfo::new(MemoryContextId::root(), EMPTY_WORD, FMP_MIN + TWO, 17, overflow_addr_after_pad);
+        ExecutionContextInfo::new(ContextId::root(), EMPTY_WORD, FMP_MIN + TWO, 17, overflow_addr_after_pad);
     let expected_rows = vec![
         BlockStackTableRow::new_test(INIT_ADDR, ZERO, false),
         BlockStackTableRow::new_test(join1_addr, INIT_ADDR, false),
@@ -1435,7 +1435,7 @@ fn syscall_block() {
 
     // --- check block stack table rows -----------------------------------------------------------
     let call_ctx =
-        ExecutionContextInfo::new(MemoryContextId::root(), EMPTY_WORD, FMP_MIN + ONE, 17, overflow_addr_after_pad);
+        ExecutionContextInfo::new(ContextId::root(), EMPTY_WORD, FMP_MIN + ONE, 17, overflow_addr_after_pad);
     let syscall_ctx = ExecutionContextInfo::new(8.into(), bar_root_hash, FMP_MIN + TWO, 16, ZERO);
     let expected_rows = vec![
         BlockStackTableRow::new_test(INIT_ADDR, ZERO, false),

--- a/processor/src/decoder/tests.rs
+++ b/processor/src/decoder/tests.rs
@@ -6,7 +6,7 @@ use super::{
     build_op_group, AuxTraceHints, BlockHashTableRow, BlockStackTableRow, BlockTableUpdate,
     ExecutionContextInfo, OpGroupTableRow, OpGroupTableUpdate,
 };
-use crate::DefaultHost;
+use crate::{DefaultHost, MemoryContextId};
 use miden_air::trace::{
     decoder::{
         ADDR_COL_IDX, GROUP_COUNT_COL_IDX, HASHER_STATE_RANGE, IN_SPAN_COL_IDX, NUM_HASHER_COLUMNS,
@@ -1098,7 +1098,7 @@ fn call_block() {
 
     // --- check block stack table rows -----------------------------------------------------------
     let call_ctx =
-        ExecutionContextInfo::new(0, EMPTY_WORD, FMP_MIN + TWO, 17, overflow_addr_after_pad);
+        ExecutionContextInfo::new(MemoryContextId::root(), EMPTY_WORD, FMP_MIN + TWO, 17, overflow_addr_after_pad);
     let expected_rows = vec![
         BlockStackTableRow::new_test(INIT_ADDR, ZERO, false),
         BlockStackTableRow::new_test(join1_addr, INIT_ADDR, false),
@@ -1435,8 +1435,8 @@ fn syscall_block() {
 
     // --- check block stack table rows -----------------------------------------------------------
     let call_ctx =
-        ExecutionContextInfo::new(0, EMPTY_WORD, FMP_MIN + ONE, 17, overflow_addr_after_pad);
-    let syscall_ctx = ExecutionContextInfo::new(8, bar_root_hash, FMP_MIN + TWO, 16, ZERO);
+        ExecutionContextInfo::new(MemoryContextId::root(), EMPTY_WORD, FMP_MIN + ONE, 17, overflow_addr_after_pad);
+    let syscall_ctx = ExecutionContextInfo::new(8.into(), bar_root_hash, FMP_MIN + TWO, 16, ZERO);
     let expected_rows = vec![
         BlockStackTableRow::new_test(INIT_ADDR, ZERO, false),
         BlockStackTableRow::new_test(inner_join_addr, INIT_ADDR, false),

--- a/processor/src/decoder/tests.rs
+++ b/processor/src/decoder/tests.rs
@@ -6,7 +6,7 @@ use super::{
     build_op_group, AuxTraceHints, BlockHashTableRow, BlockStackTableRow, BlockTableUpdate,
     ExecutionContextInfo, OpGroupTableRow, OpGroupTableUpdate,
 };
-use crate::{DefaultHost, ContextId};
+use crate::{ContextId, DefaultHost};
 use miden_air::trace::{
     decoder::{
         ADDR_COL_IDX, GROUP_COUNT_COL_IDX, HASHER_STATE_RANGE, IN_SPAN_COL_IDX, NUM_HASHER_COLUMNS,

--- a/processor/src/host/debug.rs
+++ b/processor/src/host/debug.rs
@@ -1,5 +1,5 @@
 use super::ProcessState;
-use crate::{chiplets::ContextId, Vec};
+use crate::{Vec, system::ContextId};
 use vm_core::{DebugOptions, StarkField, Word};
 
 // DEBUG HANDLER

--- a/processor/src/host/debug.rs
+++ b/processor/src/host/debug.rs
@@ -1,5 +1,5 @@
 use super::ProcessState;
-use crate::{Vec, system::ContextId};
+use crate::{system::ContextId, Vec};
 use vm_core::{DebugOptions, StarkField, Word};
 
 // DEBUG HANDLER

--- a/processor/src/host/debug.rs
+++ b/processor/src/host/debug.rs
@@ -1,5 +1,5 @@
 use super::ProcessState;
-use crate::Vec;
+use crate::{chiplets::MemoryContextId, Vec};
 use vm_core::{DebugOptions, StarkField, Word};
 
 // DEBUG HANDLER
@@ -32,12 +32,12 @@ pub fn print_debug_info<S: ProcessState>(process: &S, options: &DebugOptions) {
 
 struct Printer {
     clk: u32,
-    ctx: u32,
+    ctx: MemoryContextId,
     fmp: u32,
 }
 
 impl Printer {
-    fn new(clk: u32, ctx: u32, fmp: u64) -> Self {
+    fn new(clk: u32, ctx: MemoryContextId, fmp: u64) -> Self {
         Self {
             clk,
             ctx,

--- a/processor/src/host/debug.rs
+++ b/processor/src/host/debug.rs
@@ -1,5 +1,5 @@
 use super::ProcessState;
-use crate::{chiplets::MemoryContextId, Vec};
+use crate::{chiplets::ContextId, Vec};
 use vm_core::{DebugOptions, StarkField, Word};
 
 // DEBUG HANDLER
@@ -32,12 +32,12 @@ pub fn print_debug_info<S: ProcessState>(process: &S, options: &DebugOptions) {
 
 struct Printer {
     clk: u32,
-    ctx: MemoryContextId,
+    ctx: ContextId,
     fmp: u32,
 }
 
 impl Printer {
-    fn new(clk: u32, ctx: MemoryContextId, fmp: u64) -> Self {
+    fn new(clk: u32, ctx: ContextId, fmp: u64) -> Self {
         Self {
             clk,
             ctx,

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -49,6 +49,7 @@ pub use host::{
 
 mod chiplets;
 use chiplets::Chiplets;
+pub use chiplets::MemoryContextId;
 
 mod trace;
 use trace::TraceFragment;
@@ -527,7 +528,7 @@ pub trait ProcessState {
     fn clk(&self) -> u32;
 
     /// Returns the current execution context ID.
-    fn ctx(&self) -> u32;
+    fn ctx(&self) -> MemoryContextId;
 
     /// Returns the current value of the free memory pointer.
     fn fmp(&self) -> u64;
@@ -553,14 +554,14 @@ pub trait ProcessState {
 
     /// Returns a word located at the specified context/address, or None if the address hasn't
     /// been accessed previously.
-    fn get_mem_value(&self, ctx: u32, addr: u32) -> Option<Word>;
+    fn get_mem_value(&self, ctx: MemoryContextId, addr: u32) -> Option<Word>;
 
     /// Returns the entire memory state for the specified execution context at the current clock
     /// cycle.
     ///
     /// The state is returned as a vector of (address, value) tuples, and includes addresses which
     /// have been accessed at least once.
-    fn get_mem_state(&self, ctx: u32) -> Vec<(u64, Word)>;
+    fn get_mem_state(&self, ctx: MemoryContextId) -> Vec<(u64, Word)>;
 }
 
 impl<H: Host> ProcessState for Process<H> {
@@ -568,7 +569,7 @@ impl<H: Host> ProcessState for Process<H> {
         self.system.clk()
     }
 
-    fn ctx(&self) -> u32 {
+    fn ctx(&self) -> MemoryContextId {
         self.system.ctx()
     }
 
@@ -588,11 +589,11 @@ impl<H: Host> ProcessState for Process<H> {
         self.stack.get_state_at(self.system.clk())
     }
 
-    fn get_mem_value(&self, ctx: u32, addr: u32) -> Option<Word> {
+    fn get_mem_value(&self, ctx: MemoryContextId, addr: u32) -> Option<Word> {
         self.chiplets.get_mem_value(ctx, addr)
     }
 
-    fn get_mem_state(&self, ctx: u32) -> Vec<(u64, Word)> {
+    fn get_mem_state(&self, ctx: MemoryContextId) -> Vec<(u64, Word)> {
         self.chiplets.get_mem_state_at(ctx, self.system.clk())
     }
 }

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -30,7 +30,7 @@ mod operations;
 
 mod system;
 use system::System;
-pub use system::{FMP_MIN, SYSCALL_FMP_MIN};
+pub use system::{ContextId, FMP_MIN, SYSCALL_FMP_MIN};
 
 mod decoder;
 use decoder::Decoder;
@@ -49,7 +49,6 @@ pub use host::{
 
 mod chiplets;
 use chiplets::Chiplets;
-pub use chiplets::ContextId;
 
 mod trace;
 use trace::TraceFragment;

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -49,7 +49,7 @@ pub use host::{
 
 mod chiplets;
 use chiplets::Chiplets;
-pub use chiplets::MemoryContextId;
+pub use chiplets::ContextId;
 
 mod trace;
 use trace::TraceFragment;
@@ -528,7 +528,7 @@ pub trait ProcessState {
     fn clk(&self) -> u32;
 
     /// Returns the current execution context ID.
-    fn ctx(&self) -> MemoryContextId;
+    fn ctx(&self) -> ContextId;
 
     /// Returns the current value of the free memory pointer.
     fn fmp(&self) -> u64;
@@ -554,14 +554,14 @@ pub trait ProcessState {
 
     /// Returns a word located at the specified context/address, or None if the address hasn't
     /// been accessed previously.
-    fn get_mem_value(&self, ctx: MemoryContextId, addr: u32) -> Option<Word>;
+    fn get_mem_value(&self, ctx: ContextId, addr: u32) -> Option<Word>;
 
     /// Returns the entire memory state for the specified execution context at the current clock
     /// cycle.
     ///
     /// The state is returned as a vector of (address, value) tuples, and includes addresses which
     /// have been accessed at least once.
-    fn get_mem_state(&self, ctx: MemoryContextId) -> Vec<(u64, Word)>;
+    fn get_mem_state(&self, ctx: ContextId) -> Vec<(u64, Word)>;
 }
 
 impl<H: Host> ProcessState for Process<H> {
@@ -569,7 +569,7 @@ impl<H: Host> ProcessState for Process<H> {
         self.system.clk()
     }
 
-    fn ctx(&self) -> MemoryContextId {
+    fn ctx(&self) -> ContextId {
         self.system.ctx()
     }
 
@@ -589,11 +589,11 @@ impl<H: Host> ProcessState for Process<H> {
         self.stack.get_state_at(self.system.clk())
     }
 
-    fn get_mem_value(&self, ctx: MemoryContextId, addr: u32) -> Option<Word> {
+    fn get_mem_value(&self, ctx: ContextId, addr: u32) -> Option<Word> {
         self.chiplets.get_mem_value(ctx, addr)
     }
 
-    fn get_mem_state(&self, ctx: MemoryContextId) -> Vec<(u64, Word)> {
+    fn get_mem_state(&self, ctx: ContextId) -> Vec<(u64, Word)> {
         self.chiplets.get_mem_state_at(ctx, self.system.clk())
     }
 }

--- a/processor/src/operations/io_ops.rs
+++ b/processor/src/operations/io_ops.rs
@@ -275,7 +275,7 @@ mod tests {
         super::{super::AdviceProvider, Operation, STACK_TOP_SIZE},
         Felt, Host, Process,
     };
-    use crate::{AdviceSource, MemoryContextId};
+    use crate::{AdviceSource, ContextId};
     use vm_core::{utils::ToElements, Word, ONE, ZERO};
 
     #[test]
@@ -332,7 +332,7 @@ mod tests {
 
         // check memory state
         assert_eq!(1, process.chiplets.get_mem_size());
-        assert_eq!(word, process.chiplets.get_mem_value(MemoryContextId::root(), 1).unwrap());
+        assert_eq!(word, process.chiplets.get_mem_value(ContextId::root(), 1).unwrap());
 
         // --- calling MLOADW with address greater than u32::MAX leads to an error ----------------
         process.execute_op(Operation::Push(Felt::from(u64::MAX / 2))).unwrap();
@@ -361,7 +361,7 @@ mod tests {
 
         // check memory state
         assert_eq!(1, process.chiplets.get_mem_size());
-        assert_eq!(word, process.chiplets.get_mem_value(MemoryContextId::root(), 2).unwrap());
+        assert_eq!(word, process.chiplets.get_mem_value(ContextId::root(), 2).unwrap());
 
         // --- calling MLOAD with address greater than u32::MAX leads to an error -----------------
         process.execute_op(Operation::Push(Felt::from(u64::MAX / 2))).unwrap();
@@ -388,11 +388,11 @@ mod tests {
         assert_eq!(2, process.chiplets.get_mem_size());
         assert_eq!(
             word1_felts,
-            process.chiplets.get_mem_value(MemoryContextId::root(), 1).unwrap()
+            process.chiplets.get_mem_value(ContextId::root(), 1).unwrap()
         );
         assert_eq!(
             word2_felts,
-            process.chiplets.get_mem_value(MemoryContextId::root(), 2).unwrap()
+            process.chiplets.get_mem_value(ContextId::root(), 2).unwrap()
         );
 
         // clear the stack
@@ -439,7 +439,7 @@ mod tests {
 
         // check memory state
         assert_eq!(1, process.chiplets.get_mem_size());
-        assert_eq!(word1, process.chiplets.get_mem_value(MemoryContextId::root(), 0).unwrap());
+        assert_eq!(word1, process.chiplets.get_mem_value(ContextId::root(), 0).unwrap());
 
         // push the second word onto the stack and save it at address 3
         let word2 = [2, 4, 6, 8].to_elements().try_into().unwrap();
@@ -451,8 +451,8 @@ mod tests {
 
         // check memory state
         assert_eq!(2, process.chiplets.get_mem_size());
-        assert_eq!(word1, process.chiplets.get_mem_value(MemoryContextId::root(), 0).unwrap());
-        assert_eq!(word2, process.chiplets.get_mem_value(MemoryContextId::root(), 3).unwrap());
+        assert_eq!(word1, process.chiplets.get_mem_value(ContextId::root(), 0).unwrap());
+        assert_eq!(word2, process.chiplets.get_mem_value(ContextId::root(), 3).unwrap());
 
         // --- calling MSTOREW with address greater than u32::MAX leads to an error ----------------
         process.execute_op(Operation::Push(Felt::from(u64::MAX / 2))).unwrap();
@@ -480,7 +480,7 @@ mod tests {
         // check memory state
         let mem_0 = [element, ZERO, ZERO, ZERO];
         assert_eq!(1, process.chiplets.get_mem_size());
-        assert_eq!(mem_0, process.chiplets.get_mem_value(MemoryContextId::root(), 0).unwrap());
+        assert_eq!(mem_0, process.chiplets.get_mem_value(ContextId::root(), 0).unwrap());
 
         // push the word onto the stack and save it at address 2
         let word_2 = [1, 3, 5, 7].to_elements().try_into().unwrap();
@@ -497,7 +497,7 @@ mod tests {
         // check memory state to make sure the other 3 elements were not affected
         let mem_2 = [element, Felt::new(3), Felt::new(5), Felt::new(7)];
         assert_eq!(2, process.chiplets.get_mem_size());
-        assert_eq!(mem_2, process.chiplets.get_mem_value(MemoryContextId::root(), 2).unwrap());
+        assert_eq!(mem_2, process.chiplets.get_mem_value(ContextId::root(), 2).unwrap());
 
         // --- calling MSTORE with address greater than u32::MAX leads to an error ----------------
         process.execute_op(Operation::Push(Felt::from(u64::MAX / 2))).unwrap();
@@ -546,11 +546,11 @@ mod tests {
         assert_eq!(2, process.chiplets.get_mem_size());
         assert_eq!(
             word1_felts,
-            process.chiplets.get_mem_value(MemoryContextId::root(), 1).unwrap()
+            process.chiplets.get_mem_value(ContextId::root(), 1).unwrap()
         );
         assert_eq!(
             word2_felts,
-            process.chiplets.get_mem_value(MemoryContextId::root(), 2).unwrap()
+            process.chiplets.get_mem_value(ContextId::root(), 2).unwrap()
         );
 
         // the first 8 values should be the values from the advice stack. the next 4 values should

--- a/processor/src/operations/io_ops.rs
+++ b/processor/src/operations/io_ops.rs
@@ -386,14 +386,8 @@ mod tests {
 
         // check memory state
         assert_eq!(2, process.chiplets.get_mem_size());
-        assert_eq!(
-            word1_felts,
-            process.chiplets.get_mem_value(ContextId::root(), 1).unwrap()
-        );
-        assert_eq!(
-            word2_felts,
-            process.chiplets.get_mem_value(ContextId::root(), 2).unwrap()
-        );
+        assert_eq!(word1_felts, process.chiplets.get_mem_value(ContextId::root(), 1).unwrap());
+        assert_eq!(word2_felts, process.chiplets.get_mem_value(ContextId::root(), 2).unwrap());
 
         // clear the stack
         for _ in 0..8 {
@@ -544,14 +538,8 @@ mod tests {
 
         // check memory state contains the words from the advice stack
         assert_eq!(2, process.chiplets.get_mem_size());
-        assert_eq!(
-            word1_felts,
-            process.chiplets.get_mem_value(ContextId::root(), 1).unwrap()
-        );
-        assert_eq!(
-            word2_felts,
-            process.chiplets.get_mem_value(ContextId::root(), 2).unwrap()
-        );
+        assert_eq!(word1_felts, process.chiplets.get_mem_value(ContextId::root(), 1).unwrap());
+        assert_eq!(word2_felts, process.chiplets.get_mem_value(ContextId::root(), 2).unwrap());
 
         // the first 8 values should be the values from the advice stack. the next 4 values should
         // remain unchanged, and the address should be incremented by 2 (i.e., 1 -> 3).

--- a/processor/src/operations/io_ops.rs
+++ b/processor/src/operations/io_ops.rs
@@ -275,7 +275,7 @@ mod tests {
         super::{super::AdviceProvider, Operation, STACK_TOP_SIZE},
         Felt, Host, Process,
     };
-    use crate::AdviceSource;
+    use crate::{AdviceSource, MemoryContextId};
     use vm_core::{utils::ToElements, Word, ONE, ZERO};
 
     #[test]
@@ -332,7 +332,7 @@ mod tests {
 
         // check memory state
         assert_eq!(1, process.chiplets.get_mem_size());
-        assert_eq!(word, process.chiplets.get_mem_value(0, 1).unwrap());
+        assert_eq!(word, process.chiplets.get_mem_value(MemoryContextId::root(), 1).unwrap());
 
         // --- calling MLOADW with address greater than u32::MAX leads to an error ----------------
         process.execute_op(Operation::Push(Felt::from(u64::MAX / 2))).unwrap();
@@ -361,7 +361,7 @@ mod tests {
 
         // check memory state
         assert_eq!(1, process.chiplets.get_mem_size());
-        assert_eq!(word, process.chiplets.get_mem_value(0, 2).unwrap());
+        assert_eq!(word, process.chiplets.get_mem_value(MemoryContextId::root(), 2).unwrap());
 
         // --- calling MLOAD with address greater than u32::MAX leads to an error -----------------
         process.execute_op(Operation::Push(Felt::from(u64::MAX / 2))).unwrap();
@@ -386,8 +386,14 @@ mod tests {
 
         // check memory state
         assert_eq!(2, process.chiplets.get_mem_size());
-        assert_eq!(word1_felts, process.chiplets.get_mem_value(0, 1).unwrap());
-        assert_eq!(word2_felts, process.chiplets.get_mem_value(0, 2).unwrap());
+        assert_eq!(
+            word1_felts,
+            process.chiplets.get_mem_value(MemoryContextId::root(), 1).unwrap()
+        );
+        assert_eq!(
+            word2_felts,
+            process.chiplets.get_mem_value(MemoryContextId::root(), 2).unwrap()
+        );
 
         // clear the stack
         for _ in 0..8 {
@@ -433,7 +439,7 @@ mod tests {
 
         // check memory state
         assert_eq!(1, process.chiplets.get_mem_size());
-        assert_eq!(word1, process.chiplets.get_mem_value(0, 0).unwrap());
+        assert_eq!(word1, process.chiplets.get_mem_value(MemoryContextId::root(), 0).unwrap());
 
         // push the second word onto the stack and save it at address 3
         let word2 = [2, 4, 6, 8].to_elements().try_into().unwrap();
@@ -445,8 +451,8 @@ mod tests {
 
         // check memory state
         assert_eq!(2, process.chiplets.get_mem_size());
-        assert_eq!(word1, process.chiplets.get_mem_value(0, 0).unwrap());
-        assert_eq!(word2, process.chiplets.get_mem_value(0, 3).unwrap());
+        assert_eq!(word1, process.chiplets.get_mem_value(MemoryContextId::root(), 0).unwrap());
+        assert_eq!(word2, process.chiplets.get_mem_value(MemoryContextId::root(), 3).unwrap());
 
         // --- calling MSTOREW with address greater than u32::MAX leads to an error ----------------
         process.execute_op(Operation::Push(Felt::from(u64::MAX / 2))).unwrap();
@@ -474,7 +480,7 @@ mod tests {
         // check memory state
         let mem_0 = [element, ZERO, ZERO, ZERO];
         assert_eq!(1, process.chiplets.get_mem_size());
-        assert_eq!(mem_0, process.chiplets.get_mem_value(0, 0).unwrap());
+        assert_eq!(mem_0, process.chiplets.get_mem_value(MemoryContextId::root(), 0).unwrap());
 
         // push the word onto the stack and save it at address 2
         let word_2 = [1, 3, 5, 7].to_elements().try_into().unwrap();
@@ -491,7 +497,7 @@ mod tests {
         // check memory state to make sure the other 3 elements were not affected
         let mem_2 = [element, Felt::new(3), Felt::new(5), Felt::new(7)];
         assert_eq!(2, process.chiplets.get_mem_size());
-        assert_eq!(mem_2, process.chiplets.get_mem_value(0, 2).unwrap());
+        assert_eq!(mem_2, process.chiplets.get_mem_value(MemoryContextId::root(), 2).unwrap());
 
         // --- calling MSTORE with address greater than u32::MAX leads to an error ----------------
         process.execute_op(Operation::Push(Felt::from(u64::MAX / 2))).unwrap();
@@ -538,8 +544,14 @@ mod tests {
 
         // check memory state contains the words from the advice stack
         assert_eq!(2, process.chiplets.get_mem_size());
-        assert_eq!(word1_felts, process.chiplets.get_mem_value(0, 1).unwrap());
-        assert_eq!(word2_felts, process.chiplets.get_mem_value(0, 2).unwrap());
+        assert_eq!(
+            word1_felts,
+            process.chiplets.get_mem_value(MemoryContextId::root(), 1).unwrap()
+        );
+        assert_eq!(
+            word2_felts,
+            process.chiplets.get_mem_value(MemoryContextId::root(), 2).unwrap()
+        );
 
         // the first 8 values should be the values from the advice stack. the next 4 values should
         // remain unchanged, and the address should be incremented by 2 (i.e., 1 -> 3).

--- a/processor/src/system/mod.rs
+++ b/processor/src/system/mod.rs
@@ -1,7 +1,6 @@
 use super::{
     ExecutionError, Felt, FieldElement, StarkField, SysTrace, Vec, Word, EMPTY_WORD, ONE, ZERO,
 };
-
 use core::fmt::{self, Display};
 
 #[cfg(test)]

--- a/processor/src/system/mod.rs
+++ b/processor/src/system/mod.rs
@@ -2,10 +2,7 @@ use super::{
     ExecutionError, Felt, FieldElement, StarkField, SysTrace, Vec, Word, EMPTY_WORD, ONE, ZERO,
 };
 
-use core::{
-    fmt::{self, Display},
-    ops::Sub,
-};
+use core::fmt::{self, Display};
 
 #[cfg(test)]
 mod tests;
@@ -342,14 +339,6 @@ impl From<ContextId> for u64 {
 impl From<ContextId> for Felt {
     fn from(context_id: ContextId) -> Self {
         u64::from(context_id).into()
-    }
-}
-
-impl Sub for ContextId {
-    type Output = u32;
-
-    fn sub(self, rhs: Self) -> Self::Output {
-        self.0 - rhs.0
     }
 }
 

--- a/processor/src/system/mod.rs
+++ b/processor/src/system/mod.rs
@@ -305,6 +305,7 @@ impl System {
 // MEMORY CONTEXT
 // ================================================================================================
 
+/// Represents the ID of a memory context
 #[derive(Clone, Copy, Debug, Default, Eq, Ord, PartialEq, PartialOrd)]
 pub struct ContextId(u32);
 

--- a/processor/src/system/mod.rs
+++ b/processor/src/system/mod.rs
@@ -1,4 +1,4 @@
-use crate::chiplets::MemoryContextId;
+use crate::chiplets::ContextId;
 
 use super::{
     ExecutionError, Felt, FieldElement, StarkField, SysTrace, Vec, Word, EMPTY_WORD, ONE, ZERO,
@@ -41,7 +41,7 @@ pub const FMP_MAX: u64 = 3 * 2_u64.pow(30) - 1;
 ///   initiated from the root context, this will be set to ZEROs.
 pub struct System {
     clk: u32,
-    ctx: MemoryContextId,
+    ctx: ContextId,
     fmp: Felt,
     in_syscall: bool,
     fn_hash: Word,
@@ -66,7 +66,7 @@ impl System {
 
         Self {
             clk: 0,
-            ctx: MemoryContextId::root(),
+            ctx: ContextId::root(),
             fmp,
             in_syscall: false,
             fn_hash: EMPTY_WORD,
@@ -94,7 +94,7 @@ impl System {
 
     /// Returns the current execution context ID.
     #[inline(always)]
-    pub fn ctx(&self) -> MemoryContextId {
+    pub fn ctx(&self) -> ContextId {
         self.ctx
     }
 
@@ -125,7 +125,7 @@ impl System {
 
     /// Returns execution context ID at the specified clock cycle.
     #[inline(always)]
-    pub fn get_ctx_at(&self, clk: u32) -> MemoryContextId {
+    pub fn get_ctx_at(&self, clk: u32) -> ContextId {
         (self.ctx_trace[clk as usize].as_int() as u32).into()
     }
 
@@ -210,7 +210,7 @@ impl System {
     ///
     /// Note that we set in_syscall flag to true regardless of whether we return from a CALL or a
     /// SYSCALL.
-    pub fn restore_context(&mut self, ctx: MemoryContextId, fmp: Felt, fn_hash: Word) {
+    pub fn restore_context(&mut self, ctx: ContextId, fmp: Felt, fn_hash: Word) {
         self.ctx = ctx;
         self.fmp = fmp;
         self.in_syscall = false;

--- a/processor/src/system/mod.rs
+++ b/processor/src/system/mod.rs
@@ -1,8 +1,8 @@
-use crate::chiplets::ContextId;
-
 use super::{
     ExecutionError, Felt, FieldElement, StarkField, SysTrace, Vec, Word, EMPTY_WORD, ONE, ZERO,
 };
+
+use derive_more::{Add, AddAssign, Display, From, Into, Sub, SubAssign};
 
 #[cfg(test)]
 mod tests;
@@ -296,5 +296,51 @@ impl System {
                 column.resize(new_length, ZERO);
             }
         }
+    }
+}
+
+// MEMORY CONTEXT
+// ================================================================================================
+
+#[derive(
+    Add,
+    AddAssign,
+    Clone,
+    Copy,
+    Debug,
+    Default,
+    Display,
+    Eq,
+    From,
+    Into,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    Sub,
+    SubAssign,
+)]
+pub struct ContextId(u32);
+
+impl ContextId {
+    /// Returns the root context ID
+    pub fn root() -> Self {
+        Self(0)
+    }
+
+    /// Returns true if the context ID represents the root context
+    pub fn is_root(&self) -> bool {
+        self.0 == 0
+    }
+}
+
+impl From<ContextId> for u64 {
+    fn from(context_id: ContextId) -> Self {
+        context_id.0.into()
+    }
+}
+
+impl From<ContextId> for Felt {
+    fn from(context_id: ContextId) -> Self {
+        u64::from(context_id).into()
     }
 }

--- a/processor/src/system/mod.rs
+++ b/processor/src/system/mod.rs
@@ -299,7 +299,7 @@ impl System {
     }
 }
 
-// MEMORY CONTEXT
+// EXECUTION CONTEXT
 // ================================================================================================
 
 /// Represents the ID of a memory context

--- a/processor/src/system/mod.rs
+++ b/processor/src/system/mod.rs
@@ -199,7 +199,7 @@ impl System {
     /// for SYSCALLs this remains set to the hash of the last invoked function.
     pub fn start_syscall(&mut self) {
         debug_assert!(!self.in_syscall, "already in syscall");
-        self.ctx = 0.into();
+        self.ctx = ContextId::root();
         self.fmp = Felt::from(SYSCALL_FMP_MIN);
         self.in_syscall = true;
     }

--- a/processor/src/system/mod.rs
+++ b/processor/src/system/mod.rs
@@ -2,7 +2,10 @@ use super::{
     ExecutionError, Felt, FieldElement, StarkField, SysTrace, Vec, Word, EMPTY_WORD, ONE, ZERO,
 };
 
-use derive_more::{Add, AddAssign, Display, From, Into, Sub, SubAssign};
+use core::{
+    fmt::{self, Display},
+    ops::Sub,
+};
 
 #[cfg(test)]
 mod tests;
@@ -302,23 +305,7 @@ impl System {
 // MEMORY CONTEXT
 // ================================================================================================
 
-#[derive(
-    Add,
-    AddAssign,
-    Clone,
-    Copy,
-    Debug,
-    Default,
-    Display,
-    Eq,
-    From,
-    Into,
-    Ord,
-    PartialEq,
-    PartialOrd,
-    Sub,
-    SubAssign,
-)]
+#[derive(Clone, Copy, Debug, Default, Eq, Ord, PartialEq, PartialOrd)]
 pub struct ContextId(u32);
 
 impl ContextId {
@@ -333,6 +320,18 @@ impl ContextId {
     }
 }
 
+impl From<u32> for ContextId {
+    fn from(value: u32) -> Self {
+        Self(value)
+    }
+}
+
+impl From<ContextId> for u32 {
+    fn from(value: ContextId) -> Self {
+        value.0
+    }
+}
+
 impl From<ContextId> for u64 {
     fn from(context_id: ContextId) -> Self {
         context_id.0.into()
@@ -342,5 +341,19 @@ impl From<ContextId> for u64 {
 impl From<ContextId> for Felt {
     fn from(context_id: ContextId) -> Self {
         u64::from(context_id).into()
+    }
+}
+
+impl Sub for ContextId {
+    type Output = u32;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        self.0 - rhs.0
+    }
+}
+
+impl Display for ContextId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
     }
 }

--- a/processor/src/system/mod.rs
+++ b/processor/src/system/mod.rs
@@ -301,7 +301,7 @@ impl System {
 // EXECUTION CONTEXT
 // ================================================================================================
 
-/// Represents the ID of a memory context
+/// Represents the ID of an execution context
 #[derive(Clone, Copy, Debug, Default, Eq, Ord, PartialEq, PartialOrd)]
 pub struct ContextId(u32);
 

--- a/stdlib/tests/mem/mod.rs
+++ b/stdlib/tests/mem/mod.rs
@@ -1,4 +1,4 @@
-use processor::{DefaultHost, ContextId, ProcessState};
+use processor::{ContextId, DefaultHost, ProcessState};
 use test_utils::{
     build_expected_hash, build_expected_perm, stack_to_ints, ExecutionOptions, Process,
     StackInputs, ONE, ZERO,

--- a/stdlib/tests/mem/mod.rs
+++ b/stdlib/tests/mem/mod.rs
@@ -1,4 +1,4 @@
-use processor::{DefaultHost, ProcessState};
+use processor::{DefaultHost, MemoryContextId, ProcessState};
 use test_utils::{
     build_expected_hash, build_expected_perm, stack_to_ints, ExecutionOptions, Process,
     StackInputs, ONE, ZERO,
@@ -36,17 +36,57 @@ fn test_memcopy() {
     );
     process.execute(&program).unwrap();
 
-    assert_eq!(process.get_mem_value(0, 1000), Some([ZERO, ZERO, ZERO, ONE]), "Address 1000");
-    assert_eq!(process.get_mem_value(0, 1001), Some([ZERO, ZERO, ONE, ZERO]), "Address 1001");
-    assert_eq!(process.get_mem_value(0, 1002), Some([ZERO, ZERO, ONE, ONE]), "Address 1002");
-    assert_eq!(process.get_mem_value(0, 1003), Some([ZERO, ONE, ZERO, ZERO]), "Address 1003");
-    assert_eq!(process.get_mem_value(0, 1004), Some([ZERO, ONE, ZERO, ONE]), "Address 1004");
+    assert_eq!(
+        process.get_mem_value(MemoryContextId::root(), 1000),
+        Some([ZERO, ZERO, ZERO, ONE]),
+        "Address 1000"
+    );
+    assert_eq!(
+        process.get_mem_value(MemoryContextId::root(), 1001),
+        Some([ZERO, ZERO, ONE, ZERO]),
+        "Address 1001"
+    );
+    assert_eq!(
+        process.get_mem_value(MemoryContextId::root(), 1002),
+        Some([ZERO, ZERO, ONE, ONE]),
+        "Address 1002"
+    );
+    assert_eq!(
+        process.get_mem_value(MemoryContextId::root(), 1003),
+        Some([ZERO, ONE, ZERO, ZERO]),
+        "Address 1003"
+    );
+    assert_eq!(
+        process.get_mem_value(MemoryContextId::root(), 1004),
+        Some([ZERO, ONE, ZERO, ONE]),
+        "Address 1004"
+    );
 
-    assert_eq!(process.get_mem_value(0, 2000), Some([ZERO, ZERO, ZERO, ONE]), "Address 2000");
-    assert_eq!(process.get_mem_value(0, 2001), Some([ZERO, ZERO, ONE, ZERO]), "Address 2001");
-    assert_eq!(process.get_mem_value(0, 2002), Some([ZERO, ZERO, ONE, ONE]), "Address 2002");
-    assert_eq!(process.get_mem_value(0, 2003), Some([ZERO, ONE, ZERO, ZERO]), "Address 2003");
-    assert_eq!(process.get_mem_value(0, 2004), Some([ZERO, ONE, ZERO, ONE]), "Address 2004");
+    assert_eq!(
+        process.get_mem_value(MemoryContextId::root(), 2000),
+        Some([ZERO, ZERO, ZERO, ONE]),
+        "Address 2000"
+    );
+    assert_eq!(
+        process.get_mem_value(MemoryContextId::root(), 2001),
+        Some([ZERO, ZERO, ONE, ZERO]),
+        "Address 2001"
+    );
+    assert_eq!(
+        process.get_mem_value(MemoryContextId::root(), 2002),
+        Some([ZERO, ZERO, ONE, ONE]),
+        "Address 2002"
+    );
+    assert_eq!(
+        process.get_mem_value(MemoryContextId::root(), 2003),
+        Some([ZERO, ONE, ZERO, ZERO]),
+        "Address 2003"
+    );
+    assert_eq!(
+        process.get_mem_value(MemoryContextId::root(), 2004),
+        Some([ZERO, ONE, ZERO, ONE]),
+        "Address 2004"
+    );
 }
 
 #[test]

--- a/stdlib/tests/mem/mod.rs
+++ b/stdlib/tests/mem/mod.rs
@@ -1,4 +1,4 @@
-use processor::{DefaultHost, MemoryContextId, ProcessState};
+use processor::{DefaultHost, ContextId, ProcessState};
 use test_utils::{
     build_expected_hash, build_expected_perm, stack_to_ints, ExecutionOptions, Process,
     StackInputs, ONE, ZERO,
@@ -37,53 +37,53 @@ fn test_memcopy() {
     process.execute(&program).unwrap();
 
     assert_eq!(
-        process.get_mem_value(MemoryContextId::root(), 1000),
+        process.get_mem_value(ContextId::root(), 1000),
         Some([ZERO, ZERO, ZERO, ONE]),
         "Address 1000"
     );
     assert_eq!(
-        process.get_mem_value(MemoryContextId::root(), 1001),
+        process.get_mem_value(ContextId::root(), 1001),
         Some([ZERO, ZERO, ONE, ZERO]),
         "Address 1001"
     );
     assert_eq!(
-        process.get_mem_value(MemoryContextId::root(), 1002),
+        process.get_mem_value(ContextId::root(), 1002),
         Some([ZERO, ZERO, ONE, ONE]),
         "Address 1002"
     );
     assert_eq!(
-        process.get_mem_value(MemoryContextId::root(), 1003),
+        process.get_mem_value(ContextId::root(), 1003),
         Some([ZERO, ONE, ZERO, ZERO]),
         "Address 1003"
     );
     assert_eq!(
-        process.get_mem_value(MemoryContextId::root(), 1004),
+        process.get_mem_value(ContextId::root(), 1004),
         Some([ZERO, ONE, ZERO, ONE]),
         "Address 1004"
     );
 
     assert_eq!(
-        process.get_mem_value(MemoryContextId::root(), 2000),
+        process.get_mem_value(ContextId::root(), 2000),
         Some([ZERO, ZERO, ZERO, ONE]),
         "Address 2000"
     );
     assert_eq!(
-        process.get_mem_value(MemoryContextId::root(), 2001),
+        process.get_mem_value(ContextId::root(), 2001),
         Some([ZERO, ZERO, ONE, ZERO]),
         "Address 2001"
     );
     assert_eq!(
-        process.get_mem_value(MemoryContextId::root(), 2002),
+        process.get_mem_value(ContextId::root(), 2002),
         Some([ZERO, ZERO, ONE, ONE]),
         "Address 2002"
     );
     assert_eq!(
-        process.get_mem_value(MemoryContextId::root(), 2003),
+        process.get_mem_value(ContextId::root(), 2003),
         Some([ZERO, ONE, ZERO, ZERO]),
         "Address 2003"
     );
     assert_eq!(
-        process.get_mem_value(MemoryContextId::root(), 2004),
+        process.get_mem_value(ContextId::root(), 2004),
         Some([ZERO, ONE, ZERO, ONE]),
         "Address 2004"
     );

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -20,7 +20,7 @@ pub use vm_core::chiplets::hasher::{hash_elements, STATE_WIDTH};
 pub use assembly::{Library, MaslLibrary};
 pub use processor::{
     AdviceInputs, AdviceProvider, DefaultHost, ExecutionError, ExecutionOptions, ExecutionTrace,
-    Process, ProcessState, StackInputs, VmStateIterator,
+    MemoryContextId, Process, ProcessState, StackInputs, VmStateIterator,
 };
 pub use prover::{prove, MemAdviceProvider, ProvingOptions};
 pub use test_case::test_case;
@@ -175,7 +175,9 @@ impl Test {
         // validate the memory state
         for data in expected_mem.chunks(WORD_SIZE) {
             // Main memory is zeroed by default, use zeros as a fallback when unwrap to make testing easier
-            let mem_state = process.get_mem_value(0, mem_start_addr).unwrap_or(EMPTY_WORD);
+            let mem_state = process
+                .get_mem_value(MemoryContextId::root(), mem_start_addr)
+                .unwrap_or(EMPTY_WORD);
 
             let mem_state = stack_to_ints(&mem_state);
             assert_eq!(

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -19,8 +19,8 @@ pub use vm_core::chiplets::hasher::{hash_elements, STATE_WIDTH};
 
 pub use assembly::{Library, MaslLibrary};
 pub use processor::{
-    AdviceInputs, AdviceProvider, DefaultHost, ExecutionError, ExecutionOptions, ExecutionTrace,
-    ContextId, Process, ProcessState, StackInputs, VmStateIterator,
+    AdviceInputs, AdviceProvider, ContextId, DefaultHost, ExecutionError, ExecutionOptions,
+    ExecutionTrace, Process, ProcessState, StackInputs, VmStateIterator,
 };
 pub use prover::{prove, MemAdviceProvider, ProvingOptions};
 pub use test_case::test_case;
@@ -175,9 +175,8 @@ impl Test {
         // validate the memory state
         for data in expected_mem.chunks(WORD_SIZE) {
             // Main memory is zeroed by default, use zeros as a fallback when unwrap to make testing easier
-            let mem_state = process
-                .get_mem_value(ContextId::root(), mem_start_addr)
-                .unwrap_or(EMPTY_WORD);
+            let mem_state =
+                process.get_mem_value(ContextId::root(), mem_start_addr).unwrap_or(EMPTY_WORD);
 
             let mem_state = stack_to_ints(&mem_state);
             assert_eq!(

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -20,7 +20,7 @@ pub use vm_core::chiplets::hasher::{hash_elements, STATE_WIDTH};
 pub use assembly::{Library, MaslLibrary};
 pub use processor::{
     AdviceInputs, AdviceProvider, DefaultHost, ExecutionError, ExecutionOptions, ExecutionTrace,
-    MemoryContextId, Process, ProcessState, StackInputs, VmStateIterator,
+    ContextId, Process, ProcessState, StackInputs, VmStateIterator,
 };
 pub use prover::{prove, MemAdviceProvider, ProvingOptions};
 pub use test_case::test_case;
@@ -176,7 +176,7 @@ impl Test {
         for data in expected_mem.chunks(WORD_SIZE) {
             // Main memory is zeroed by default, use zeros as a fallback when unwrap to make testing easier
             let mem_state = process
-                .get_mem_value(MemoryContextId::root(), mem_start_addr)
+                .get_mem_value(ContextId::root(), mem_start_addr)
                 .unwrap_or(EMPTY_WORD);
 
             let mem_state = stack_to_ints(&mem_state);


### PR DESCRIPTION
Creates the `ContextId` type instead of using `u32` everywhere. This makes the code easier to understand to a newcomer; e.g. types such as `(u32, u32, u32)` make understanding the code harder. And this newtype will also prevent bugs which e.g. use the context ID as an address (who's also a `u32`).

I suggest we also introduce a newtype for memory `Address`.