### PR TITLE
Make u32 shift and rotation instructions always checked

### DIFF
--- a/assembly/src/assembler/instruction/u32_ops.rs
+++ b/assembly/src/assembler/instruction/u32_ops.rs
@@ -197,8 +197,8 @@ pub fn u32not(span: &mut SpanBuilder) -> Result<Option<CodeBlock>, AssemblyError
 /// the value to be shifted and splitting the result.
 ///
 /// VM cycles per mode:
-/// - u32shl: 18 cycles
-/// - u32shl.b: 3 cycles
+/// - u32shl: 19 cycles
+/// - u32shl.b: 4 cycles
 pub fn u32shl(span: &mut SpanBuilder, imm: Option<u8>) -> Result<Option<CodeBlock>, AssemblyError> {
     prepare_bitwise::<MAX_U32_SHIFT_VALUE>(span, imm)?;
     if imm != Some(0) {
@@ -214,8 +214,8 @@ pub fn u32shl(span: &mut SpanBuilder, imm: Option<u8>) -> Result<Option<CodeBloc
 /// be shifted by it and returning the quotient.
 ///
 /// VM cycles per mode:
-/// - u32shr: 18 cycles
-/// - u32shr.b: 3 cycles
+/// - u32shr: 19 cycles
+/// - u32shr.b: 4 cycles
 pub fn u32shr(span: &mut SpanBuilder, imm: Option<u8>) -> Result<Option<CodeBlock>, AssemblyError> {
     prepare_bitwise::<MAX_U32_SHIFT_VALUE>(span, imm)?;
     if imm != Some(0) {
@@ -231,8 +231,8 @@ pub fn u32shr(span: &mut SpanBuilder, imm: Option<u8>) -> Result<Option<CodeBloc
 /// value to be shifted by it and adding the overflow limb to the shifted limb.
 ///
 /// VM cycles per mode:
-/// - u32rotl: 18 cycles
-/// - u32rotl.b: 3 cycles
+/// - u32rotl: 19 cycles
+/// - u32rotl.b: 4 cycles
 pub fn u32rotl(
     span: &mut SpanBuilder,
     imm: Option<u8>,
@@ -251,8 +251,8 @@ pub fn u32rotl(
 /// b is the shift amount, then adding the overflow limb to the shifted limb.
 ///
 /// VM cycles per mode:
-/// - u32rotr: 22 cycles
-/// - u32rotr.b: 3 cycles
+/// - u32rotr: 31 cycles
+/// - u32rotr.b: 4 cycles
 pub fn u32rotr(
     span: &mut SpanBuilder,
     imm: Option<u8>,

--- a/docs/src/user_docs/assembly/u32_operations.md
+++ b/docs/src/user_docs/assembly/u32_operations.md
@@ -50,10 +50,10 @@ If the error code is omitted, the default value of $0$ is assumed.
 | u32or <br> - *(6 cycle)s*                                                     | [b, a, ...]    | [c, ...]      | Computes $c$ as a bitwise `OR` of binary representations of $a$ and $b$. <br> Fails if $max(a,b) \ge 2^{32}$                   |
 | u32xor <br> - *(1 cycle)*                                                     | [b, a, ...]    | [c, ...]      | Computes $c$ as a bitwise `XOR` of binary representations of $a$ and $b$. <br> Fails if $max(a,b) \ge 2^{32}$                  |
 | u32not <br> - *(5 cycles)*                                                    | [a, ...]       | [b, ...]      | Computes $b$ as a bitwise `NOT` of binary representation of $a$. <br> Fails if $a \ge 2^{32}$                                  |
-| u32shl <br> - *(40 cycles)* <br> u32shl.*b* <br> - *(3 cycles)*   | [b, a, ...]    | [c, ...]      | $c \leftarrow (a \cdot 2^b) \mod 2^{32}$ <br> Undefined if $a \ge 2^{32}$ or $b > 31$                                          |
-| u32shr <br> - *(40 cycles)* <br> u32shr.*b* <br> - *(3 cycles)*   | [b, a, ...]    | [c, ...]      | $c \leftarrow \lfloor a/2^b \rfloor$ <br> Undefined if $a \ge 2^{32}$ or $b > 31$                                              |
-| u32rotl <br> - *(40 cycles)* <br> u32rotl.*b* <br> - *(3 cycles)* | [b, a, ...]    | [c, ...]      | Computes $c$ by rotating a 32-bit representation of $a$ to the left by $b$ bits. <br> Undefined if $a \ge 2^{32}$ or $b > 31$  |
-| u32rotr <br> - *(44 cycles)* <br> u32rotr.*b* <br> - *(3 cycles)* | [b, a, ...]    | [c, ...]      | Computes $c$ by rotating a 32-bit representation of $a$ to the right by $b$ bits. <br> Undefined if $a \ge 2^{32}$ or $b > 31$ |
+| u32shl <br> - *(47 cycles)* <br> u32shl.*b* <br> - *(4 cycles)*   | [b, a, ...] | [c, ...] | $c \leftarrow (a \cdot 2^b) \mod 2^{32}$ <br> Fails if $a \ge 2^{32}$ or $b > 31$                                          |
+| u32shr <br> - *(47 cycles)*<br> u32shr.*b* <br> - *(4 cycles)* | [b, a, ...] | [c, ...] | $c \leftarrow \lfloor a/2^b \rfloor$ <br> Fails if $a \ge 2^{32}$ or $b > 31$ |
+| u32rotl <br> - *(47 cycles)* <br> u32rotl.*b* <br> - *(4 cycles)* | [b, a, ...] | [c, ...] | Computes $c$ by rotating a 32-bit representation of $a$ to the left by $b$ bits. <br> Fails if $a \ge 2^{32}$ or $b > 31$ |
+| u32rotr <br> - *(59 cycles)* <br> u32rotr.*b* <br> - *(6 cycles)* | [b, a, ...] | [c, ...] | Computes $c$ by rotating a 32-bit representation of $a$ to the right by $b$ bits. <br> Fails if $a \ge 2^{32}$ or $b > 31$ |
 | u32popcnt <br> - *(33 cycles)*                                              | [a, ...]       | [b, ...]      | Computes $b$ by counting the number of set bits in $a$ (hamming weight of $a$). <br> Undefined if $a \ge 2^{32}$               |
 
 ### Comparison operations

--- a/docs/src/user_docs/assembly/u32_operations.md
+++ b/docs/src/user_docs/assembly/u32_operations.md
@@ -50,10 +50,10 @@ If the error code is omitted, the default value of $0$ is assumed.
 | u32or <br> - *(6 cycle)s*                                                     | [b, a, ...]    | [c, ...]      | Computes $c$ as a bitwise `OR` of binary representations of $a$ and $b$. <br> Fails if $max(a,b) \ge 2^{32}$                   |
 | u32xor <br> - *(1 cycle)*                                                     | [b, a, ...]    | [c, ...]      | Computes $c$ as a bitwise `XOR` of binary representations of $a$ and $b$. <br> Fails if $max(a,b) \ge 2^{32}$                  |
 | u32not <br> - *(5 cycles)*                                                    | [a, ...]       | [b, ...]      | Computes $b$ as a bitwise `NOT` of binary representation of $a$. <br> Fails if $a \ge 2^{32}$                                  |
-| u32shl <br> - *(47 cycles)* <br> u32shl.*b* <br> - *(4 cycles)*   | [b, a, ...] | [c, ...] | $c \leftarrow (a \cdot 2^b) \mod 2^{32}$ <br> Fails if $a \ge 2^{32}$ or $b > 31$                                          |
-| u32shr <br> - *(47 cycles)*<br> u32shr.*b* <br> - *(4 cycles)* | [b, a, ...] | [c, ...] | $c \leftarrow \lfloor a/2^b \rfloor$ <br> Fails if $a \ge 2^{32}$ or $b > 31$ |
-| u32rotl <br> - *(47 cycles)* <br> u32rotl.*b* <br> - *(4 cycles)* | [b, a, ...] | [c, ...] | Computes $c$ by rotating a 32-bit representation of $a$ to the left by $b$ bits. <br> Fails if $a \ge 2^{32}$ or $b > 31$ |
-| u32rotr <br> - *(59 cycles)* <br> u32rotr.*b* <br> - *(6 cycles)* | [b, a, ...] | [c, ...] | Computes $c$ by rotating a 32-bit representation of $a$ to the right by $b$ bits. <br> Fails if $a \ge 2^{32}$ or $b > 31$ |
+| u32shl <br> - *(19 cycles)* <br> u32shl.*b* <br> - *(4 cycles)*   | [b, a, ...] | [c, ...] | $c \leftarrow (a \cdot 2^b) \mod 2^{32}$ <br> Fails if $a \ge 2^{32}$ or $b > 31$                                          |
+| u32shr <br> - *(19 cycles)*<br> u32shr.*b* <br> - *(4 cycles)* | [b, a, ...] | [c, ...] | $c \leftarrow \lfloor a/2^b \rfloor$ <br> Fails if $a \ge 2^{32}$ or $b > 31$ |
+| u32rotl <br> - *(19 cycles)* <br> u32rotl.*b* <br> - *(4 cycles)* | [b, a, ...] | [c, ...] | Computes $c$ by rotating a 32-bit representation of $a$ to the left by $b$ bits. <br> Fails if $a \ge 2^{32}$ or $b > 31$ |
+| u32rotr <br> - *(31 cycles)* <br> u32rotr.*b* <br> - *(4 cycles)* | [b, a, ...] | [c, ...] | Computes $c$ by rotating a 32-bit representation of $a$ to the right by $b$ bits. <br> Fails if $a \ge 2^{32}$ or $b > 31$ |
 | u32popcnt <br> - *(33 cycles)*                                              | [a, ...]       | [b, ...]      | Computes $b$ by counting the number of set bits in $a$ (hamming weight of $a$). <br> Undefined if $a \ge 2^{32}$               |
 
 ### Comparison operations

--- a/miden/tests/integration/operations/u32_ops/mod.rs
+++ b/miden/tests/integration/operations/u32_ops/mod.rs
@@ -30,6 +30,14 @@ pub fn test_inputs_out_of_bounds(asm_op: &str, input_count: usize) {
     }
 }
 
+/// This helper function tests a provided assembly operation which takes a single parameter
+/// to ensure that it fails when that parameter is over the maximum allowed value (out of bounds).
+pub fn test_param_out_of_bounds(asm_op_base: &str, gt_max_value: u64) {
+    let asm_op = format!("{asm_op_base}.{gt_max_value}");
+    let test = build_op_test!(&asm_op);
+    test.expect_error(TestError::AssemblyError("parameter"));
+}
+
 /// This helper function tests that when the given u32 assembly instruction is executed on
 /// out-of-bounds inputs it does not fail. Each input is tested independently.
 pub fn test_unchecked_execution(asm_op: &str, input_count: usize) {


### PR DESCRIPTION
This small PR changes a little bit `u32shl`, `u32shr`, `u32rotl` and `u32totr` instructions to make them always checked — input values are always validated to be a u32 and a value less than 32.
