### PR TITLE
`StackOutputs`: `get_stack_{item, word}()` methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 #### VM Internals
 - Introduced the `Event` decorator and an associated `on_event` handler on the `Host` trait (#1119).
 - Updated Winterfell dependency to v0.7 (#1121).
+- Added methods `StackOutputs::get_stack_item()` and `StackOutputs::get_stack_word()` (#1155).
 
 ## 0.7.0 (2023-10-11)
 

--- a/core/src/stack/outputs.rs
+++ b/core/src/stack/outputs.rs
@@ -93,7 +93,7 @@ impl StackOutputs {
         self.stack.get(idx).map(|&felt| felt.into())
     }
 
-    /// Returns the word located at the specified position on the stack
+    /// Returns the word located at the specified Felt position on the stack.
     pub fn get_stack_word(&self, idx: usize) -> Option<Word> {
         let word_elements: Word = {
             let word_elements: Vec<Felt> = range(idx, 4)

--- a/core/src/stack/outputs.rs
+++ b/core/src/stack/outputs.rs
@@ -84,6 +84,11 @@ impl StackOutputs {
     // PUBLIC ACCESSORS
     // --------------------------------------------------------------------------------------------
 
+    /// Returns the value located at the specified position on the stack
+    pub fn get_stack_item(&self, idx: usize) -> Option<Felt> {
+        self.stack.get(idx).map(|&felt| felt.into())
+    }
+
     /// Returns the stack outputs, which is state of the stack at the end of execution converted to
     /// integers.
     pub fn stack(&self) -> &[u64] {

--- a/core/src/stack/outputs.rs
+++ b/core/src/stack/outputs.rs
@@ -88,12 +88,15 @@ impl StackOutputs {
     // PUBLIC ACCESSORS
     // --------------------------------------------------------------------------------------------
 
-    /// Returns the element located at the specified position on the stack or `None` if out of bounds.
+    /// Returns the element located at the specified position on the stack or `None` if out of
+    /// bounds.
     pub fn get_stack_item(&self, idx: usize) -> Option<Felt> {
         self.stack.get(idx).map(|&felt| felt.into())
     }
 
-    /// Returns the word located at the specified Felt position on the stack or `None` if out of bounds.
+    /// Returns the word located starting at the specified Felt position on the stack or `None` if
+    /// out of bounds. For example, passing in `0` returns the word at the top of the stack, and
+    /// passing in `4` returns the word starting at element index `4`.
     pub fn get_stack_word(&self, idx: usize) -> Option<Word> {
         let word_elements: Word = {
             let word_elements: Vec<Felt> = range(idx, 4)

--- a/core/src/stack/outputs.rs
+++ b/core/src/stack/outputs.rs
@@ -88,7 +88,7 @@ impl StackOutputs {
     // PUBLIC ACCESSORS
     // --------------------------------------------------------------------------------------------
 
-    /// Returns the value located at the specified position on the stack or `None` if out of bounds.
+    /// Returns the element located at the specified position on the stack or `None` if out of bounds.
     pub fn get_stack_item(&self, idx: usize) -> Option<Felt> {
         self.stack.get(idx).map(|&felt| felt.into())
     }

--- a/core/src/stack/outputs.rs
+++ b/core/src/stack/outputs.rs
@@ -1,3 +1,7 @@
+use miden_crypto::Word;
+
+use crate::utils::range;
+
 use super::{
     ByteWriter, Felt, OutputError, Serializable, StackTopState, StarkField, ToElements, Vec,
     STACK_TOP_SIZE,
@@ -87,6 +91,22 @@ impl StackOutputs {
     /// Returns the value located at the specified position on the stack
     pub fn get_stack_item(&self, idx: usize) -> Option<Felt> {
         self.stack.get(idx).map(|&felt| felt.into())
+    }
+
+    /// Returns the word located at the specified position on the stack
+    pub fn get_stack_word(&self, idx: usize) -> Option<Word> {
+        let word_elements: Word = {
+            let word_elements: Vec<Felt> = range(idx, 4)
+                .map(|idx| self.get_stack_item(idx))
+                // Elements need to be reversed, since a word `[a, b, c, d]` will be stored on the
+                // stack as `[d, c, b, a]`
+                .rev()
+                .collect::<Option<_>>()?;
+
+            word_elements.try_into().expect("a Word contains 4 elements")
+        };
+
+        Some(word_elements)
     }
 
     /// Returns the stack outputs, which is state of the stack at the end of execution converted to

--- a/core/src/stack/outputs.rs
+++ b/core/src/stack/outputs.rs
@@ -88,12 +88,12 @@ impl StackOutputs {
     // PUBLIC ACCESSORS
     // --------------------------------------------------------------------------------------------
 
-    /// Returns the value located at the specified position on the stack
+    /// Returns the value located at the specified position on the stack or `None` if out of bounds.
     pub fn get_stack_item(&self, idx: usize) -> Option<Felt> {
         self.stack.get(idx).map(|&felt| felt.into())
     }
 
-    /// Returns the word located at the specified Felt position on the stack.
+    /// Returns the word located at the specified Felt position on the stack or `None` if out of bounds.
     pub fn get_stack_word(&self, idx: usize) -> Option<Word> {
         let word_elements: Word = {
             let word_elements: Vec<Felt> = range(idx, 4)


### PR DESCRIPTION
Followup to discussions in https://github.com/0xPolygonMiden/miden-vm/pull/1146