### PR TITLE
Fix unused imports checker

### DIFF
--- a/assembly/src/ast/mod.rs
+++ b/assembly/src/ast/mod.rs
@@ -92,16 +92,3 @@ fn sort_procs_into_vec(proc_map: LocalProcMap) -> Vec<ProcedureAst> {
 
     procedures.into_iter().map(|(_idx, proc)| proc).collect()
 }
-
-/// Logging a warning message for every imported but unused module.
-fn check_unused_imports(import_info: &ModuleImports) {
-    let import_lib_paths = import_info.import_paths();
-    let invoked_procs_paths: Vec<&LibraryPath> =
-        import_info.invoked_procs().iter().map(|(_id, (_name, path))| path).collect();
-
-    for lib in import_lib_paths {
-        if !invoked_procs_paths.contains(&lib) {
-            event!(Level::WARN, "unused import: \"{}\"", lib);
-        }
-    }
-}

--- a/assembly/src/ast/module.rs
+++ b/assembly/src/ast/module.rs
@@ -1,4 +1,3 @@
-use super::check_unused_imports;
 use super::{
     format::*,
     imports::ModuleImports,
@@ -110,7 +109,7 @@ impl ModuleAst {
         // get module docs and make sure the size is within the limit
         let docs = tokens.take_module_comments();
 
-        check_unused_imports(context.import_info);
+        context.import_info.check_unused_imports();
 
         Ok(Self::new(local_procs, reexported_procs, docs)?.with_import_info(import_info))
     }

--- a/assembly/src/ast/parsers/context.rs
+++ b/assembly/src/ast/parsers/context.rs
@@ -349,7 +349,7 @@ impl ParserContext<'_> {
     /// - A procedure with the same name as re-exported procedure has already been either
     ///   declared or re-exported from this context.
     fn parse_reexported_procedure(
-        &self,
+        &mut self,
         tokens: &mut TokenStream,
     ) -> Result<ProcReExport, ParsingError> {
         let proc_start = tokens.pos();
@@ -365,7 +365,11 @@ impl ParserContext<'_> {
         let module_path = self
             .import_info
             .get_module_path(module)
+            .cloned()
             .ok_or(ParsingError::procedure_module_not_imported(header, module))?;
+
+        // add module path of reexported procedure to the module imports
+        self.import_info.add_reexported_module(&module_path);
 
         // consume the `export` token
         tokens.advance();
@@ -381,7 +385,7 @@ impl ParserContext<'_> {
             }
         }
 
-        let proc_id = ProcedureId::from_name(&ref_name, module_path);
+        let proc_id = ProcedureId::from_name(&ref_name, &module_path);
         Ok(ProcReExport::new(proc_id, proc_name, docs))
     }
 

--- a/assembly/src/ast/procedure.rs
+++ b/assembly/src/ast/procedure.rs
@@ -2,7 +2,7 @@ use crate::ast::{MAX_BODY_LEN, MAX_DOCS_LEN};
 
 use super::{
     super::tokens::SourceLocation, code_body::CodeBody, nodes::Node, ByteReader, ByteWriter,
-    Deserializable, DeserializationError, LibraryPath, ProcedureId, ProcedureName, Serializable,
+    Deserializable, DeserializationError, ProcedureId, ProcedureName, Serializable,
 };
 use crate::utils::{collections::*, string::*};
 use core::{iter, str::from_utf8};
@@ -203,11 +203,6 @@ impl ProcReExport {
     /// Returns the documentation of the re-exported procedure, if present.
     pub fn docs(&self) -> Option<&str> {
         self.docs.as_deref()
-    }
-
-    /// Returns the ID of the re-exported procedure using the specified module.
-    pub fn get_alias_id(&self, module_path: &LibraryPath) -> ProcedureId {
-        ProcedureId::from_name(&self.name, module_path)
     }
 }
 

--- a/assembly/src/ast/program.rs
+++ b/assembly/src/ast/program.rs
@@ -2,7 +2,6 @@ use crate::ast::MAX_BODY_LEN;
 
 use super::{
     super::tokens::SourceLocation,
-    check_unused_imports,
     code_body::CodeBody,
     imports::ModuleImports,
     instrument,
@@ -182,7 +181,7 @@ impl ProgramAst {
             return Err(ParsingError::dangling_ops_after_program(token));
         }
 
-        check_unused_imports(context.import_info);
+        context.import_info.check_unused_imports();
 
         let local_procs = sort_procs_into_vec(context.local_procs);
         let (nodes, locations) = body.into_parts();


### PR DESCRIPTION
This PR fixes the the unused import checker. After this update it will check not only invoked procedures, but also reexported procedures in modules. 
