### PR TITLE
`mpverify`: don't panic when verification fails

### DIFF
--- a/processor/src/errors.rs
+++ b/processor/src/errors.rs
@@ -50,6 +50,11 @@ pub enum ExecutionError {
         value: Felt,
     },
     MemoryAddressOutOfBounds(u64),
+    MerklePathVerificationFailed {
+        value: Word,
+        index: Felt,
+        root: Digest,
+    },
     MerkleStoreMergeFailed(MerkleError),
     MerkleStoreLookupFailed(MerkleError),
     MerkleStoreUpdateFailed(MerkleError),
@@ -145,6 +150,11 @@ impl Display for ExecutionError {
             }
             MemoryAddressOutOfBounds(addr) => {
                 write!(f, "Memory address cannot exceed 2^32 but was {addr}")
+            }
+            MerklePathVerificationFailed { value, index, root } => {
+                let value = to_hex(Felt::elements_as_bytes(value))?;
+                let root = to_hex(&root.as_bytes())?;
+                write!(f, "Merkle path verification failed for value {value} at index {index}, in the Merkle tree with root {root}")
             }
             MerkleStoreLookupFailed(reason) => {
                 write!(f, "Advice provider Merkle store backend lookup failed: {reason}")

--- a/processor/src/operations/crypto_ops.rs
+++ b/processor/src/operations/crypto_ops.rs
@@ -84,10 +84,9 @@ where
         // helper registers.
         self.decoder.set_user_op_helpers(Operation::MpVerify, &[addr]);
 
-        // Asserting the computed root of the Merkle path from the advice provider is consistent with
-        // the input root.
-        assert_eq!(root, computed_root, "inconsistent Merkle tree root");
-        if root == computed_root {
+        if root != computed_root {
+            // If the hasher chiplet doesn't compute the same root (using the same path),
+            // then it means that `node` is not the value currently in the tree at `index`
             return Err(ExecutionError::MerklePathVerificationFailed {
                 value: node,
                 index,

--- a/processor/src/operations/crypto_ops.rs
+++ b/processor/src/operations/crypto_ops.rs
@@ -87,6 +87,13 @@ where
         // Asserting the computed root of the Merkle path from the advice provider is consistent with
         // the input root.
         assert_eq!(root, computed_root, "inconsistent Merkle tree root");
+        if root == computed_root {
+            return Err(ExecutionError::MerklePathVerificationFailed {
+                value: node,
+                index,
+                root: root.into(),
+            });
+        }
 
         // The same state is copied over to the next clock cycle with no changes.
         self.stack.copy_state(0);


### PR DESCRIPTION
Converts a `panic!()` into an error when Merkle Path verification fails.