### PR TITLE
Support hexadecimal literals in constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Introduced the `procref.<proc_name>` assembly instruction (#1113).
 - Added the ability to use constants as counters in `repeat` loops (#1124). 
 - All `checked` versions of the u32 instructions were removed. All `unchecked` versions were renamed: this mode specification was removed from their titles (#1115).
+- Added support for hexadecimal values in constants (#1199).
 
 #### Stdlib
 - Introduced `std::utils` module with `is_empty_word` procedure.  Refactored `std::collections::smt`

--- a/assembly/src/tests.rs
+++ b/assembly/src/tests.rs
@@ -427,6 +427,24 @@ fn constant_alphanumeric_expression() {
 }
 
 #[test]
+fn constant_hexadecimal_value() {
+    let assembler = Assembler::default();
+    let source = "const.TEST_CONSTANT=0xFF \
+    begin \
+    push.TEST_CONSTANT \
+    end \
+    ";
+    let expected = "\
+    begin \
+        span \
+            push(255) \
+        end \
+    end";
+    let program = assembler.compile(source).unwrap();
+    assert_eq!(expected, format!("{program}"));
+}
+
+#[test]
 fn constant_field_division() {
     let assembler = Assembler::default();
     let source = "const.TEST_CONSTANT=(17//4)/4*(1//2)+2 \

--- a/docs/src/user_docs/assembly/code_organization.md
+++ b/docs/src/user_docs/assembly/code_organization.md
@@ -145,7 +145,7 @@ Miden assembly supports constant declarations. These constants are scoped to the
 
 Constants must be declared right after module imports and before any procedures or program bodies. A constant's name must start with an upper-case letter and can contain any combination of numbers, upper-case ASCII letters, and underscores (`_`). The number of characters in a constant name cannot exceed 100.
 
-A constant's value must be in the range between $0$ and $2^{64} - 2^{32}$ (both inclusive) and can be defined by an arithmetic expression using `+`, `-`, `*`, `/`, `//`, `(`, `)` operators and references to the previously defined constants. Here `/` is a field division and `//` is an integer division. Note that the arithmetic expression cannot contain spaces.
+A constant's value must be in a decimal or hexidecimal form and be in the range between $0$ and $2^{64} - 2^{32}$ (both inclusive). Value can be defined by an arithmetic expression using `+`, `-`, `*`, `/`, `//`, `(`, `)` operators and references to the previously defined constants if it uses only decimal numbers. Here `/` is a field division and `//` is an integer division. Note that the arithmetic expression cannot contain spaces.
 
 ```
 use.std::math::u64


### PR DESCRIPTION
This small PR adds support for hexadecimal values in constants, e.g.
```
const.TEST_CONSTANT=0xFF
```
