### PR TITLE
`StackOutputs`: introduce `pop_*()` methods

### DIFF
--- a/processor/src/trace/mod.rs
+++ b/processor/src/trace/mod.rs
@@ -117,6 +117,10 @@ impl ExecutionTrace {
         &self.stack_outputs
     }
 
+    pub fn stack_outputs_mut(&mut self) -> &mut StackOutputs {
+        &mut self.stack_outputs
+    }
+
     /// Returns the initial state of the top 16 stack registers.
     pub fn init_stack_state(&self) -> StackTopState {
         let mut result = [ZERO; STACK_TOP_SIZE];


### PR DESCRIPTION
This PR introduces methods to pop common types off `StackOutputs`.

The main benefits are:
1. We encode the logic that elements of a word are stored in reverse order in `pop_digest()`
2. Allows other crates to extend `StackOutputs` to pop their own types

For example, in `miden-base`, we should add:

```rust
pub trait StackOutputsPopHeader {
  fn pop_header(&mut self) -> Option<BlockHeader>;
}

impl StackOutputsPopHeader for StackOutputs {
  fn pop(&mut self) -> Option<BlockHeader> {
    let prev_hash = self.pop_felt();
    // ...
  }
}


// snippet
let block_header: BlockHeader = stack_outputs.pop_header()?;
```