### PR TITLE
Update `usize` serialization and deserialization 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 #### VM Internals
 - Removed unused `find_lone_leaf()` function from the Advice Provider (#1262).
-- Changed fields type of the `StackOutputs` struct from `Vec<u64>` to `Vec<Felt>` (#1268).
+- [BREAKING] Changed fields type of the `StackOutputs` struct from `Vec<u64>` to `Vec<Felt>` (#1268).
 
 ## 0.8.0 (02-26-2024)
 

--- a/core/src/errors.rs
+++ b/core/src/errors.rs
@@ -6,19 +6,26 @@ use core::fmt;
 
 #[derive(Clone, Debug)]
 pub enum InputError {
-    NotFieldElement(u64, String),
     DuplicateAdviceRoot([u8; 32]),
+    InputLengthExceeded(usize, usize),
+    NotFieldElement(u64, String),
 }
 
 impl fmt::Display for InputError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use InputError::*;
         match self {
-            NotFieldElement(num, description) => {
-                write!(f, "{num} is not a valid field element: {description}")
-            }
             DuplicateAdviceRoot(key) => {
                 write!(f, "{key:02x?} is a duplicate of the current merkle set")
+            }
+            InputLengthExceeded(limit, provided) => {
+                write!(
+                    f,
+                    "Number of input values can not exceed {limit}, but {provided} was provided"
+                )
+            }
+            NotFieldElement(num, description) => {
+                write!(f, "{num} is not a valid field element: {description}")
             }
         }
     }

--- a/miden/README.md
+++ b/miden/README.md
@@ -181,7 +181,7 @@ let program = Assembler::default().compile(&source).unwrap();
 let host = DefaultHost::default();
 
 // initialize the stack with values 0 and 1
-let stack_inputs = StackInputs::try_from_values([0, 1]).unwrap();
+let stack_inputs = StackInputs::try_from_ints([0, 1]).unwrap();
 
 // execute the program
 let (outputs, proof) = miden_vm::prove(

--- a/miden/src/cli/data.rs
+++ b/miden/src/cli/data.rs
@@ -295,7 +295,7 @@ impl InputFile {
             .map(|v| v.parse::<u64>().map_err(|e| e.to_string()))
             .collect::<Result<Vec<_>, _>>()?;
 
-        StackInputs::try_from_values(stack_inputs).map_err(|e| e.to_string())
+        StackInputs::try_from_ints(stack_inputs).map_err(|e| e.to_string())
     }
 }
 

--- a/miden/src/examples/blake3.rs
+++ b/miden/src/examples/blake3.rs
@@ -22,7 +22,7 @@ pub fn get_example(n: usize) -> Example<DefaultHost<MemAdviceProvider>> {
 
     Example {
         program,
-        stack_inputs: StackInputs::try_from_values(INITIAL_HASH_VALUE.iter().map(|&v| v as u64))
+        stack_inputs: StackInputs::try_from_ints(INITIAL_HASH_VALUE.iter().map(|&v| v as u64))
             .unwrap(),
         host: DefaultHost::default(),
         expected_result,

--- a/miden/src/examples/fibonacci.rs
+++ b/miden/src/examples/fibonacci.rs
@@ -15,7 +15,7 @@ pub fn get_example(n: usize) -> Example<DefaultHost<MemAdviceProvider>> {
 
     Example {
         program,
-        stack_inputs: StackInputs::try_from_values([0, 1]).unwrap(),
+        stack_inputs: StackInputs::try_from_ints([0, 1]).unwrap(),
         host: DefaultHost::default(),
         expected_result,
         num_outputs: 1,

--- a/miden/src/tools/mod.rs
+++ b/miden/src/tools/mod.rs
@@ -323,7 +323,7 @@ mod tests {
     fn analyze_test_execution_error() {
         let source = "begin div end";
         let stack_inputs = vec![1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
-        let stack_inputs = StackInputs::try_from_values(stack_inputs).unwrap();
+        let stack_inputs = StackInputs::try_from_ints(stack_inputs).unwrap();
         let host = DefaultHost::default();
         let execution_details = super::analyze(source, stack_inputs, host);
         let expected_error = "Execution Error: DivideByZero(1)";

--- a/miden/tests/integration/flow_control/mod.rs
+++ b/miden/tests/integration/flow_control/mod.rs
@@ -204,7 +204,7 @@ fn simple_syscall() {
     let test = Test {
         source: program_source.to_string(),
         kernel: Some(kernel_source.to_string()),
-        stack_inputs: StackInputs::try_from_values([1, 2]).unwrap(),
+        stack_inputs: StackInputs::try_from_ints([1, 2]).unwrap(),
         advice_inputs: AdviceInputs::default(),
         in_debug_mode: false,
         libraries: Vec::default(),
@@ -251,7 +251,7 @@ fn simple_dyn_exec() {
     let test = Test {
         source: program_source.to_string(),
         kernel: None,
-        stack_inputs: StackInputs::try_from_values([
+        stack_inputs: StackInputs::try_from_ints([
             3,
             // put the hash of foo on the stack
             16045159387802755434,
@@ -357,7 +357,7 @@ fn simple_dyncall() {
     let test = Test {
         source: program_source.to_string(),
         kernel: None,
-        stack_inputs: StackInputs::try_from_values([
+        stack_inputs: StackInputs::try_from_ints([
             3,
             // put the hash of foo on the stack
             8324248212344458853,

--- a/miden/tests/integration/operations/io_ops/env_ops.rs
+++ b/miden/tests/integration/operations/io_ops/env_ops.rs
@@ -146,7 +146,7 @@ fn caller() {
     let test = Test {
         source: program_source.to_string(),
         kernel: Some(kernel_source.to_string()),
-        stack_inputs: StackInputs::try_from_values([1, 2, 3, 4, 5]).unwrap(),
+        stack_inputs: StackInputs::try_from_ints([1, 2, 3, 4, 5]).unwrap(),
         advice_inputs: AdviceInputs::default(),
         in_debug_mode: false,
         libraries: Vec::default(),

--- a/processor/src/chiplets/tests.rs
+++ b/processor/src/chiplets/tests.rs
@@ -110,7 +110,7 @@ fn build_trace(
     operations: Vec<Operation>,
     kernel: Kernel,
 ) -> (ChipletsTrace, usize) {
-    let stack_inputs = StackInputs::try_from_values(stack_inputs.iter().copied()).unwrap();
+    let stack_inputs = StackInputs::try_from_ints(stack_inputs.iter().copied()).unwrap();
     let host = DefaultHost::default();
     let mut process = Process::new(kernel, stack_inputs, host, ExecutionOptions::default());
     let program = CodeBlock::new_span(operations);

--- a/processor/src/decoder/tests.rs
+++ b/processor/src/decoder/tests.rs
@@ -1194,7 +1194,7 @@ fn set_user_op_helpers_many() {
 // ================================================================================================
 
 fn build_trace(stack_inputs: &[u64], program: &CodeBlock) -> (DecoderTrace, usize) {
-    let stack_inputs = StackInputs::try_from_values(stack_inputs.iter().copied()).unwrap();
+    let stack_inputs = StackInputs::try_from_ints(stack_inputs.iter().copied()).unwrap();
     let host = DefaultHost::default();
     let mut process =
         Process::new(Kernel::default(), stack_inputs, host, ExecutionOptions::default());
@@ -1217,7 +1217,7 @@ fn build_dyn_trace(
     program: &CodeBlock,
     fn_block: CodeBlock,
 ) -> (DecoderTrace, usize) {
-    let stack_inputs = StackInputs::try_from_values(stack_inputs.iter().copied()).unwrap();
+    let stack_inputs = StackInputs::try_from_ints(stack_inputs.iter().copied()).unwrap();
     let host = DefaultHost::default();
     let mut process =
         Process::new(Kernel::default(), stack_inputs, host, ExecutionOptions::default());

--- a/processor/src/operations/comb_ops.rs
+++ b/processor/src/operations/comb_ops.rs
@@ -195,7 +195,7 @@ mod tests {
         inputs.reverse();
 
         // --- setup the operand stack ------------------------------------------------------------
-        let stack_inputs = StackInputs::new(inputs.to_vec());
+        let stack_inputs = StackInputs::new(inputs.to_vec()).expect("inputs lenght too long");
         let mut process = Process::new_dummy_with_decoder_helpers(stack_inputs);
 
         // --- setup memory -----------------------------------------------------------------------

--- a/processor/src/operations/crypto_ops.rs
+++ b/processor/src/operations/crypto_ops.rs
@@ -201,7 +201,7 @@ mod tests {
             1, 1,            // data: [ONE, ONE]
             1, 0, 0, 0, 0, 0 // padding: ONE followed by the necessary ZEROs
         ];
-        let stack = StackInputs::try_from_values(inputs).unwrap();
+        let stack = StackInputs::try_from_ints(inputs).unwrap();
         let mut process = Process::new_dummy_with_decoder_helpers(stack);
 
         let expected: [Felt; STATE_WIDTH] = build_expected_perm(&inputs);
@@ -212,7 +212,7 @@ mod tests {
         let values = rand_vector::<u64>(8);
         let mut inputs: Vec<u64> = vec![values.len() as u64, 0, 0, 0];
         inputs.extend_from_slice(&values);
-        let stack = StackInputs::try_from_values(inputs.clone()).unwrap();
+        let stack = StackInputs::try_from_ints(inputs.clone()).unwrap();
         let mut process = Process::new_dummy_with_decoder_helpers(stack);
 
         // add the capacity to prepare the input vector
@@ -226,7 +226,7 @@ mod tests {
         let values: Vec<u64> = vec![2, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0];
         inputs.extend_from_slice(&values);
 
-        let stack = StackInputs::try_from_values(inputs).unwrap();
+        let stack = StackInputs::try_from_ints(inputs).unwrap();
         let mut process = Process::new_dummy_with_decoder_helpers(stack);
         process.execute_op(Operation::HPerm).unwrap();
         assert_eq!(expected, &process.stack.trace_state()[12..16]);
@@ -260,7 +260,7 @@ mod tests {
         let index = Felt::new(index);
 
         let advice_inputs = AdviceInputs::default().with_merkle_store(store);
-        let stack_inputs = StackInputs::try_from_values(stack_inputs).unwrap();
+        let stack_inputs = StackInputs::try_from_ints(stack_inputs).unwrap();
         let mut process =
             Process::new_dummy_with_inputs_and_decoder_helpers(stack_inputs, advice_inputs);
 
@@ -302,7 +302,7 @@ mod tests {
 
         let store = MerkleStore::from(&tree);
         let advice_inputs = AdviceInputs::default().with_merkle_store(store);
-        let stack_inputs = StackInputs::try_from_values(stack_inputs).unwrap();
+        let stack_inputs = StackInputs::try_from_ints(stack_inputs).unwrap();
         let mut process =
             Process::new_dummy_with_inputs_and_decoder_helpers(stack_inputs, advice_inputs);
 
@@ -380,7 +380,7 @@ mod tests {
             replaced_node[2].as_int(),
             replaced_node[3].as_int(),
         ];
-        let stack_inputs = StackInputs::try_from_values(stack_inputs).unwrap();
+        let stack_inputs = StackInputs::try_from_ints(stack_inputs).unwrap();
         let mut process =
             Process::new_dummy_with_inputs_and_decoder_helpers(stack_inputs, advice_inputs);
 

--- a/processor/src/operations/ext2_ops.rs
+++ b/processor/src/operations/ext2_ops.rs
@@ -49,7 +49,7 @@ mod tests {
         // initialize the stack with a few values
         let [a0, a1, b0, b1] = [rand_value(); 4];
 
-        let stack = StackInputs::new(vec![a0, a1, b0, b1]);
+        let stack = StackInputs::new(vec![a0, a1, b0, b1]).expect("inputs lenght too long");
         let mut process = Process::new_dummy(stack);
 
         // multiply the top two values
@@ -64,7 +64,7 @@ mod tests {
         assert_eq!(expected, process.stack.trace_state());
 
         // calling ext2mul with a stack of minimum depth is ok
-        let stack = StackInputs::new(vec![]);
+        let stack = StackInputs::new(vec![]).expect("inputs lenght too long");
         let mut process = Process::new_dummy(stack);
         assert!(process.execute_op(Operation::Ext2Mul).is_ok());
     }

--- a/processor/src/operations/field_ops.rs
+++ b/processor/src/operations/field_ops.rs
@@ -235,7 +235,7 @@ mod tests {
     fn op_add() {
         // initialize the stack with a few values
         let (a, b, c) = get_rand_values();
-        let stack = StackInputs::try_from_values([c.as_int(), b.as_int(), a.as_int()]).unwrap();
+        let stack = StackInputs::try_from_ints([c.as_int(), b.as_int(), a.as_int()]).unwrap();
         let mut process = Process::new_dummy(stack);
 
         // add the top two values
@@ -255,7 +255,7 @@ mod tests {
     fn op_neg() {
         // initialize the stack with a few values
         let (a, b, c) = get_rand_values();
-        let stack = StackInputs::try_from_values([c.as_int(), b.as_int(), a.as_int()]).unwrap();
+        let stack = StackInputs::try_from_ints([c.as_int(), b.as_int(), a.as_int()]).unwrap();
         let mut process = Process::new_dummy(stack);
 
         // negate the top value
@@ -271,7 +271,7 @@ mod tests {
     fn op_mul() {
         // initialize the stack with a few values
         let (a, b, c) = get_rand_values();
-        let stack = StackInputs::try_from_values([c.as_int(), b.as_int(), a.as_int()]).unwrap();
+        let stack = StackInputs::try_from_ints([c.as_int(), b.as_int(), a.as_int()]).unwrap();
         let mut process = Process::new_dummy(stack);
 
         // add the top two values
@@ -291,7 +291,7 @@ mod tests {
     fn op_inv() {
         // initialize the stack with a few values
         let (a, b, c) = get_rand_values();
-        let stack = StackInputs::try_from_values([c.as_int(), b.as_int(), a.as_int()]).unwrap();
+        let stack = StackInputs::try_from_ints([c.as_int(), b.as_int(), a.as_int()]).unwrap();
         let mut process = Process::new_dummy(stack);
 
         // invert the top value
@@ -313,7 +313,7 @@ mod tests {
     fn op_incr() {
         // initialize the stack with a few values
         let (a, b, c) = get_rand_values();
-        let stack = StackInputs::try_from_values([c.as_int(), b.as_int(), a.as_int()]).unwrap();
+        let stack = StackInputs::try_from_ints([c.as_int(), b.as_int(), a.as_int()]).unwrap();
         let mut process = Process::new_dummy(stack);
 
         // negate the top value
@@ -331,7 +331,7 @@ mod tests {
     #[test]
     fn op_and() {
         // --- test 0 AND 0 ---------------------------------------------------
-        let stack = StackInputs::try_from_values([2, 0, 0]).unwrap();
+        let stack = StackInputs::try_from_ints([2, 0, 0]).unwrap();
         let mut process = Process::new_dummy(stack);
 
         process.execute_op(Operation::And).unwrap();
@@ -339,7 +339,7 @@ mod tests {
         assert_eq!(expected, process.stack.trace_state());
 
         // --- test 1 AND 0 ---------------------------------------------------
-        let stack = StackInputs::try_from_values([2, 0, 1]).unwrap();
+        let stack = StackInputs::try_from_ints([2, 0, 1]).unwrap();
         let mut process = Process::new_dummy(stack);
 
         process.execute_op(Operation::And).unwrap();
@@ -347,7 +347,7 @@ mod tests {
         assert_eq!(expected, process.stack.trace_state());
 
         // --- test 0 AND 1 ---------------------------------------------------
-        let stack = StackInputs::try_from_values([2, 1, 0]).unwrap();
+        let stack = StackInputs::try_from_ints([2, 1, 0]).unwrap();
         let mut process = Process::new_dummy(stack);
 
         process.execute_op(Operation::And).unwrap();
@@ -355,7 +355,7 @@ mod tests {
         assert_eq!(expected, process.stack.trace_state());
 
         // --- test 1 AND 1 ---------------------------------------------------
-        let stack = StackInputs::try_from_values([2, 1, 1]).unwrap();
+        let stack = StackInputs::try_from_ints([2, 1, 1]).unwrap();
         let mut process = Process::new_dummy(stack);
 
         process.execute_op(Operation::And).unwrap();
@@ -363,12 +363,12 @@ mod tests {
         assert_eq!(expected, process.stack.trace_state());
 
         // --- first operand is not binary ------------------------------------
-        let stack = StackInputs::try_from_values([2, 1, 2]).unwrap();
+        let stack = StackInputs::try_from_ints([2, 1, 2]).unwrap();
         let mut process = Process::new_dummy(stack);
         assert!(process.execute_op(Operation::And).is_err());
 
         // --- second operand is not binary -----------------------------------
-        let stack = StackInputs::try_from_values([2, 2, 1]).unwrap();
+        let stack = StackInputs::try_from_ints([2, 2, 1]).unwrap();
         let mut process = Process::new_dummy(stack);
         assert!(process.execute_op(Operation::And).is_err());
 
@@ -380,7 +380,7 @@ mod tests {
     #[test]
     fn op_or() {
         // --- test 0 OR 0 ---------------------------------------------------
-        let stack = StackInputs::try_from_values([2, 0, 0]).unwrap();
+        let stack = StackInputs::try_from_ints([2, 0, 0]).unwrap();
         let mut process = Process::new_dummy(stack);
 
         process.execute_op(Operation::Or).unwrap();
@@ -388,7 +388,7 @@ mod tests {
         assert_eq!(expected, process.stack.trace_state());
 
         // --- test 1 OR 0 ---------------------------------------------------
-        let stack = StackInputs::try_from_values([2, 0, 1]).unwrap();
+        let stack = StackInputs::try_from_ints([2, 0, 1]).unwrap();
         let mut process = Process::new_dummy(stack);
 
         process.execute_op(Operation::Or).unwrap();
@@ -396,7 +396,7 @@ mod tests {
         assert_eq!(expected, process.stack.trace_state());
 
         // --- test 0 OR 1 ---------------------------------------------------
-        let stack = StackInputs::try_from_values([2, 1, 0]).unwrap();
+        let stack = StackInputs::try_from_ints([2, 1, 0]).unwrap();
         let mut process = Process::new_dummy(stack);
 
         process.execute_op(Operation::Or).unwrap();
@@ -404,7 +404,7 @@ mod tests {
         assert_eq!(expected, process.stack.trace_state());
 
         // --- test 1 OR 0 ---------------------------------------------------
-        let stack = StackInputs::try_from_values([2, 1, 1]).unwrap();
+        let stack = StackInputs::try_from_ints([2, 1, 1]).unwrap();
         let mut process = Process::new_dummy(stack);
 
         process.execute_op(Operation::Or).unwrap();
@@ -412,12 +412,12 @@ mod tests {
         assert_eq!(expected, process.stack.trace_state());
 
         // --- first operand is not binary ------------------------------------
-        let stack = StackInputs::try_from_values([2, 1, 2]).unwrap();
+        let stack = StackInputs::try_from_ints([2, 1, 2]).unwrap();
         let mut process = Process::new_dummy(stack);
         assert!(process.execute_op(Operation::Or).is_err());
 
         // --- second operand is not binary -----------------------------------
-        let stack = StackInputs::try_from_values([2, 2, 1]).unwrap();
+        let stack = StackInputs::try_from_ints([2, 2, 1]).unwrap();
         let mut process = Process::new_dummy(stack);
         assert!(process.execute_op(Operation::Or).is_err());
 
@@ -429,21 +429,21 @@ mod tests {
     #[test]
     fn op_not() {
         // --- test NOT 0 -----------------------------------------------------
-        let stack = StackInputs::try_from_values([2, 0]).unwrap();
+        let stack = StackInputs::try_from_ints([2, 0]).unwrap();
         let mut process = Process::new_dummy(stack);
         process.execute_op(Operation::Not).unwrap();
         let expected = build_expected(&[ONE, Felt::new(2)]);
         assert_eq!(expected, process.stack.trace_state());
 
         // --- test NOT 1 ----------------------------------------------------
-        let stack = StackInputs::try_from_values([2, 1]).unwrap();
+        let stack = StackInputs::try_from_ints([2, 1]).unwrap();
         let mut process = Process::new_dummy(stack);
         process.execute_op(Operation::Not).unwrap();
         let expected = build_expected(&[ZERO, Felt::new(2)]);
         assert_eq!(expected, process.stack.trace_state());
 
         // --- operand is not binary ------------------------------------------
-        let stack = StackInputs::try_from_values([2, 2]).unwrap();
+        let stack = StackInputs::try_from_ints([2, 2]).unwrap();
         let mut process = Process::new_dummy(stack);
         assert!(process.execute_op(Operation::Not).is_err());
     }
@@ -455,7 +455,7 @@ mod tests {
     fn op_eq() {
         // --- test when top two values are equal -----------------------------
         let advice_inputs = AdviceInputs::default();
-        let stack_inputs = StackInputs::try_from_values([3, 7, 7]).unwrap();
+        let stack_inputs = StackInputs::try_from_ints([3, 7, 7]).unwrap();
         let mut process =
             Process::new_dummy_with_inputs_and_decoder_helpers(stack_inputs, advice_inputs);
 
@@ -465,7 +465,7 @@ mod tests {
 
         // --- test when top two values are not equal -------------------------
         let advice_inputs = AdviceInputs::default();
-        let stack_inputs = StackInputs::try_from_values([3, 5, 7]).unwrap();
+        let stack_inputs = StackInputs::try_from_ints([3, 5, 7]).unwrap();
         let mut process =
             Process::new_dummy_with_inputs_and_decoder_helpers(stack_inputs, advice_inputs);
 
@@ -485,7 +485,7 @@ mod tests {
     fn op_eqz() {
         // --- test when top is zero ------------------------------------------
         let advice_inputs = AdviceInputs::default();
-        let stack_inputs = StackInputs::try_from_values([3, 0]).unwrap();
+        let stack_inputs = StackInputs::try_from_ints([3, 0]).unwrap();
         let mut process =
             Process::new_dummy_with_inputs_and_decoder_helpers(stack_inputs, advice_inputs);
 
@@ -495,7 +495,7 @@ mod tests {
 
         // --- test when top is not zero --------------------------------------
         let advice_inputs = AdviceInputs::default();
-        let stack_inputs = StackInputs::try_from_values([3, 4]).unwrap();
+        let stack_inputs = StackInputs::try_from_ints([3, 4]).unwrap();
         let mut process =
             Process::new_dummy_with_inputs_and_decoder_helpers(stack_inputs, advice_inputs);
 
@@ -516,7 +516,7 @@ mod tests {
         let c = 4;
 
         let advice_inputs = AdviceInputs::default();
-        let stack_inputs = StackInputs::try_from_values([a, b, c, 0]).unwrap();
+        let stack_inputs = StackInputs::try_from_ints([a, b, c, 0]).unwrap();
         let mut process =
             Process::new_dummy_with_inputs_and_decoder_helpers(stack_inputs, advice_inputs);
 
@@ -531,7 +531,7 @@ mod tests {
         let c = 16;
 
         let advice_inputs = AdviceInputs::default();
-        let stack_inputs = StackInputs::try_from_values([a, b, c, 0]).unwrap();
+        let stack_inputs = StackInputs::try_from_ints([a, b, c, 0]).unwrap();
         let mut process =
             Process::new_dummy_with_inputs_and_decoder_helpers(stack_inputs, advice_inputs);
 
@@ -546,7 +546,7 @@ mod tests {
         let c = 625;
 
         let advice_inputs = AdviceInputs::default();
-        let stack_inputs = StackInputs::try_from_values([a, b, c, 0]).unwrap();
+        let stack_inputs = StackInputs::try_from_ints([a, b, c, 0]).unwrap();
         let mut process =
             Process::new_dummy_with_inputs_and_decoder_helpers(stack_inputs, advice_inputs);
 

--- a/processor/src/operations/fri_ops.rs
+++ b/processor/src/operations/fri_ops.rs
@@ -321,7 +321,7 @@ mod tests {
         ];
 
         // --- execute FRIE2F4 operation --------------------------------------
-        let stack_inputs = StackInputs::new(inputs.to_vec());
+        let stack_inputs = StackInputs::new(inputs.to_vec()).expect("inputs lenght too long");
         let mut process = Process::new_dummy_with_decoder_helpers(stack_inputs);
         process.execute_op(Operation::FriE2F4).unwrap();
 

--- a/processor/src/operations/stack_ops.rs
+++ b/processor/src/operations/stack_ops.rs
@@ -414,7 +414,7 @@ mod tests {
     #[test]
     fn op_swap() {
         // push a few items onto the stack
-        let stack = StackInputs::try_from_values([1, 2, 3]).unwrap();
+        let stack = StackInputs::try_from_ints([1, 2, 3]).unwrap();
         let mut process = Process::new_dummy(stack);
 
         process.execute_op(Operation::Swap).unwrap();
@@ -430,7 +430,7 @@ mod tests {
     #[test]
     fn op_swapw() {
         // push a few items onto the stack
-        let stack = StackInputs::try_from_values([1, 2, 3, 4, 5, 6, 7, 8, 9]).unwrap();
+        let stack = StackInputs::try_from_ints([1, 2, 3, 4, 5, 6, 7, 8, 9]).unwrap();
         let mut process = Process::new_dummy(stack);
 
         process.execute_op(Operation::SwapW).unwrap();
@@ -447,7 +447,7 @@ mod tests {
     fn op_swapw2() {
         // push a few items onto the stack
         let stack =
-            StackInputs::try_from_values([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]).unwrap();
+            StackInputs::try_from_ints([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]).unwrap();
         let mut process = Process::new_dummy(stack);
 
         process.execute_op(Operation::SwapW2).unwrap();
@@ -463,10 +463,9 @@ mod tests {
     #[test]
     fn op_swapw3() {
         // push a few items onto the stack
-        let stack = StackInputs::try_from_values([
-            1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
-        ])
-        .unwrap();
+        let stack =
+            StackInputs::try_from_ints([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17])
+                .unwrap();
         let mut process = Process::new_dummy(stack);
 
         process.execute_op(Operation::SwapW3).unwrap();
@@ -487,7 +486,7 @@ mod tests {
     fn op_movup() {
         // push a few items onto the stack
         let stack =
-            StackInputs::try_from_values([16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1])
+            StackInputs::try_from_ints([16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1])
                 .unwrap();
         let mut process = Process::new_dummy(stack);
 
@@ -520,7 +519,7 @@ mod tests {
     fn op_movdn() {
         // push a few items onto the stack
         let stack =
-            StackInputs::try_from_values([16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1])
+            StackInputs::try_from_ints([16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1])
                 .unwrap();
         let mut process = Process::new_dummy(stack);
 
@@ -552,7 +551,7 @@ mod tests {
     #[test]
     fn op_cswap() {
         // push a few items onto the stack
-        let stack = StackInputs::try_from_values([4, 3, 2, 1, 0]).unwrap();
+        let stack = StackInputs::try_from_ints([4, 3, 2, 1, 0]).unwrap();
         let mut process = Process::new_dummy(stack);
 
         // no swap (top of the stack is 0)
@@ -576,7 +575,7 @@ mod tests {
     #[test]
     fn op_cswapw() {
         // push a few items onto the stack
-        let stack = StackInputs::try_from_values([11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0]).unwrap();
+        let stack = StackInputs::try_from_ints([11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0]).unwrap();
         let mut process = Process::new_dummy(stack);
 
         // no swap (top of the stack is 0)

--- a/processor/src/operations/sys_ops.rs
+++ b/processor/src/operations/sys_ops.rs
@@ -158,18 +158,18 @@ mod tests {
         assert!(process.execute_op(Operation::FmpUpdate).is_err());
 
         // going up to the max fmp value should be OK
-        let stack = StackInputs::try_from_values([MAX_PROC_LOCALS]).unwrap();
+        let stack = StackInputs::try_from_ints([MAX_PROC_LOCALS]).unwrap();
         let mut process = Process::new_dummy(stack);
         process.execute_op(Operation::FmpUpdate).unwrap();
         assert_eq!(Felt::new(FMP_MAX), process.system.fmp());
 
         // but going beyond that should be an error
-        let stack = StackInputs::try_from_values([MAX_PROC_LOCALS + 1]).unwrap();
+        let stack = StackInputs::try_from_ints([MAX_PROC_LOCALS + 1]).unwrap();
         let mut process = Process::new_dummy(stack);
         assert!(process.execute_op(Operation::FmpUpdate).is_err());
 
         // should not affect the rest of the stack state
-        let stack = StackInputs::try_from_values([2, 3]).unwrap();
+        let stack = StackInputs::try_from_ints([2, 3]).unwrap();
         let mut process = Process::new_dummy(stack);
         process.execute_op(Operation::FmpUpdate).unwrap();
 

--- a/processor/src/operations/u32_ops.rs
+++ b/processor/src/operations/u32_ops.rs
@@ -247,7 +247,7 @@ mod tests {
     fn op_u32split() {
         // --- test a random value ---------------------------------------------
         let a: u64 = rand_value();
-        let stack = StackInputs::try_from_values([a]).unwrap();
+        let stack = StackInputs::try_from_ints([a]).unwrap();
         let mut process = Process::new_dummy_with_decoder_helpers(stack);
         let hi = a >> 32;
         let lo = (a as u32) as u64;
@@ -260,7 +260,7 @@ mod tests {
 
         // --- test the rest of the stack is not modified -----------------------
         let b: u64 = rand_value();
-        let stack = StackInputs::try_from_values([a, b]).unwrap();
+        let stack = StackInputs::try_from_ints([a, b]).unwrap();
         let mut process = Process::new_dummy_with_decoder_helpers(stack);
         let hi = b >> 32;
         let lo = (b as u32) as u64;
@@ -277,7 +277,7 @@ mod tests {
     fn op_u32assert2() {
         // --- test random values ensuring other elements are still values are still intact ----------
         let (a, b, c, d) = get_rand_values();
-        let stack = StackInputs::try_from_values([d as u64, c as u64, b as u64, a as u64]).unwrap();
+        let stack = StackInputs::try_from_ints([d as u64, c as u64, b as u64, a as u64]).unwrap();
         let mut process = Process::new_dummy_with_decoder_helpers(stack);
 
         process.execute_op(Operation::U32assert2(ZERO)).unwrap();
@@ -292,7 +292,7 @@ mod tests {
     fn op_u32add() {
         // --- test random values ---------------------------------------------
         let (a, b, c, d) = get_rand_values();
-        let stack = StackInputs::try_from_values([d as u64, c as u64, b as u64, a as u64]).unwrap();
+        let stack = StackInputs::try_from_ints([d as u64, c as u64, b as u64, a as u64]).unwrap();
         let mut process = Process::new_dummy_with_decoder_helpers(stack);
         let (result, over) = a.overflowing_add(b);
 
@@ -304,7 +304,7 @@ mod tests {
         let a = u32::MAX - 1;
         let b = 2u32;
 
-        let stack = StackInputs::try_from_values([a as u64, b as u64]).unwrap();
+        let stack = StackInputs::try_from_ints([a as u64, b as u64]).unwrap();
         let mut process = Process::new_dummy_with_decoder_helpers(stack);
         let (result, over) = a.overflowing_add(b);
         let (b1, b0) = split_u32_into_u16(result.into());
@@ -325,7 +325,7 @@ mod tests {
         let c = rand_value::<u32>() as u64;
         let d = rand_value::<u32>() as u64;
 
-        let stack = StackInputs::try_from_values([d, c, b, a]).unwrap();
+        let stack = StackInputs::try_from_ints([d, c, b, a]).unwrap();
         let mut process = Process::new_dummy_with_decoder_helpers(stack);
 
         let result = a + b + c;
@@ -346,7 +346,7 @@ mod tests {
     fn op_u32sub() {
         // --- test random values ---------------------------------------------
         let (a, b, c, d) = get_rand_values();
-        let stack = StackInputs::try_from_values([d as u64, c as u64, b as u64, a as u64]).unwrap();
+        let stack = StackInputs::try_from_ints([d as u64, c as u64, b as u64, a as u64]).unwrap();
         let mut process = Process::new_dummy_with_decoder_helpers(stack);
         let (result, under) = b.overflowing_sub(a);
 
@@ -358,7 +358,7 @@ mod tests {
         let a = 10u32;
         let b = 11u32;
 
-        let stack = StackInputs::try_from_values([a as u64, b as u64]).unwrap();
+        let stack = StackInputs::try_from_ints([a as u64, b as u64]).unwrap();
         let mut process = Process::new_dummy_with_decoder_helpers(stack);
         let (result, under) = a.overflowing_sub(b);
 
@@ -370,7 +370,7 @@ mod tests {
     #[test]
     fn op_u32mul() {
         let (a, b, c, d) = get_rand_values();
-        let stack = StackInputs::try_from_values([d as u64, c as u64, b as u64, a as u64]).unwrap();
+        let stack = StackInputs::try_from_ints([d as u64, c as u64, b as u64, a as u64]).unwrap();
         let mut process = Process::new_dummy_with_decoder_helpers(stack);
         let result = (a as u64) * (b as u64);
         let hi = (result >> 32) as u32;
@@ -384,7 +384,7 @@ mod tests {
     #[test]
     fn op_u32madd() {
         let (a, b, c, d) = get_rand_values();
-        let stack = StackInputs::try_from_values([d as u64, c as u64, b as u64, a as u64]).unwrap();
+        let stack = StackInputs::try_from_ints([d as u64, c as u64, b as u64, a as u64]).unwrap();
         let mut process = Process::new_dummy_with_decoder_helpers(stack);
         let result = (a as u64) * (b as u64) + (c as u64);
         let hi = (result >> 32) as u32;
@@ -402,7 +402,7 @@ mod tests {
     #[test]
     fn op_u32div() {
         let (a, b, c, d) = get_rand_values();
-        let stack = StackInputs::try_from_values([d as u64, c as u64, b as u64, a as u64]).unwrap();
+        let stack = StackInputs::try_from_ints([d as u64, c as u64, b as u64, a as u64]).unwrap();
         let mut process = Process::new_dummy_with_decoder_helpers(stack);
         let q = b / a;
         let r = b % a;
@@ -418,7 +418,7 @@ mod tests {
     #[test]
     fn op_u32and() {
         let (a, b, c, d) = get_rand_values();
-        let stack = StackInputs::try_from_values([d as u64, c as u64, b as u64, a as u64]).unwrap();
+        let stack = StackInputs::try_from_ints([d as u64, c as u64, b as u64, a as u64]).unwrap();
         let mut process = Process::new_dummy_with_decoder_helpers(stack);
 
         process.execute_op(Operation::U32and).unwrap();
@@ -433,7 +433,7 @@ mod tests {
     #[test]
     fn op_u32xor() {
         let (a, b, c, d) = get_rand_values();
-        let stack = StackInputs::try_from_values([d as u64, c as u64, b as u64, a as u64]).unwrap();
+        let stack = StackInputs::try_from_ints([d as u64, c as u64, b as u64, a as u64]).unwrap();
         let mut process = Process::new_dummy_with_decoder_helpers(stack);
 
         process.execute_op(Operation::U32xor).unwrap();

--- a/processor/src/stack/tests.rs
+++ b/processor/src/stack/tests.rs
@@ -19,7 +19,7 @@ type StackHelpersState = [Felt; NUM_STACK_HELPER_COLS];
 fn initialize() {
     // initialize a new stack with some initial values
     let mut stack_inputs = [1, 2, 3, 4];
-    let stack = StackInputs::try_from_values(stack_inputs).unwrap();
+    let stack = StackInputs::try_from_ints(stack_inputs).unwrap();
     let stack = Stack::new(&stack, 4, false);
 
     // Prepare the expected results.
@@ -38,7 +38,7 @@ fn initialize() {
 fn initialize_overflow() {
     // Initialize a new stack with enough initial values that the overflow table is non-empty.
     let mut stack_inputs = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19];
-    let stack = StackInputs::try_from_values(stack_inputs).unwrap();
+    let stack = StackInputs::try_from_ints(stack_inputs).unwrap();
     let stack = Stack::new(&stack, 4, false);
 
     // Prepare the expected results.
@@ -75,7 +75,7 @@ fn initialize_overflow() {
 #[test]
 fn shift_left() {
     let stack_inputs = [1, 2, 3, 4];
-    let stack_inputs = StackInputs::try_from_values(stack_inputs).unwrap();
+    let stack_inputs = StackInputs::try_from_ints(stack_inputs).unwrap();
     let mut stack = Stack::new(&stack_inputs, 4, false);
 
     // ---- left shift an entire stack of minimum depth -------------------------------------------
@@ -127,7 +127,7 @@ fn shift_left() {
 #[test]
 fn shift_right() {
     let stack_inputs = [1, 2, 3, 4];
-    let stack_inputs = StackInputs::try_from_values(stack_inputs).unwrap();
+    let stack_inputs = StackInputs::try_from_ints(stack_inputs).unwrap();
     let mut stack = Stack::new(&stack_inputs, 4, false);
 
     // make sure the first right shift is not executed at clk = 0
@@ -167,7 +167,7 @@ fn shift_right() {
 #[test]
 fn start_restore_context() {
     let stack_init = (0..16).map(|v| v as u64 + 1);
-    let stack = StackInputs::try_from_values(stack_init).unwrap();
+    let stack = StackInputs::try_from_ints(stack_init).unwrap();
     let mut stack = Stack::new(&stack, 8, false);
 
     // ----- when overflow table is empty -------------------------------------
@@ -205,7 +205,7 @@ fn start_restore_context() {
 
     // ----- when overflow table is not empty ---------------------------------
     let stack_init = (0..16).map(|v| v as u64 + 1);
-    let stack = StackInputs::try_from_values(stack_init.clone()).unwrap();
+    let stack = StackInputs::try_from_ints(stack_init.clone()).unwrap();
     let mut stack = Stack::new(&stack, 8, false);
 
     let mut stack_state = stack_init.collect::<Vec<_>>();
@@ -279,7 +279,7 @@ fn start_restore_context() {
 #[test]
 fn generate_trace() {
     let stack_inputs = [1, 2, 3, 4];
-    let stack_inputs = StackInputs::try_from_values(stack_inputs).unwrap();
+    let stack_inputs = StackInputs::try_from_ints(stack_inputs).unwrap();
     let mut stack = Stack::new(&stack_inputs, 16, false);
 
     // clk = 0

--- a/processor/src/trace/tests/chiplets/hasher.rs
+++ b/processor/src/trace/tests/chiplets/hasher.rs
@@ -422,7 +422,7 @@ fn b_chip_mpverify() {
         leaves[index][2].as_int(),
         leaves[index][3].as_int(),
     ];
-    let stack_inputs = StackInputs::try_from_values(stack_inputs).unwrap();
+    let stack_inputs = StackInputs::try_from_ints(stack_inputs).unwrap();
     let store = MerkleStore::from(&tree);
     let advice_inputs = AdviceInputs::default().with_merkle_store(store);
 
@@ -568,7 +568,7 @@ fn b_chip_mrupdate() {
         old_leaf_value[2].as_int(),
         old_leaf_value[3].as_int(),
     ];
-    let stack_inputs = StackInputs::try_from_values(stack_inputs).unwrap();
+    let stack_inputs = StackInputs::try_from_ints(stack_inputs).unwrap();
     let store = MerkleStore::from(&tree);
     let advice_inputs = AdviceInputs::default().with_merkle_store(store);
 

--- a/processor/src/trace/tests/hasher.rs
+++ b/processor/src/trace/tests/hasher.rs
@@ -28,7 +28,7 @@ fn hasher_p1_mp_verify() {
     init_stack.extend_from_slice(&[3, 1]);
     append_word(&mut init_stack, tree.root().into());
     init_stack.reverse();
-    let stack_inputs = StackInputs::try_from_values(init_stack).unwrap();
+    let stack_inputs = StackInputs::try_from_ints(init_stack).unwrap();
     let advice_inputs = AdviceInputs::default().with_merkle_store(store);
 
     // build execution trace and extract the sibling table column from it
@@ -62,7 +62,7 @@ fn hasher_p1_mr_update() {
     append_word(&mut init_stack, new_node);
 
     init_stack.reverse();
-    let stack_inputs = StackInputs::try_from_values(init_stack).unwrap();
+    let stack_inputs = StackInputs::try_from_ints(init_stack).unwrap();
     let store = MerkleStore::from(&tree);
     let advice_inputs = AdviceInputs::default().with_merkle_store(store);
 

--- a/processor/src/trace/tests/mod.rs
+++ b/processor/src/trace/tests/mod.rs
@@ -22,7 +22,7 @@ mod stack;
 
 /// Builds a sample trace by executing the provided code block against the provided stack inputs.
 pub fn build_trace_from_block(program: &CodeBlock, stack_inputs: &[u64]) -> ExecutionTrace {
-    let stack_inputs = StackInputs::try_from_values(stack_inputs.iter().copied()).unwrap();
+    let stack_inputs = StackInputs::try_from_ints(stack_inputs.iter().copied()).unwrap();
     let host = DefaultHost::default();
     let mut process =
         Process::new(Kernel::default(), stack_inputs, host, ExecutionOptions::default());

--- a/stdlib/tests/crypto/falcon.rs
+++ b/stdlib/tests/crypto/falcon.rs
@@ -31,8 +31,7 @@ fn falcon_prove_verify() {
         .compile(source)
         .expect("failed to compile test source");
 
-    let stack_inputs =
-        StackInputs::try_from_values(op_stack).expect("failed to create stack inputs");
+    let stack_inputs = StackInputs::try_from_ints(op_stack).expect("failed to create stack inputs");
     let advice_inputs = AdviceInputs::default().with_map(advice_map);
     let advice_provider = MemAdviceProvider::from(advice_inputs);
     let host = DefaultHost::new(advice_provider);

--- a/stdlib/tests/crypto/stark/mod.rs
+++ b/stdlib/tests/crypto/stark/mod.rs
@@ -51,7 +51,7 @@ pub fn generate_recursive_verifier_data(
     stack_inputs: Vec<u64>,
 ) -> Result<VerifierData, VerifierError> {
     let program = Assembler::default().compile(source).unwrap();
-    let stack_inputs = StackInputs::try_from_values(stack_inputs).unwrap();
+    let stack_inputs = StackInputs::try_from_ints(stack_inputs).unwrap();
     let advice_inputs = AdviceInputs::default();
     let advice_provider = MemAdviceProvider::from(advice_inputs);
     let host = DefaultHost::new(advice_provider);

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -244,7 +244,7 @@ impl Test {
     /// using the given public inputs and the specified number of stack outputs. When `test_fail`
     /// is true, this function will force a failure by modifying the first output.
     pub fn prove_and_verify(&self, pub_inputs: Vec<u64>, test_fail: bool) {
-        let stack_inputs = StackInputs::try_from_values(pub_inputs).unwrap();
+        let stack_inputs = StackInputs::try_from_ints(pub_inputs).unwrap();
         let program = self.compile().expect("Failed to compile test source.");
         let host = DefaultHost::new(MemAdviceProvider::from(self.advice_inputs.clone()));
         let (mut stack_outputs, proof) =

--- a/test-utils/src/test_builders.rs
+++ b/test-utils/src/test_builders.rs
@@ -82,7 +82,7 @@ macro_rules! build_test_by_mode {
     }};
     ($in_debug_mode:expr, $source:expr, $stack_inputs:expr) => {{
         let stack_inputs: Vec<u64> = $stack_inputs.to_vec();
-        let stack_inputs = $crate::StackInputs::try_from_values(stack_inputs).unwrap();
+        let stack_inputs = $crate::StackInputs::try_from_ints(stack_inputs).unwrap();
         let advice_inputs = $crate::AdviceInputs::default();
 
         $crate::Test {
@@ -98,7 +98,7 @@ macro_rules! build_test_by_mode {
         $in_debug_mode:expr, $source:expr, $stack_inputs:expr, $advice_stack:expr
     ) => {{
         let stack_inputs: Vec<u64> = $stack_inputs.to_vec();
-        let stack_inputs = $crate::StackInputs::try_from_values(stack_inputs).unwrap();
+        let stack_inputs = $crate::StackInputs::try_from_ints(stack_inputs).unwrap();
         let stack_values: Vec<u64> = $advice_stack.to_vec();
         let store = $crate::crypto::MerkleStore::new();
         let advice_inputs = $crate::AdviceInputs::default()
@@ -119,7 +119,7 @@ macro_rules! build_test_by_mode {
         $in_debug_mode:expr, $source:expr, $stack_inputs:expr, $advice_stack:expr, $advice_merkle_store:expr
     ) => {{
         let stack_inputs: Vec<u64> = $stack_inputs.to_vec();
-        let stack_inputs = $crate::StackInputs::try_from_values(stack_inputs).unwrap();
+        let stack_inputs = $crate::StackInputs::try_from_ints(stack_inputs).unwrap();
         let stack_values: Vec<u64> = $advice_stack.to_vec();
         let advice_inputs = $crate::AdviceInputs::default()
             .with_stack_values(stack_values)
@@ -137,7 +137,7 @@ macro_rules! build_test_by_mode {
     }};
     ($in_debug_mode:expr, $source:expr, $stack_inputs:expr, $advice_stack:expr, $advice_merkle_store:expr, $advice_map:expr) => {{
         let stack_inputs: Vec<u64> = $stack_inputs.to_vec();
-        let stack_inputs = $crate::StackInputs::try_from_values(stack_inputs).unwrap();
+        let stack_inputs = $crate::StackInputs::try_from_ints(stack_inputs).unwrap();
         let stack_values: Vec<u64> = $advice_stack.to_vec();
         let advice_inputs = $crate::AdviceInputs::default()
             .with_stack_values(stack_values)


### PR DESCRIPTION
This PR changes the serialization and deserialization method of `usize` values to `write_usize()` and `read_usize()` respectively. 
