### PR TITLE
miden-vm: match the crate with the package name. Fix #1270

### DIFF
--- a/miden/Cargo.toml
+++ b/miden/Cargo.toml
@@ -20,7 +20,6 @@ doctest = false
 required-features = ["executable"]
 
 [lib]
-name = "miden"
 path = "src/lib.rs"
 bench = false
 doctest = false

--- a/miden/README.md
+++ b/miden/README.md
@@ -42,7 +42,7 @@ The `execute_iter()` function takes similar arguments (but without the `options`
 
 For example:
 ```rust
-use miden::{Assembler, execute, execute_iter, DefaultHost, StackInputs};
+use miden_vm::{Assembler, execute, execute_iter, DefaultHost, StackInputs};
 use processor::ExecutionOptions;
 
 // instantiate the assembler
@@ -88,7 +88,7 @@ If the program is executed successfully, the function returns a tuple with 2 ele
 #### Proof generation example
 Here is a simple example of executing a program which pushes two numbers onto the stack and computes their sum:
 ```rust
-use miden::{Assembler, DefaultHost, ProvingOptions, prove, StackInputs};
+use miden_vm::{Assembler, DefaultHost, ProvingOptions, prove, StackInputs};
 
 // instantiate the assembler
 let assembler = Assembler::default();
@@ -136,7 +136,7 @@ let program =   /* value from previous example */;
 let proof =     /* value from previous example */;
 
 // let's verify program execution
-match miden::verify(program.hash(), StackInputs::default(), &[8], proof) {
+match miden_vm::verify(program.hash(), StackInputs::default(), &[8], proof) {
     Ok(_) => println!("Execution verified!"),
     Err(msg) => println!("Something went terribly wrong: {}", msg),
 }
@@ -160,7 +160,7 @@ add         // stack state: 3 2
 ```
 Notice that except for the first 2 operations which initialize the stack, the sequence of `swap dup.1 add` operations repeats over and over. In fact, we can repeat these operations an arbitrary number of times to compute an arbitrary Fibonacci number. In Rust, it would look like this (this is actually a simplified version of the example in [fibonacci.rs](src/examples/src/fibonacci.rs)):
 ```rust
-use miden::{Assembler, DefaultHost, ProvingOptions, StackInputs};
+use miden_vm::{Assembler, DefaultHost, ProvingOptions, StackInputs};
 
 // set the number of terms to compute
 let n = 50;
@@ -184,7 +184,7 @@ let host = DefaultHost::default();
 let stack_inputs = StackInputs::try_from_values([0, 1]).unwrap();
 
 // execute the program
-let (outputs, proof) = miden::prove(
+let (outputs, proof) = miden_vm::prove(
     &program,
     stack_inputs,
     host,

--- a/miden/benches/program_execution.rs
+++ b/miden/benches/program_execution.rs
@@ -1,5 +1,5 @@
 use criterion::{criterion_group, criterion_main, Criterion};
-use miden::{execute, Assembler, DefaultHost, StackInputs};
+use miden_vm::{execute, Assembler, DefaultHost, StackInputs};
 use processor::ExecutionOptions;
 use std::time::Duration;
 use stdlib::StdLibrary;

--- a/miden/src/cli/data.rs
+++ b/miden/src/cli/data.rs
@@ -1,5 +1,5 @@
 use assembly::{Library, MaslLibrary};
-use miden::{
+use miden_vm::{
     crypto::{MerkleStore, MerkleTree, NodeIndex, PartialMerkleTree, RpoDigest, SimpleSmt},
     math::Felt,
     utils::{Deserializable, SliceReader},
@@ -324,7 +324,7 @@ impl OutputFile {
     }
 
     /// Read the output file
-    #[instrument(name = "read_output_file", 
+    #[instrument(name = "read_output_file",
         fields(path = %outputs_path.clone().unwrap_or(program_path.with_extension("outputs")).display()), skip_all)]
     pub fn read(outputs_path: &Option<PathBuf>, program_path: &Path) -> Result<Self, String> {
         // If outputs_path has been provided then use this as path.  Alternatively we will
@@ -449,7 +449,7 @@ pub struct ProofFile;
 /// Helper methods to interact with proof file
 impl ProofFile {
     /// Read stark proof from file
-    #[instrument(name = "read_proof_file", 
+    #[instrument(name = "read_proof_file",
         fields(path = %proof_path.clone().unwrap_or(program_path.with_extension("proof")).display()), skip_all)]
     pub fn read(
         proof_path: &Option<PathBuf>,
@@ -472,9 +472,9 @@ impl ProofFile {
     }
 
     /// Write stark proof to file
-    #[instrument(name = "write_data_to_proof_file", 
+    #[instrument(name = "write_data_to_proof_file",
                  fields(
-                    path = %proof_path.clone().unwrap_or(program_path.with_extension("proof")).display(), 
+                    path = %proof_path.clone().unwrap_or(program_path.with_extension("proof")).display(),
                     size = format!("{} KB", proof.to_bytes().len() / 1024)), skip_all)]
     pub fn write(
         proof: ExecutionProof,

--- a/miden/src/cli/debug/executor.rs
+++ b/miden/src/cli/debug/executor.rs
@@ -1,5 +1,5 @@
 use super::DebugCommand;
-use miden::{
+use miden_vm::{
     math::Felt, DefaultHost, MemAdviceProvider, Program, StackInputs, VmState, VmStateIterator,
 };
 

--- a/miden/src/cli/prove.rs
+++ b/miden/src/cli/prove.rs
@@ -1,6 +1,6 @@
 use super::data::{instrument, Debug, InputFile, Libraries, OutputFile, ProgramFile, ProofFile};
 use clap::Parser;
-use miden::ProvingOptions;
+use miden_vm::ProvingOptions;
 use processor::{DefaultHost, ExecutionOptions, ExecutionOptionsError, Program};
 
 use std::{path::PathBuf, time::Instant};

--- a/miden/src/cli/verify.rs
+++ b/miden/src/cli/verify.rs
@@ -1,6 +1,6 @@
 use super::data::{InputFile, OutputFile, ProgramHash, ProofFile};
 use clap::Parser;
-use miden::{Kernel, ProgramInfo};
+use miden_vm::{Kernel, ProgramInfo};
 use std::{path::PathBuf, time::Instant};
 
 #[derive(Debug, Clone, Parser)]

--- a/miden/src/examples/blake3.rs
+++ b/miden/src/examples/blake3.rs
@@ -1,5 +1,5 @@
 use super::Example;
-use miden::{Assembler, DefaultHost, MemAdviceProvider, Program, StackInputs};
+use miden_vm::{Assembler, DefaultHost, MemAdviceProvider, Program, StackInputs};
 use stdlib::StdLibrary;
 use vm_core::utils::group_slice_elements;
 
@@ -35,7 +35,7 @@ fn generate_blake3_program(n: usize) -> Program {
     let program = format!(
         "
         use.std::crypto::hashes::blake3
-        
+
         begin
             repeat.{}
                 exec.blake3::hash_1to1

--- a/miden/src/examples/fibonacci.rs
+++ b/miden/src/examples/fibonacci.rs
@@ -1,5 +1,5 @@
 use super::{Example, ONE, ZERO};
-use miden::{math::Felt, Assembler, DefaultHost, MemAdviceProvider, Program, StackInputs};
+use miden_vm::{math::Felt, Assembler, DefaultHost, MemAdviceProvider, Program, StackInputs};
 
 // EXAMPLE BUILDER
 // ================================================================================================

--- a/miden/src/examples/mod.rs
+++ b/miden/src/examples/mod.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use miden::{ExecutionProof, Host, Program, ProgramInfo, ProvingOptions, StackInputs};
+use miden_vm::{ExecutionProof, Host, Program, ProgramInfo, ProvingOptions, StackInputs};
 use processor::{ExecutionOptions, ExecutionOptionsError, ONE, ZERO};
 
 use std::time::Instant;
@@ -105,7 +105,7 @@ impl ExampleOptions {
         // execute the program and generate the proof of execution
         let now = Instant::now();
         let (stack_outputs, proof) =
-            miden::prove(&program, stack_inputs.clone(), host, proof_options).unwrap();
+            miden_vm::prove(&program, stack_inputs.clone(), host, proof_options).unwrap();
         println!("--------------------------------");
 
         println!(
@@ -132,7 +132,7 @@ impl ExampleOptions {
         let now = Instant::now();
         let program_info = ProgramInfo::from(program);
 
-        match miden::verify(program_info, stack_inputs, stack_outputs, proof) {
+        match miden_vm::verify(program_info, stack_inputs, stack_outputs, proof) {
             Ok(_) => println!("Execution verified in {} ms", now.elapsed().as_millis()),
             Err(err) => println!("Failed to verify execution: {}", err),
         }
@@ -158,7 +158,7 @@ where
     } = example;
 
     let (mut outputs, proof) =
-        miden::prove(&program, stack_inputs.clone(), host, ProvingOptions::default()).unwrap();
+        miden_vm::prove(&program, stack_inputs.clone(), host, ProvingOptions::default()).unwrap();
 
     assert_eq!(
         expected_result,
@@ -166,13 +166,13 @@ where
         "Program result was computed incorrectly"
     );
 
-    let kernel = miden::Kernel::default();
+    let kernel = miden_vm::Kernel::default();
     let program_info = ProgramInfo::new(program.hash(), kernel);
 
     if fail {
         outputs.stack_mut()[0] += 1;
-        assert!(miden::verify(program_info, stack_inputs, outputs, proof).is_err())
+        assert!(miden_vm::verify(program_info, stack_inputs, outputs, proof).is_err())
     } else {
-        assert!(miden::verify(program_info, stack_inputs, outputs, proof).is_ok());
+        assert!(miden_vm::verify(program_info, stack_inputs, outputs, proof).is_ok());
     }
 }

--- a/miden/src/main.rs
+++ b/miden/src/main.rs
@@ -1,6 +1,6 @@
 use clap::Parser;
 use core::fmt;
-use miden::{AssemblyError, ExecutionError};
+use miden_vm::{AssemblyError, ExecutionError};
 #[cfg(feature = "tracing-forest")]
 use tracing_forest::ForestLayer;
 #[cfg(not(feature = "tracing-forest"))]

--- a/miden/src/repl/mod.rs
+++ b/miden/src/repl/mod.rs
@@ -1,5 +1,5 @@
 use assembly::{Assembler, Library, MaslLibrary};
-use miden::{math::Felt, DefaultHost, StackInputs, Word};
+use miden_vm::{math::Felt, DefaultHost, StackInputs, Word};
 use processor::ContextId;
 use rustyline::{error::ReadlineError, DefaultEditor};
 use std::{collections::BTreeSet, path::PathBuf};

--- a/miden/src/tools/mod.rs
+++ b/miden/src/tools/mod.rs
@@ -1,7 +1,7 @@
 use super::{cli::InputFile, ProgramError};
 use clap::Parser;
 use core::fmt;
-use miden::{utils::collections::*, Assembler, DefaultHost, Host, Operation, StackInputs};
+use miden_vm::{utils::collections::*, Assembler, DefaultHost, Host, Operation, StackInputs};
 use processor::{AsmOpInfo, TraceLenSummary};
 use std::{fs, path::PathBuf};
 use stdlib::StdLibrary;

--- a/miden/tests/integration/flow_control/mod.rs
+++ b/miden/tests/integration/flow_control/mod.rs
@@ -1,5 +1,5 @@
 use assembly::{Assembler, AssemblyContext, LibraryPath};
-use miden::ModuleAst;
+use miden_vm::ModuleAst;
 use processor::ExecutionError;
 use stdlib::StdLibrary;
 use test_utils::{build_test, AdviceInputs, StackInputs, Test, TestError};
@@ -295,7 +295,7 @@ fn dynexec_with_procref() {
 
     begin
         procref.foo
-        dynexec 
+        dynexec
 
         procref.u64::wrapping_add
         dynexec


### PR DESCRIPTION
## Describe your changes

As per the PR title. This makes the library crate name match the package name.


## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
