### PR TITLE
Update `StackOutputs` fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 #### VM Internals
 - Removed unused `find_lone_leaf()` function from the Advice Provider (#1262).
+- Changed fields type of the `StackOutputs` struct from `Vec<u64>` to `Vec<Felt>` (#1268).
 
 ## 0.8.0 (02-26-2024)
 

--- a/core/src/errors.rs
+++ b/core/src/errors.rs
@@ -32,9 +32,9 @@ impl std::error::Error for InputError {}
 
 #[derive(Clone, Debug)]
 pub enum OutputError {
-    InvalidOverflowAddress(u64),
+    InvalidOverflowAddress(String),
     InvalidOverflowAddressLength(usize, usize),
-    InvalidStackElement(u64),
+    InvalidStackElement(String),
     OutputSizeTooBig(usize),
 }
 
@@ -42,14 +42,14 @@ impl fmt::Display for OutputError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use OutputError::*;
         match self {
-            InvalidOverflowAddress(address) => {
-                write!(f, "overflow addresses contains {address} that is not a valid field element")
+            InvalidOverflowAddress(description) => {
+                write!(f, "overflow addresses contains invalid field element: {description}")
             }
             InvalidOverflowAddressLength(actual, expected) => {
                 write!(f, "overflow addresses length is {actual}, but expected {expected}")
             }
-            InvalidStackElement(element) => {
-                write!(f, "stack contains {element} that is not a valid field element")
+            InvalidStackElement(description) => {
+                write!(f, "stack contains an invalid field element: {description}")
             }
             OutputSizeTooBig(size) => {
                 write!(f, "too many elements for output stack, {size} elements")

--- a/core/src/stack/inputs.rs
+++ b/core/src/stack/inputs.rs
@@ -19,7 +19,7 @@ impl StackInputs {
     // CONSTRUCTORS
     // --------------------------------------------------------------------------------------------
 
-    /// Returns `[StackInputs]` from a list of values, reversing them into a stack.
+    /// Returns [StackInputs] from a list of values, reversing them into a stack.
     pub fn new(mut values: Vec<Felt>) -> Self {
         values.reverse();
         Self { values }

--- a/core/src/stack/mod.rs
+++ b/core/src/stack/mod.rs
@@ -1,6 +1,6 @@
 use super::{
     errors::{InputError, OutputError},
-    Felt, StackTopState, StarkField, ToElements,
+    Felt, StackTopState, ToElements,
 };
 use crate::utils::{ByteWriter, Serializable};
 

--- a/miden/README.md
+++ b/miden/README.md
@@ -106,7 +106,7 @@ let (outputs, proof) = prove(
 .unwrap();
 
 // the output should be 8
-assert_eq!(Some(&8), outputs.stack().first());
+assert_eq!(8, outputs.stack().first().unwrap().as_int());
 ```
 
 ### Verifying program execution
@@ -196,7 +196,7 @@ let (outputs, proof) = miden_vm::prove(
 let stack = outputs.stack_truncated(1);
 
 // the output should be the 50th Fibonacci number
-assert_eq!(&[12586269025], stack);
+assert_eq!(12586269025, stack[0].as_int());
 ```
 Above, we used public inputs to initialize the stack rather than using `push` operations. This makes the program a bit simpler, and also allows us to run the program from arbitrary starting points without changing program hash.
 

--- a/miden/src/cli/data.rs
+++ b/miden/src/cli/data.rs
@@ -368,7 +368,7 @@ impl OutputFile {
             .map(|v| v.parse::<u64>().unwrap())
             .collect::<Vec<u64>>();
 
-        StackOutputs::new(stack, overflow_addrs)
+        StackOutputs::try_from_ints(stack, overflow_addrs)
             .map_err(|e| format!("Construct stack outputs failed {e}"))
     }
 }

--- a/miden/src/examples/blake3.rs
+++ b/miden/src/examples/blake3.rs
@@ -1,7 +1,7 @@
 use super::Example;
 use miden_vm::{Assembler, DefaultHost, MemAdviceProvider, Program, StackInputs};
 use stdlib::StdLibrary;
-use vm_core::utils::group_slice_elements;
+use vm_core::{utils::group_slice_elements, Felt};
 
 // CONSTANTS
 // ================================================================================================
@@ -52,7 +52,7 @@ fn generate_blake3_program(n: usize) -> Program {
 }
 
 /// Computes the `n`-th hash of blake3 1-to-1 hash chain
-fn compute_hash_chain(n: usize) -> Vec<u64> {
+fn compute_hash_chain(n: usize) -> Vec<Felt> {
     let mut bytes: [u8; 32] = INITIAL_HASH_VALUE
         .iter()
         .flat_map(|v| v.to_le_bytes())
@@ -67,8 +67,8 @@ fn compute_hash_chain(n: usize) -> Vec<u64> {
 
     group_slice_elements::<u8, 4>(&bytes)
         .iter()
-        .map(|&bytes| u32::from_le_bytes(bytes) as u64)
-        .collect::<Vec<u64>>()
+        .map(|&bytes| Felt::from(u32::from_le_bytes(bytes)))
+        .collect::<Vec<Felt>>()
 }
 
 // EXAMPLE TESTER

--- a/miden/src/examples/fibonacci.rs
+++ b/miden/src/examples/fibonacci.rs
@@ -7,7 +7,7 @@ use miden_vm::{math::Felt, Assembler, DefaultHost, MemAdviceProvider, Program, S
 pub fn get_example(n: usize) -> Example<DefaultHost<MemAdviceProvider>> {
     // generate the program and expected results
     let program = generate_fibonacci_program(n);
-    let expected_result = vec![compute_fibonacci(n).as_int()];
+    let expected_result = vec![compute_fibonacci(n)];
     println!(
         "Generated a program to compute {}-th Fibonacci term; expected result: {}",
         n, expected_result[0]

--- a/miden/src/examples/mod.rs
+++ b/miden/src/examples/mod.rs
@@ -1,6 +1,6 @@
 use clap::Parser;
 use miden_vm::{ExecutionProof, Host, Program, ProgramInfo, ProvingOptions, StackInputs};
-use processor::{ExecutionOptions, ExecutionOptionsError, ONE, ZERO};
+use processor::{ExecutionOptions, ExecutionOptionsError, Felt, ONE, ZERO};
 
 use std::time::Instant;
 
@@ -18,7 +18,7 @@ where
     pub stack_inputs: StackInputs,
     pub host: H,
     pub num_outputs: usize,
-    pub expected_result: Vec<u64>,
+    pub expected_result: Vec<Felt>,
 }
 
 // EXAMPLE OPTIONS
@@ -170,7 +170,7 @@ where
     let program_info = ProgramInfo::new(program.hash(), kernel);
 
     if fail {
-        outputs.stack_mut()[0] += 1;
+        outputs.stack_mut()[0] += ONE;
         assert!(miden_vm::verify(program_info, stack_inputs, outputs, proof).is_err())
     } else {
         assert!(miden_vm::verify(program_info, stack_inputs, outputs, proof).is_ok());

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -13,7 +13,7 @@ use miden_air::trace::{
 pub use miden_air::{ExecutionOptions, ExecutionOptionsError};
 pub use vm_core::{
     chiplets::hasher::Digest, crypto::merkle::SMT_DEPTH, errors::InputError,
-    utils::DeserializationError, AdviceInjector, AssemblyOp, Kernel, Operation, Program,
+    utils::DeserializationError, AdviceInjector, AssemblyOp, Felt, Kernel, Operation, Program,
     ProgramInfo, QuadExtension, StackInputs, StackOutputs, Word, EMPTY_WORD, ONE, ZERO,
 };
 use vm_core::{
@@ -21,7 +21,7 @@ use vm_core::{
         Call, CodeBlock, Dyn, Join, Loop, OpBatch, Span, Split, OP_BATCH_SIZE, OP_GROUP_SIZE,
     },
     utils::collections::*,
-    CodeBlockTable, Decorator, DecoratorIterator, Felt, FieldElement, StackTopState,
+    CodeBlockTable, Decorator, DecoratorIterator, FieldElement, StackTopState,
 };
 
 pub use winter_prover::matrix::ColMatrix;

--- a/processor/src/stack/mod.rs
+++ b/processor/src/stack/mod.rs
@@ -143,7 +143,7 @@ impl Stack {
         let mut stack_items = Vec::with_capacity(self.active_depth);
         self.trace.append_state_into(&mut stack_items, self.clk);
         self.overflow.append_into(&mut stack_items);
-        StackOutputs::from_elements(stack_items, self.overflow.get_addrs())
+        StackOutputs::new(stack_items, self.overflow.get_addrs())
             .expect("processor stack handling logic is valid")
     }
 

--- a/prover/README.md
+++ b/prover/README.md
@@ -36,7 +36,7 @@ let (outputs, proof) = prove(
 .unwrap();
 
 // the output should be 8
-assert_eq!(Some(&8), outputs.stack().first());
+assert_eq!(8, outputs.stack().first().unwrap().as_int());
 ```
 
 ## Crate features

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -252,7 +252,7 @@ impl Test {
 
         let program_info = ProgramInfo::from(program);
         if test_fail {
-            stack_outputs.stack_mut()[0] += 1;
+            stack_outputs.stack_mut()[0] += ONE;
             assert!(verifier::verify(program_info, stack_inputs, stack_outputs, proof).is_err());
         } else {
             let result = verifier::verify(program_info, stack_inputs, stack_outputs, proof);


### PR DESCRIPTION
This PR updates the fields of `StackOutputs` struct. 
It changes them from `Vec<u64>` to `Vec<Felt>` to make them consistent with the stack values. 
