### PR TITLE
Derive `PartialEq, Eq` for `ExecutionError`

### DIFF
--- a/assembly/src/ast/imports.rs
+++ b/assembly/src/ast/imports.rs
@@ -95,7 +95,9 @@ impl ModuleImports {
     /// Look up the actual procedure name and module path associated with the given [ProcedureId],
     /// if that procedure was imported and invoked in the current module.
     pub fn get_procedure_info(&self, id: &ProcedureId) -> Option<(&ProcedureName, &LibraryPath)> {
-        self.invoked_procs.get(id).map(|(name, path)| (name, path))
+        self.invoked_procs
+            .get(id)
+            .map(|invoked_proc| (&invoked_proc.0, &invoked_proc.1))
     }
 
     /// Look up the procedure name associated with the given [ProcedureId],

--- a/core/src/program/blocks/call_block.rs
+++ b/core/src/program/blocks/call_block.rs
@@ -14,7 +14,7 @@ use crate::utils::to_hex;
 /// > hash(fn_hash || padding, domain=SYSCALL_DOMAIN)  # when a syscall is used
 ///
 /// Where `fn_hash` is 4 field elements (256 bits), and `padding` is 4 ZERO elements (256 bits).
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Call {
     hash: Digest,
     fn_hash: Digest,

--- a/core/src/program/blocks/dyn_block.rs
+++ b/core/src/program/blocks/dyn_block.rs
@@ -24,7 +24,7 @@ const DYN_CONSTANT: Digest = Digest::new([
 /// affect the representation of the Dyn block. Therefore all Dyn blocks are represented by the same
 /// constant (rather than by unique hashes), which is computed as an RPO hash of two empty words
 /// ([ZERO, ZERO, ZERO, ZERO]) with a domain value of `DYN_DOMAIN`.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Dyn {}
 
 impl Dyn {

--- a/core/src/program/blocks/join_block.rs
+++ b/core/src/program/blocks/join_block.rs
@@ -11,7 +11,7 @@ use super::{fmt, hasher, Box, CodeBlock, Digest, Felt, Operation};
 /// > hash(left_block_hash || right_block_hash, domain=JOIN_DOMAIN)
 ///
 /// Where `left_block_hash` and `right_block_hash` are 4 field elements (256 bits) each.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Join {
     body: Box<[CodeBlock; 2]>,
     hash: Digest,

--- a/core/src/program/blocks/loop_block.rs
+++ b/core/src/program/blocks/loop_block.rs
@@ -12,7 +12,7 @@ use super::{fmt, hasher, Box, CodeBlock, Digest, Felt, Operation};
 /// > hash(body_hash || padding, domain=LOOP_DOMAIN)
 ///
 /// Where `body_hash` is 4 field elements (256 bits), and `padding` is 4 ZERO elements (256 bits).
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Loop {
     body: Box<CodeBlock>,
     hash: Digest,

--- a/core/src/program/blocks/mod.rs
+++ b/core/src/program/blocks/mod.rs
@@ -24,7 +24,7 @@ pub use split_block::Split;
 // PROGRAM BLOCK
 // ================================================================================================
 /// TODO: add comments
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum CodeBlock {
     Span(Span),
     Join(Join),

--- a/core/src/program/blocks/proxy_block.rs
+++ b/core/src/program/blocks/proxy_block.rs
@@ -8,7 +8,7 @@ use super::{fmt, Digest};
 /// of the program secret. Fails if executed.
 ///
 /// Hash of a proxy block is not computed but is rather defined at instantiation time.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Proxy {
     hash: Digest,
 }

--- a/core/src/program/blocks/span_block.rs
+++ b/core/src/program/blocks/span_block.rs
@@ -45,7 +45,7 @@ const MAX_OPS_PER_BATCH: usize = GROUP_SIZE * BATCH_SIZE;
 ///
 /// Where `batches` is the concatenation of each `batch` in the span, and each batch is 8 field
 /// elements (512 bits).
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Span {
     op_batches: Vec<OpBatch>,
     hash: Digest,
@@ -170,7 +170,7 @@ impl fmt::Display for Span {
 ///
 /// An operation batch consists of up to 8 operation groups, with each group containing up to 9
 /// operations or a single immediate value.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct OpBatch {
     ops: Vec<Operation>,
     groups: [Felt; BATCH_SIZE],

--- a/core/src/program/blocks/split_block.rs
+++ b/core/src/program/blocks/split_block.rs
@@ -12,7 +12,7 @@ use super::{fmt, hasher, Box, CodeBlock, Digest, Felt, Operation};
 /// > hash(true_branch_hash || false_branch_hash, domain=SPLIT_DOMAIN)
 ///
 /// Where `true_branch_hash` and `false_branch_hash` are 4 field elements (256 bits) each.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Split {
     branches: Box<[CodeBlock; 2]>,
     hash: Digest,

--- a/core/src/stack/inputs.rs
+++ b/core/src/stack/inputs.rs
@@ -29,14 +29,8 @@ impl StackInputs {
     where
         I: IntoIterator<Item = u64>,
     {
-        iter.into_iter()
-            .map(|v| {
-                Felt::try_from(v).map_err(|_| {
-                    InputError::NotFieldElement(v, "the provided value isn't a valid field element")
-                })
-            })
-            .collect::<Result<Vec<_>, _>>()
-            .map(Self::new)
+        let values: Vec<Felt> = iter.into_iter().map(Felt::from).collect();
+        Ok(Self::new(values))
     }
 
     // PUBLIC ACCESSORS

--- a/processor/src/errors.rs
+++ b/processor/src/errors.rs
@@ -16,7 +16,7 @@ use std::error::Error;
 // EXECUTION ERROR
 // ================================================================================================
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum ExecutionError {
     AdviceMapKeyNotFound(Word),
     AdviceMapValueInvalidLength(Word, usize, usize),
@@ -169,7 +169,7 @@ impl From<Ext2InttError> for ExecutionError {
 // EXT2INTT ERROR
 // ================================================================================================
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum Ext2InttError {
     DomainSizeNotPowerOf2(u64),
     DomainSizeTooSmall(u64),

--- a/processor/src/host/advice/inputs.rs
+++ b/processor/src/host/advice/inputs.rs
@@ -32,14 +32,7 @@ impl AdviceInputs {
     where
         I: IntoIterator<Item = u64>,
     {
-        let stack = iter
-            .into_iter()
-            .map(|v| {
-                Felt::try_from(v).map_err(|_| {
-                    InputError::NotFieldElement(v, "the provided value isn't a valid field element")
-                })
-            })
-            .collect::<Result<Vec<_>, _>>()?;
+        let stack = iter.into_iter().map(Felt::from);
         self.stack.extend(stack);
         Ok(self)
     }


### PR DESCRIPTION
This is helpful for tests. For example we can write a succinct

```rust
assert_eq!(result, Err(ExecutionError::Variant(vec![x,y,z])));
```

instead of 

```rust
match result {
  Ok(_) => panic!(""),
  Err(err) => match err {
    Variant(v) => assert_eq!(v, vec![x,y,z]),
    _ => panic!("")
  }
}
```