### PR TITLE
Use dynamic calls after `procref`

### DIFF
--- a/docs/src/user_docs/assembly/code_organization.md
+++ b/docs/src/user_docs/assembly/code_organization.md
@@ -54,7 +54,7 @@ dynexec
 This causes the VM to do the following:
 
 1. Read the top 4 elements of the stack to get the hash of the dynamic target (leaving the stack unchanged).
-2. Execute the code block which hashes to the specified target. The VM must know the specified code block and hash (they must be in the CodeBlockTable of the executing Program).
+2. Execute the code block which hashes to the specified target. The VM must know the specified code block and hash: they must be in the CodeBlockTable of the executing Program. Hashes can be put into the CodeBlockTable manually, or by executing `call`, `syscall`, or `procref` instructions. 
 
 Dynamic code execution in a new context can be achieved similarly by setting the top $4$ elements of the stack to the hash of the dynamic code block and then executing the following instruction:
 

--- a/miden/tests/integration/flow_control/mod.rs
+++ b/miden/tests/integration/flow_control/mod.rs
@@ -284,6 +284,38 @@ fn simple_dyn_exec() {
 }
 
 #[test]
+fn dynexec_with_procref() {
+    let program_source = "
+    use.std::math::u64
+
+    proc.foo
+        push.1.2
+        u32wrapping_add
+    end
+
+    begin
+        procref.foo
+        dynexec 
+
+        procref.u64::wrapping_add
+        dynexec
+    end";
+
+    let mut test = build_test!(program_source, &[]);
+    test.libraries = vec![StdLibrary::default().into()];
+
+    test.expect_stack(&[
+        1719755471,
+        1057995821,
+        3,
+        12973202366681443424,
+        7933716460165146367,
+        14382661273226268231,
+        15818904913409383971,
+    ]);
+}
+
+#[test]
 fn simple_dyncall() {
     let program_source = "
         proc.foo


### PR DESCRIPTION
This small PR makes it possible to use dynamic instructions (`dyncall` and `dynexec`) after `procref` instruction, without using `call` or `syscall` as it was explained in the #1150 issue.
