### PR TITLE
Add support for Miden Standard Library in REPL

### DIFF
--- a/miden/src/repl/mod.rs
+++ b/miden/src/repl/mod.rs
@@ -328,9 +328,7 @@ fn print_instructions() {
     println!("!mem[i]: displays the state of the memory at address i");
     println!("!undo: remove the last instruction");
     println!("!program: display the program");
-    println!(
-        "!use: displays a list of modules/imports a specified module from Miden Standard Library"
-    );
+    println!("!use: displays a list of modules/imports a specified module from Miden Standard Library");
     println!("!help: prints out all the available commands");
     println!();
 }
@@ -354,7 +352,7 @@ fn use_module() {
     println!("std::math::u256");
     println!("std::math::u64");
     println!("std::math::secp256k1");
-    println!();
+    println!("");
     println!("How it works:");
     println!("!use std::math::u64");
 }

--- a/miden/src/repl/mod.rs
+++ b/miden/src/repl/mod.rs
@@ -328,6 +328,9 @@ fn print_instructions() {
     println!("!mem[i]: displays the state of the memory at address i");
     println!("!undo: remove the last instruction");
     println!("!program: display the program");
+    println!(
+        "!use: displays a list of modules/imports a specified module from Miden Standard Library"
+    );
     println!("!help: prints out all the available commands");
     println!();
 }


### PR DESCRIPTION
**Related**: [Support stdlib (use.std::math::u64 etc) in miden repl #930](https://github.com/0xPolygonMiden/miden-vm/issues/930)

In this PR, I tried to implement what's discussed in the above issue.
i.e,
Added a new option in the REPL for modules in the Miden Standard Library:
`!use: displays a list of modules/imports a specified module from Miden Standard Library`

^Here, the user has option to either directly provide name of the module that they want to use or to get a list of available modules from which they can choose:
```
>> !use
Modules available for importing:

std::math::u256
std::math::u64
std::math::secp256k1

How it works:
!use std::math::u64
```
And it works(almost) as expected in #930; below is the demo of an example from the Miden playground that uses standard library:
```
>> push.0.1
1 0 0 3 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
>> push.3.1
1 3 1 0 0 3 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
>> exec.u64::checked_add
2 3 0 3 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
```
I worked on this PR as part of adding support for procedures and multi-line input which are discussed in #930 and #637 but wanted to hear feedback on this approach/implementation before going for all of them at once so that it will be easy to track.