### PR TITLE
Support constants in MASM `repeat` loops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Expanded capabilities of the `debug` decorator. Added `debug.mem` and `debug.local` variations (#1103).
 - Introduced the `emit.<event_id>` assembly instruction (#1119).
 - Introduced the `procref.<proc_name>` assembly instruction (#1113).
+- Added the ability to use constants as counters in `repeat` loops (#1124). 
 
 #### Stdlib
 - Introduced `std::utils` module with `is_empty_word` procedure.  Refactored `std::collections::smt`

--- a/assembly/src/ast/mod.rs
+++ b/assembly/src/ast/mod.rs
@@ -35,7 +35,9 @@ pub use invocation_target::InvocationTarget;
 mod parsers;
 use parsers::{parse_constants, ParserContext};
 
-pub(crate) use parsers::{NAMESPACE_LABEL_PARSER, PROCEDURE_LABEL_PARSER};
+pub(crate) use parsers::{
+    parse_param_with_constant_lookup, NAMESPACE_LABEL_PARSER, PROCEDURE_LABEL_PARSER,
+};
 
 mod serde;
 pub use serde::AstSerdeOptions;

--- a/assembly/src/ast/parsers/context.rs
+++ b/assembly/src/ast/parsers/context.rs
@@ -133,7 +133,7 @@ impl ParserContext<'_> {
         // record start of the repeat block and consume the 'repeat' token
         let repeat_start = tokens.pos();
         let repeat_token = tokens.read().expect("no repeat token");
-        let times = repeat_token.parse_repeat()?;
+        let times = repeat_token.parse_repeat(&self.local_constants)?;
         tokens.advance();
 
         // read the loop body

--- a/assembly/src/ast/parsers/mod.rs
+++ b/assembly/src/ast/parsers/mod.rs
@@ -122,7 +122,7 @@ fn parse_const_value(
 
 /// Parses a param from the op token with the specified type and index. If the param is a constant
 /// label, it will be looked up in the provided constant map.
-fn parse_param_with_constant_lookup<R>(
+pub(crate) fn parse_param_with_constant_lookup<R>(
     op: &Token,
     param_idx: usize,
     constants: &LocalConstMap,

--- a/assembly/src/ast/tests.rs
+++ b/assembly/src/ast/tests.rs
@@ -951,6 +951,25 @@ fn test_ast_module_serde_imports_not_serialized() {
     assert_correct_module_serialization(source, false);
 }
 
+#[test]
+fn test_repeat_with_constant_count() {
+    let source = "\
+    const.A=3
+    const.B=A*3+5
+
+    begin
+        repeat.A
+            push.1
+            push.0.1
+        end
+
+        repeat.B
+            push.0
+        end
+    end";
+    assert_correct_program_serialization(source, false);
+}
+
 fn assert_program_output(source: &str, procedures: LocalProcMap, body: Vec<Node>) {
     let program = ProgramAst::parse(source).unwrap();
     assert_eq!(program.body.nodes(), body);

--- a/assembly/src/ast/tests.rs
+++ b/assembly/src/ast/tests.rs
@@ -960,14 +960,27 @@ fn test_repeat_with_constant_count() {
     begin
         repeat.A
             push.1
-            push.0.1
         end
 
         repeat.B
             push.0
         end
     end";
+
     assert_correct_program_serialization(source, false);
+
+    let nodes: Vec<Node> = vec![
+        Node::Repeat {
+            times: 3,
+            body: CodeBody::new(vec![Node::Instruction(Instruction::PushU8(1))]),
+        },
+        Node::Repeat {
+            times: 14,
+            body: CodeBody::new(vec![Node::Instruction(Instruction::PushU8(0))]),
+        },
+    ];
+
+    assert_program_output(source, BTreeMap::new(), nodes);
 }
 
 fn assert_program_output(source: &str, procedures: LocalProcMap, body: Vec<Node>) {

--- a/assembly/src/tests.rs
+++ b/assembly/src/tests.rs
@@ -1673,7 +1673,7 @@ fn invalid_repeat() {
     if let Err(error) = program {
         assert_eq!(
             error.to_string(),
-            "malformed constant `repeat.23x3` - invalid value: `23x3` - reason: constant with name 23x3 was not initialized"
+            "malformed instruction `repeat.23x3`: parameter '23x3' is invalid"
         );
     }
 }

--- a/assembly/src/tests.rs
+++ b/assembly/src/tests.rs
@@ -1673,7 +1673,7 @@ fn invalid_repeat() {
     if let Err(error) = program {
         assert_eq!(
             error.to_string(),
-            "malformed instruction `repeat.23x3`: parameter '23x3' is invalid"
+            "malformed constant `repeat.23x3` - invalid value: `23x3` - reason: constant with name 23x3 was not initialized"
         );
     }
 }

--- a/docs/src/user_docs/assembly/flow_control.md
+++ b/docs/src/user_docs/assembly/flow_control.md
@@ -33,7 +33,7 @@ end
 where:
 
 * `instructions` can be a sequence of any instructions, including nested control structures.
-* `count` is the number of times the `instructions` sequence should be repeated (e.g. `repeat.10`). `count` must be an integer or a constant greater than $0$.
+* `count` is the number of times the `instructions` sequence should be repeated (e.g. `repeat.10`). `count` must be an integer or a [constant](./code_organization.md#constants) greater than $0$.
 
 > **Note**: During compilation the `repeat.<count>` blocks are unrolled and expanded into `<count>` copies of its inner block, there is no additional cost for counting variables in this case.
 

--- a/docs/src/user_docs/assembly/flow_control.md
+++ b/docs/src/user_docs/assembly/flow_control.md
@@ -33,7 +33,7 @@ end
 where:
 
 * `instructions` can be a sequence of any instructions, including nested control structures.
-* `count` is the number of times the `instructions` sequence should be repeated (e.g. `repeat.10`). `count` must be an integer greater than $0$.
+* `count` is the number of times the `instructions` sequence should be repeated (e.g. `repeat.10`). `count` must be an integer or a constant greater than $0$.
 
 > **Note**: During compilation the `repeat.<count>` blocks are unrolled and expanded into `<count>` copies of its inner block, there is no additional cost for counting variables in this case.
 


### PR DESCRIPTION
This small PR adds support for constants used as counters in repeat loops.
For example:
```
const.A=3

begin 
    repeat.A
        push.1
    end
end
```