### PR TITLE
Optimize push 2

### DIFF
--- a/assembly/src/assembler/instruction/field_ops.rs
+++ b/assembly/src/assembler/instruction/field_ops.rs
@@ -111,8 +111,8 @@ pub fn pow2(span: &mut SpanBuilder) -> Result<Option<CodeBlock>, AssemblyError> 
 ///
 /// VM cycles: 16 cycles
 pub fn append_pow2_op(span: &mut SpanBuilder) {
-    // push base 2 onto the stack: [exp, ...] -> [2, exp, ...]
-    span.push_op(Push(2_u8.into()));
+    // push 2 onto the stack: [exp, ...] -> [2, exp, ...]
+    span.push_ops([Pad, Incr, Incr]);
     // introduce initial value of acc onto the stack: [2, exp, ...] -> [1, 2, exp, ...]
     span.push_ops([Pad, Incr]);
     // arrange the top of the stack for EXPACC operation: [1, 2, exp, ...] -> [0, 2, 1, exp, ...]


### PR DESCRIPTION
## Describe your changes

This encodes the same value a little bit more effectively:

- The instruction `Push.2` takes one Op and a group (about 71bits).
- The instructions `Padd Incr Incr` take 3 Ops (about 21 bits).

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
