### PR TITLE
Clean up aux column generator for stack overflow table

### DIFF
--- a/processor/src/stack/mod.rs
+++ b/processor/src/stack/mod.rs
@@ -240,7 +240,7 @@ impl Stack {
 
         // Update the overflow table.
         let to_overflow = self.trace.get_stack_value_at(self.clk, MAX_TOP_IDX);
-        self.overflow.push(to_overflow, self.clk as u64);
+        self.overflow.push(to_overflow, Felt::from(self.clk));
 
         // Stack depth always increases on right shift.
         self.active_depth += 1;

--- a/processor/src/stack/tests.rs
+++ b/processor/src/stack/tests.rs
@@ -53,9 +53,9 @@ fn initialize_overflow() {
     ];
     let init_addr = Felt::MODULUS - 3;
     let expected_overflow_rows = vec![
-        OverflowTableRow::new(init_addr, ONE, ZERO),
-        OverflowTableRow::new(init_addr + 1, Felt::new(2), Felt::new(init_addr)),
-        OverflowTableRow::new(init_addr + 2, Felt::new(3), Felt::new(init_addr + 1)),
+        OverflowTableRow::new(Felt::new(init_addr), ONE, ZERO),
+        OverflowTableRow::new(Felt::new(init_addr + 1), Felt::new(2), Felt::new(init_addr)),
+        OverflowTableRow::new(Felt::new(init_addr + 2), Felt::new(3), Felt::new(init_addr + 1)),
     ];
     let expected_overflow_active_rows = vec![0, 1, 2];
 

--- a/processor/src/trace/tests/stack.rs
+++ b/processor/src/trace/tests/stack.rs
@@ -37,10 +37,10 @@ fn p1_trace() {
     let p1 = aux_columns.get_column(P1_COL_IDX);
 
     let row_values = [
-        OverflowTableRow::new(2, ONE, ZERO).to_value(&alphas),
-        OverflowTableRow::new(3, TWO, TWO).to_value(&alphas),
-        OverflowTableRow::new(6, TWO, TWO).to_value(&alphas),
-        OverflowTableRow::new(10, ZERO, ZERO).to_value(&alphas),
+        OverflowTableRow::new(Felt::new(2), ONE, ZERO).to_value(&alphas),
+        OverflowTableRow::new(Felt::new(3), TWO, TWO).to_value(&alphas),
+        OverflowTableRow::new(Felt::new(6), TWO, TWO).to_value(&alphas),
+        OverflowTableRow::new(Felt::new(10), ZERO, ZERO).to_value(&alphas),
     ];
 
     // make sure the first entry is ONE


### PR DESCRIPTION
This PR cleans up a little auxiliary column code generator for the stack overflow table.

Specifically:
- Moved some functions inline when the body of a function contains just a single function call.
- Used `OverflowTableRow::to_value()` method to compute aux request/responses.
- Removed `OverflowTable.update_trace` field since it is no longer needed.

We can further simplify the `OverflowTable` struct by not tracking all overflow table rows and instead tracking only current ones. But I didn't do this in this PR.