### PR TITLE
Error code as int

### DIFF
--- a/miden/tests/integration/operations/sys_ops.rs
+++ b/miden/tests/integration/operations/sys_ops.rs
@@ -1,4 +1,4 @@
-use test_utils::{build_op_test, Felt, TestError};
+use test_utils::{build_op_test, TestError};
 
 // SYSTEM OPS ASSERTIONS - MANUAL TESTS
 // ================================================================================================
@@ -19,7 +19,7 @@ fn assert_with_code() {
     test.expect_stack(&[]);
 
     // triggered assertion captures both the VM cycle and error code
-    let expected_err = format!("FailedAssertion(1, BaseElement({}))", Felt::new(123).inner());
+    let expected_err = format!("FailedAssertion(1, 123)");
     let test = build_op_test!(asm_op, &[0]);
     test.expect_error(TestError::ExecutionError(&expected_err));
 }

--- a/processor/src/errors.rs
+++ b/processor/src/errors.rs
@@ -28,7 +28,7 @@ pub enum ExecutionError {
     DivideByZero(u32),
     EventError(String),
     Ext2InttError(Ext2InttError),
-    FailedAssertion(u32, Felt),
+    FailedAssertion(u32, u64),
     InvalidFmpValue(Felt, Felt),
     InvalidFriDomainSegment(u64),
     InvalidFriLayerFolding(QuadFelt, QuadFelt),

--- a/processor/src/operations/sys_ops.rs
+++ b/processor/src/operations/sys_ops.rs
@@ -19,7 +19,7 @@ where
     /// Returns an error if the popped value is not ONE.
     pub(super) fn op_assert(&mut self, err_code: Felt) -> Result<(), ExecutionError> {
         if self.stack.get(0) != ONE {
-            return Err(ExecutionError::FailedAssertion(self.system.clk(), err_code));
+            return Err(ExecutionError::FailedAssertion(self.system.clk(), err_code.as_int()));
         }
         self.stack.shift_left(1);
         Ok(())


### PR DESCRIPTION
This PR modifies changes the `FailedAssertion` enum from `FailedAssertion(u32, Felt)` to `FailedAssertion(u32, u64)` such that when it is raised the error code is presented as a u64.

closes: #1147 