### PR TITLE
Remove `find_lone_leaf()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.9.0
+
+#### VM Internals
+- Removed unused `find_lone_leaf()` function from the Advice Provider (#1262).
+
 ## 0.8.0 (02-26-2024)
 
 #### Assembly

--- a/air/src/constraints/stack/mod.rs
+++ b/air/src/constraints/stack/mod.rs
@@ -227,7 +227,7 @@ pub fn get_assertions_last_step(
 // --- AUXILIARY COLUMNS --------------------------------------------------------------------------
 
 /// Returns the stack's boundary assertions for auxiliary columns at the first step.
-pub fn get_aux_assertions_first_step<E: FieldElement>(
+pub fn get_aux_assertions_first_step<E>(
     result: &mut Vec<Assertion<E>>,
     alphas: &AuxTraceRandElements<E>,
     stack_inputs: &[Felt],
@@ -245,7 +245,7 @@ pub fn get_aux_assertions_first_step<E: FieldElement>(
 }
 
 /// Returns the stack's boundary assertions for auxiliary columns at the last step.
-pub fn get_aux_assertions_last_step<E: FieldElement>(
+pub fn get_aux_assertions_last_step<E>(
     result: &mut Vec<Assertion<E>>,
     alphas: &AuxTraceRandElements<E>,
     stack_outputs: &StackOutputs,
@@ -269,7 +269,7 @@ pub fn get_aux_assertions_last_step<E: FieldElement>(
 
 /// Gets the initial value of the overflow table auxiliary column from the provided sets of initial
 /// values and random elements.
-fn get_overflow_table_init<E: FieldElement>(alphas: &[E], init_values: &[Felt]) -> E
+fn get_overflow_table_init<E>(alphas: &[E], init_values: &[Felt]) -> E
 where
     E: FieldElement<BaseField = Felt>,
 {
@@ -293,7 +293,7 @@ where
 
 /// Gets the final value of the overflow table auxiliary column from the provided program outputs
 /// and random elements.
-fn get_overflow_table_final<E: FieldElement>(alphas: &[E], stack_outputs: &StackOutputs) -> E
+fn get_overflow_table_final<E>(alphas: &[E], stack_outputs: &StackOutputs) -> E
 where
     E: FieldElement<BaseField = Felt>,
 {

--- a/assembly/src/ast/imports.rs
+++ b/assembly/src/ast/imports.rs
@@ -90,7 +90,7 @@ impl ModuleImports {
 
     /// Look up the path of the imported module with the given name.
     pub fn get_module_path(&self, module_name: &str) -> Option<&LibraryPath> {
-        self.imports.get(&module_name.to_string())
+        self.imports.get(module_name)
     }
 
     /// Look up the actual procedure name and module path associated with the given [ProcedureId],

--- a/processor/src/host/advice/mod.rs
+++ b/processor/src/host/advice/mod.rs
@@ -675,21 +675,6 @@ pub trait AdviceProvider: Sized {
         index: &Felt,
     ) -> Result<u8, ExecutionError>;
 
-    /// Returns node value and index of a leaf node in the subtree of the specified root, if and
-    /// only if this is the only leaf in the entire subtree. Otherwise, None is returned.
-    ///
-    /// The root itself is assumed to be located at the specified index in a tree with the provided
-    /// depth.
-    ///
-    /// # Errors
-    /// Returns an error if a three for the specified root does not exist in the advice provider.
-    fn find_lone_leaf(
-        &self,
-        root: Word,
-        root_index: NodeIndex,
-        tree_depth: u8,
-    ) -> Result<Option<(NodeIndex, Word)>, ExecutionError>;
-
     /// Updates a node at the specified depth and index in a Merkle tree with the specified root;
     /// returns the Merkle path from the updated node to the new root, together with the new root.
     ///
@@ -796,15 +781,6 @@ where
         index: &Felt,
     ) -> Result<u8, ExecutionError> {
         T::get_leaf_depth(self, root, tree_depth, index)
-    }
-
-    fn find_lone_leaf(
-        &self,
-        root: Word,
-        root_index: NodeIndex,
-        tree_depth: u8,
-    ) -> Result<Option<(NodeIndex, Word)>, ExecutionError> {
-        T::find_lone_leaf(self, root, root_index, tree_depth)
     }
 
     fn update_merkle_node(

--- a/processor/src/host/advice/providers.rs
+++ b/processor/src/host/advice/providers.rs
@@ -185,18 +185,6 @@ where
             .map_err(ExecutionError::MerkleStoreLookupFailed)
     }
 
-    fn find_lone_leaf(
-        &self,
-        root: Word,
-        root_index: NodeIndex,
-        tree_depth: u8,
-    ) -> Result<Option<(NodeIndex, Word)>, ExecutionError> {
-        self.store
-            .find_lone_leaf(root.into(), root_index, tree_depth)
-            .map(|leaf| leaf.map(|(index, leaf)| (index, leaf.into())))
-            .map_err(ExecutionError::MerkleStoreLookupFailed)
-    }
-
     fn update_merkle_node(
         &mut self,
         root: Word,
@@ -315,10 +303,6 @@ impl AdviceProvider for MemAdviceProvider {
 
     fn get_leaf_depth(&self, root: Word, tree_depth: &Felt, index: &Felt) -> Result<u8, ExecutionError> {
         self.provider.get_leaf_depth(root, tree_depth, index)
-    }
-
-    fn find_lone_leaf(&self, root: Word, root_index: NodeIndex, tree_depth: u8) -> Result<Option<(NodeIndex, Word)>, ExecutionError> {
-        self.provider.find_lone_leaf(root, root_index, tree_depth)
     }
 
     fn update_merkle_node(&mut self, root: Word, depth: &Felt, index: &Felt, value: Word) -> Result<(MerklePath, Word), ExecutionError> {
@@ -440,10 +424,6 @@ impl AdviceProvider for RecAdviceProvider {
 
     fn get_leaf_depth(&self, root: Word, tree_depth: &Felt, index: &Felt) -> Result<u8, ExecutionError> {
         self.provider.get_leaf_depth(root, tree_depth, index)
-    }
-
-    fn find_lone_leaf(&self, root: Word, root_index: NodeIndex, tree_depth: u8) -> Result<Option<(NodeIndex, Word)>, ExecutionError> {
-        self.provider.find_lone_leaf(root, root_index, tree_depth)
     }
 
     fn update_merkle_node(&mut self, root: Word, depth: &Felt, index: &Felt, value: Word) -> Result<(MerklePath, Word), ExecutionError> {


### PR DESCRIPTION
This small PR removes unused `find_lone_leaf()` function from the Advice Provider. 
