### PR TITLE
Update `mtree_merge` doc comments

### DIFF
--- a/assembly/src/assembler/instruction/crypto_ops.rs
+++ b/assembly/src/assembler/instruction/crypto_ops.rs
@@ -158,8 +158,7 @@ pub(super) fn mtree_set(span: &mut SpanBuilder) -> Result<Option<CodeBlock>, Ass
 /// follows:
 /// - merged root, 4 elements
 ///
-/// This operation will fail if either of the input roots doesn't exist as Merkle tree in the
-/// advice provider.
+/// It is not checked whether the provided roots exist as Merkle trees in the advide providers.
 ///
 /// This operation takes 16 VM cycles.
 pub(super) fn mtree_merge(span: &mut SpanBuilder) -> Result<Option<CodeBlock>, AssemblyError> {

--- a/processor/src/host/advice/injectors/adv_map_injectors.rs
+++ b/processor/src/host/advice/injectors/adv_map_injectors.rs
@@ -141,9 +141,7 @@ pub(crate) fn insert_hperm_into_adv_map<S: ProcessState, A: AdviceProvider>(
 /// After the operation, both the original trees and the new tree remains in the advice
 /// provider (i.e., the input trees are not removed).
 ///
-/// # Errors
-/// Return an error if a Merkle tree for either of the specified roots cannot be found in this
-/// advice provider.
+/// It is not checked whether the provided roots exist as Merkle trees in the advide providers.
 pub(crate) fn merge_merkle_nodes<S: ProcessState, A: AdviceProvider>(
     advice_provider: &mut A,
     process: &S,

--- a/processor/src/host/advice/mod.rs
+++ b/processor/src/host/advice/mod.rs
@@ -183,9 +183,7 @@ pub trait AdviceProvider: Sized {
     /// After the operation, both the original trees and the new tree remains in the advice
     /// provider (i.e., the input trees are not removed).
     ///
-    /// # Errors
-    /// Return an error if a Merkle tree for either of the specified roots cannot be found in this
-    /// advice provider.
+    /// It is not checked whether the provided roots exist as Merkle trees in the advide providers.
     fn merge_merkle_nodes<S: ProcessState>(
         &mut self,
         process: &S,
@@ -719,9 +717,8 @@ pub trait AdviceProvider: Sized {
     /// After the operation, both the original trees and the new tree remains in the advice
     /// provider (i.e., the input trees are not removed).
     ///
-    /// # Errors
-    /// Returns an error if a Merkle tree for either of the specified roots cannot be found in this
-    /// advice provider.
+    /// It is not checked whether a Merkle tree for either of the specified roots can be found in
+    /// this advice provider.
     fn merge_roots(&mut self, lhs: Word, rhs: Word) -> Result<Word, ExecutionError>;
 
     /// Returns a subset of this Merkle store such that the returned Merkle store contains all


### PR DESCRIPTION
This small PR changes the doc comments related to `mtree_merge` instruction.
It removes any comments about returning an error if provided roots are not in the advice provider (since we don't return it).
