### PR TITLE
Fix build after `SimpleSmt` change in miden-crypto

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -23,7 +23,7 @@ std = ["miden-crypto/std", "math/std", "winter-utils/std"]
 [dependencies]
 math = { package = "winter-math", version = "0.7", default-features = false }
 # miden-crypto = { package = "miden-crypto", version = "0.8", default-features = false }
-miden-crypto = { package = "miden-crypto", git = "https://github.com/0xPolygonMiden/crypto", branch= "next", default-features = false }
+miden-crypto = { package = "miden-crypto", git = "https://github.com/0xPolygonMiden/crypto", branch= "plafer-smt-trait", default-features = false }
 winter-utils = { package = "winter-utils", version = "0.7", default-features = false }
 
 [dev-dependencies]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -23,7 +23,7 @@ std = ["miden-crypto/std", "math/std", "winter-utils/std"]
 [dependencies]
 math = { package = "winter-math", version = "0.7", default-features = false }
 # miden-crypto = { package = "miden-crypto", version = "0.8", default-features = false }
-miden-crypto = { package = "miden-crypto", git = "https://github.com/0xPolygonMiden/crypto", branch= "plafer-smt-trait", default-features = false }
+miden-crypto = { package = "miden-crypto", git = "https://github.com/0xPolygonMiden/crypto", branch = "next", default-features = false }
 winter-utils = { package = "winter-utils", version = "0.7", default-features = false }
 
 [dev-dependencies]

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -11,8 +11,8 @@ pub use miden_crypto::{Word, EMPTY_WORD, ONE, WORD_SIZE, ZERO};
 pub mod crypto {
     pub mod merkle {
         pub use miden_crypto::merkle::{
-            DefaultMerkleStore, EmptySubtreeRoots, InnerNodeInfo, MerkleError, MerklePath,
-            MerkleStore, MerkleTree, Mmr, MmrPeaks, NodeIndex, PartialMerkleTree,
+            DefaultMerkleStore, EmptySubtreeRoots, InnerNodeInfo, LeafIndex, MerkleError,
+            MerklePath, MerkleStore, MerkleTree, Mmr, MmrPeaks, NodeIndex, PartialMerkleTree,
             RecordingMerkleStore, SimpleSmt, StoreNode, TieredSmt,
         };
     }

--- a/miden/src/cli/data.rs
+++ b/miden/src/cli/data.rs
@@ -16,6 +16,10 @@ use std::{
 use stdlib::StdLibrary;
 pub use tracing::{event, info_span, instrument, trace_span, Level};
 
+// CONSTANTS
+// ================================================================================================
+const SIMPLE_SMT_DEPTH: u8 = u64::BITS as u8;
+
 // HELPERS
 // ================================================================================================
 
@@ -206,7 +210,7 @@ impl InputFile {
                 }
                 MerkleData::SparseMerkleTree(data) => {
                     let entries = Self::parse_sparse_merkle_tree(data)?;
-                    let tree = SimpleSmt::with_leaves(u64::BITS as u8, entries)
+                    let tree = SimpleSmt::<SIMPLE_SMT_DEPTH>::with_leaves(entries)
                         .map_err(|e| format!("failed to parse a Sparse Merkle Tree: {e}"))?;
                     merkle_store.extend(tree.inner_nodes());
                     event!(

--- a/stdlib/tests/collections/mod.rs
+++ b/stdlib/tests/collections/mod.rs
@@ -1,5 +1,5 @@
 use test_utils::{
-    crypto::{MerkleStore, SimpleSmt},
+    crypto::{LeafIndex, MerkleStore, SimpleSmt},
     Felt, StarkField, TestError, Word, EMPTY_WORD, ONE, ZERO,
 };
 

--- a/test-utils/src/crypto.rs
+++ b/test-utils/src/crypto.rs
@@ -7,8 +7,8 @@ pub use vm_core::crypto::{
     dsa::*,
     hash::{Rpo256, RpoDigest},
     merkle::{
-        EmptySubtreeRoots, MerkleError, MerklePath, MerkleStore, MerkleTree, Mmr, MmrPeaks,
-        NodeIndex, PartialMerkleTree, SimpleSmt, TieredSmt,
+        EmptySubtreeRoots, LeafIndex, MerkleError, MerklePath, MerkleStore, MerkleTree, Mmr,
+        MmrPeaks, NodeIndex, PartialMerkleTree, SimpleSmt, TieredSmt,
     },
 };
 


### PR DESCRIPTION
Fixes build after https://github.com/0xPolygonMiden/crypto/pull/245