### PR TITLE
Support libraries in Miden REPL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@
 - Updated Winterfell dependency to v0.7 (#1121).
 - Added methods `StackOutputs::get_stack_item()` and `StackOutputs::get_stack_word()` (#1155).
 
+#### CLI
+- Introduced the `!use` command for the Miden REPL (#1162).
+
 ## 0.7.0 (2023-10-11)
 
 #### Assembly

--- a/docs/src/tools/repl.md
+++ b/docs/src/tools/repl.md
@@ -7,6 +7,11 @@ Miden REPL can be started via the CLI [repl](../intro/usage.md#cli-interface) co
 ./target/optimized/miden repl
 ```
 
+It is also possible to initialize REPL with libraries. To create it with Miden standard library you need to specify `-s` or `--stdlib` subcommand, it is also possible to add a third-party library by specifying `-l` or `--libraries` subcommand with paths to `.masl` library files. For example:
+```Shell
+./target/optimized/miden repl -s -l example/library.masl
+```
+
 ### Miden assembly instruction
 
 All Miden instructions mentioned in the [Miden Assembly sections](../user_docs/assembly/main.md) are valid. One can either input instructions one by one or multiple instructions in one input.
@@ -113,6 +118,35 @@ If the `addr` has not been initialized:
 ```
 >> !mem[87]
 Memory at address 87 is empty
+```
+
+### !use
+
+The `!use` command prints out the list of all modules available for import. 
+
+If the stdlib was added to the available libraries list `!use` command will print all its modules:
+```
+>> !use
+Modules available for importing:
+std::collections::mmr
+std::collections::smt
+std::collections::smt64
+...
+std::mem
+std::sys
+std::utils
+```
+
+Using the `!use` command with a module name will add the specified module to the program imports:
+```
+>> !use std::math::u64
+
+>> !program
+use.std::math::u64
+
+begin
+
+end
 ```
 
 ### !undo

--- a/miden/src/cli/repl.rs
+++ b/miden/src/cli/repl.rs
@@ -1,15 +1,24 @@
 use clap::Parser;
+use std::path::PathBuf;
 
 use crate::repl::start_repl;
 
 #[derive(Debug, Clone, Parser)]
 #[clap(about = "Initiates the Miden REPL tool")]
-pub struct ReplCmd {}
+pub struct ReplCmd {
+    /// Paths to .masl library files
+    #[clap(short = 'l', long = "libraries", value_parser)]
+    library_paths: Vec<PathBuf>,
+
+    /// Usage of standard library
+    #[clap(short = 's', long = "stdlib")]
+    use_stdlib: bool,
+}
 
 impl ReplCmd {
     pub fn execute(&self) -> Result<(), String> {
         // initiates repl tool.
-        start_repl();
+        start_repl(&self.library_paths, self.use_stdlib);
         Ok(())
     }
 }


### PR DESCRIPTION
This PR makes it possible to specify libraries to be used in the REPL programs. It also introduces the `!use` command for Miden REPL. This command could be used with or without parameter. 
- If `!use` command is used without parameters, it prints all modules available for import to the program.
- If `!use` command is used with parameter, it imports the provided module to the program.

