### PR TITLE
Update `miden-crypto` to v0.8

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -22,7 +22,7 @@ std = ["miden-crypto/std", "math/std", "winter-utils/std"]
 
 [dependencies]
 math = { package = "winter-math", version = "0.8", default-features = false }
-miden-crypto = { package = "miden-crypto", git = "https://github.com/0xPolygonMiden/crypto", branch = "next", default-features = false }
+miden-crypto = { version = "0.8", default-features = false }
 winter-utils = { package = "winter-utils", version = "0.8", default-features = false }
 
 [dev-dependencies]


### PR DESCRIPTION
This small PR updates the `miden-crypro` dependency to the version 0.8.
