### PR TITLE
Implement error codes for the `mtree_verify` instructions.

### DIFF
--- a/air/src/constraints/stack/op_flags/mod.rs
+++ b/air/src/constraints/stack/op_flags/mod.rs
@@ -864,7 +864,7 @@ impl<E: FieldElement> OpFlags<E> {
     /// Operation Flag of MPVERIFY operation.
     #[inline(always)]
     pub fn mpverify(&self) -> E {
-        self.degree5_op_flags[get_op_index(Operation::MpVerify.op_code())]
+        self.degree5_op_flags[get_op_index(Operation::MpVerify(0).op_code())]
     }
 
     /// Operation Flag of SPLIT operation.

--- a/air/src/constraints/stack/op_flags/tests.rs
+++ b/air/src/constraints/stack/op_flags/tests.rs
@@ -145,7 +145,7 @@ fn degree_4_op_flags() {
 fn composite_flags() {
     // ------ no change 0 ---------------------------------------------------------------------
 
-    let op_no_change_0 = [Operation::MpVerify, Operation::Span, Operation::Halt];
+    let op_no_change_0 = [Operation::MpVerify(0), Operation::Span, Operation::Halt];
     for op in op_no_change_0 {
         // frame initialised with an op operation.
         let frame = generate_evaluation_frame(op.op_code().into());
@@ -169,7 +169,7 @@ fn composite_flags() {
         assert_eq!(op_flags.left_shift(), ZERO);
         assert_eq!(op_flags.top_binary(), ZERO);
 
-        if op == Operation::MpVerify {
+        if op == Operation::MpVerify(0) {
             assert_eq!(op_flags.control_flow(), ZERO);
         } else if op == Operation::Span || op == Operation::Halt {
             assert_eq!(op_flags.control_flow(), ONE);

--- a/assembly/src/assembler/instruction/crypto_ops.rs
+++ b/assembly/src/assembler/instruction/crypto_ops.rs
@@ -119,7 +119,7 @@ pub(super) fn mtree_get(span: &mut SpanBuilder) -> Result<Option<CodeBlock>, Ass
     let ops = [
         // verify the node V for root R with depth d and index i
         // => [V, d, i, R, ...]
-        MpVerify,
+        MpVerify(0),
 
         // move d, i back to the top of the stack and are dropped since they are
         // no longer needed => [V, R, ...]
@@ -171,21 +171,6 @@ pub(super) fn mtree_merge(span: &mut SpanBuilder) -> Result<Option<CodeBlock>, A
 
     // perform the `hmerge`, updating the operand stack
     hmerge(span)
-}
-
-/// Verifies if the node value `V`, on depth `d` and index `i` opens to the root `R` of a Merkle
-/// tree by appending a [Operation::MpVerify]. The stack is expected to be arranged as follows
-/// (from the top):
-/// - node value `V`, 4 elements
-/// - depth of the node `d`, 1 element
-/// - index of the node `i`, 1 element
-/// - root of the tree `R`, 4 elements
-///
-/// After the operation is executed, the stack remains unchanged.
-///
-/// This operation takes 1 VM cycle.
-pub(super) fn mtree_verify(span: &mut SpanBuilder) -> Result<Option<CodeBlock>, AssemblyError> {
-    span.add_op(MpVerify)
 }
 
 // MERKLE TREES - HELPERS

--- a/assembly/src/assembler/instruction/mod.rs
+++ b/assembly/src/assembler/instruction/mod.rs
@@ -281,7 +281,8 @@ impl Assembler {
             Instruction::MTreeGet => crypto_ops::mtree_get(span),
             Instruction::MTreeSet => crypto_ops::mtree_set(span),
             Instruction::MTreeMerge => crypto_ops::mtree_merge(span),
-            Instruction::MTreeVerify => crypto_ops::mtree_verify(span),
+            Instruction::MTreeVerify => span.add_op(MpVerify(0)),
+            Instruction::MTreeVerifyWithError(err_code) => span.add_op(MpVerify(*err_code)),
 
             // ----- STARK proof verification -----------------------------------------------------
             Instruction::FriExt2Fold4 => span.add_op(FriE2F4),

--- a/assembly/src/ast/nodes/mod.rs
+++ b/assembly/src/ast/nodes/mod.rs
@@ -269,6 +269,7 @@ pub enum Instruction {
     MTreeSet,
     MTreeMerge,
     MTreeVerify,
+    MTreeVerifyWithError(ErrorCode),
 
     // ----- STARK proof verification -------------------------------------------------------------
     FriExt2Fold4,
@@ -535,6 +536,7 @@ impl fmt::Display for Instruction {
             Self::MTreeSet => write!(f, "mtree_set"),
             Self::MTreeMerge => write!(f, "mtree_merge"),
             Self::MTreeVerify => write!(f, "mtree_verify"),
+            Self::MTreeVerifyWithError(err_code) => write!(f, "mtree_verify.err={err_code}"),
 
             // ----- STARK proof verification -----------------------------------------------------
             Self::FriExt2Fold4 => write!(f, "fri_ext2fold4"),

--- a/assembly/src/ast/nodes/serde/deserialization.rs
+++ b/assembly/src/ast/nodes/serde/deserialization.rs
@@ -323,6 +323,9 @@ impl Deserializable for Instruction {
             OpCode::MTreeSet => Ok(Instruction::MTreeSet),
             OpCode::MTreeMerge => Ok(Instruction::MTreeMerge),
             OpCode::MTreeVerify => Ok(Instruction::MTreeVerify),
+            OpCode::MTreeVerifyWithError => {
+                Ok(Instruction::MTreeVerifyWithError(source.read_u32()?))
+            }
 
             // ----- STARK proof verification -----------------------------------------------------
             OpCode::FriExt2Fold4 => Ok(Instruction::FriExt2Fold4),

--- a/assembly/src/ast/nodes/serde/mod.rs
+++ b/assembly/src/ast/nodes/serde/mod.rs
@@ -244,29 +244,30 @@ pub enum OpCode {
     MTreeSet = 211,
     MTreeMerge = 212,
     MTreeVerify = 213,
+    MTreeVerifyWithError = 214,
 
     // ----- STARK proof verification -------------------------------------------------------------
-    FriExt2Fold4 = 214,
-    RCombBase = 215,
+    FriExt2Fold4 = 215,
+    RCombBase = 216,
 
     // ----- exec / call --------------------------------------------------------------------------
-    ExecLocal = 216,
-    ExecImported = 217,
-    CallLocal = 218,
-    CallMastRoot = 219,
-    CallImported = 220,
-    SysCall = 221,
-    DynExec = 222,
-    DynCall = 223,
-    ProcRefLocal = 224,
-    ProcRefImported = 225,
+    ExecLocal = 217,
+    ExecImported = 218,
+    CallLocal = 219,
+    CallMastRoot = 220,
+    CallImported = 221,
+    SysCall = 222,
+    DynExec = 223,
+    DynCall = 224,
+    ProcRefLocal = 225,
+    ProcRefImported = 226,
 
     // ----- debugging ----------------------------------------------------------------------------
-    Debug = 226,
+    Debug = 227,
 
     // ----- event decorators ---------------------------------------------------------------------
-    Emit = 227,
-    Trace = 228,
+    Emit = 228,
+    Trace = 229,
 
     // ----- control flow -------------------------------------------------------------------------
     IfElse = 253,

--- a/assembly/src/ast/nodes/serde/serialization.rs
+++ b/assembly/src/ast/nodes/serde/serialization.rs
@@ -428,6 +428,10 @@ impl Serializable for Instruction {
             Self::MTreeSet => OpCode::MTreeSet.write_into(target),
             Self::MTreeMerge => OpCode::MTreeMerge.write_into(target),
             Self::MTreeVerify => OpCode::MTreeVerify.write_into(target),
+            Self::MTreeVerifyWithError(err_code) => {
+                OpCode::MTreeVerifyWithError.write_into(target);
+                target.write_u32(*err_code);
+            }
 
             // ----- STARK proof verification -----------------------------------------------------
             Self::FriExt2Fold4 => OpCode::FriExt2Fold4.write_into(target),

--- a/assembly/src/ast/parsers/context.rs
+++ b/assembly/src/ast/parsers/context.rs
@@ -1,6 +1,6 @@
 use super::{
-    super::ProcReExport, adv_ops, debug, events, field_ops, io_ops, stack_ops, sys_ops, u32_ops,
-    CodeBody, Instruction, InvocationTarget, LibraryPath, LocalConstMap, LocalProcMap,
+    super::ProcReExport, adv_ops, crypro_ops, debug, events, field_ops, io_ops, stack_ops, sys_ops,
+    u32_ops, CodeBody, Instruction, InvocationTarget, LibraryPath, LocalConstMap, LocalProcMap,
     ModuleImports, Node, ParsingError, ProcedureAst, ProcedureId, ProcedureName, ReExportedProcMap,
     Token, TokenStream, MAX_BODY_LEN, MAX_DOCS_LEN,
 };
@@ -612,7 +612,7 @@ impl ParserContext<'_> {
             "mtree_get" => simple_instruction(op, MTreeGet),
             "mtree_set" => simple_instruction(op, MTreeSet),
             "mtree_merge" => simple_instruction(op, MTreeMerge),
-            "mtree_verify" => simple_instruction(op, MTreeVerify),
+            "mtree_verify" => crypro_ops::parse_mtree_verify(op, &self.local_constants),
 
             // ----- STARK proof verification -----------------------------------------------------
             "fri_ext2fold4" => simple_instruction(op, FriExt2Fold4),

--- a/assembly/src/ast/parsers/crypro_ops.rs
+++ b/assembly/src/ast/parsers/crypro_ops.rs
@@ -1,0 +1,33 @@
+use super::{
+    parse_error_code,
+    Instruction::*,
+    LocalConstMap,
+    Node::{self, Instruction},
+    ParsingError, Token,
+};
+
+// INSTRUCTION PARSERS
+// ================================================================================================
+
+/// Returns `MTreeVerify` instruction node if no error code value is provided, or
+/// `MTreeVerifyWithError` instruction node otherwise.
+///
+/// # Errors
+/// Returns an error if the instruction token contains a wrong number of parameters, or if
+/// the provided parameter is not a u32 value.
+pub fn parse_mtree_verify(op: &Token, constants: &LocalConstMap) -> Result<Node, ParsingError> {
+    debug_assert_eq!(op.parts()[0], "mtree_verify");
+    match op.num_parts() {
+        0 => unreachable!(),
+        1 => Ok(Instruction(MTreeVerify)),
+        2 => {
+            let err_code = parse_error_code(op, constants)?;
+            if err_code == 0 {
+                Ok(Instruction(MTreeVerify))
+            } else {
+                Ok(Instruction(MTreeVerifyWithError(err_code)))
+            }
+        }
+        _ => Err(ParsingError::extra_param(op)),
+    }
+}

--- a/assembly/src/ast/parsers/mod.rs
+++ b/assembly/src/ast/parsers/mod.rs
@@ -12,6 +12,7 @@ use crate::{
 use core::{fmt::Display, ops::RangeBounds};
 
 mod adv_ops;
+mod crypro_ops;
 mod debug;
 mod events;
 mod field_ops;

--- a/assembly/src/tests.rs
+++ b/assembly/src/tests.rs
@@ -908,6 +908,32 @@ fn u32assertw_with_code() {
     assert_eq!(expected, format!("{program}"));
 }
 
+#[test]
+fn mtree_verify_with_code() {
+    let source = "\
+    const.ERR1=1
+
+    begin
+        mtree_verify
+        mtree_verify.err=ERR1
+        mtree_verify.err=2
+    end
+    "
+    .to_string();
+    let assembler = Assembler::default();
+    let program = assembler.compile(source).unwrap();
+
+    let expected = "\
+        begin \
+            span \
+                mpverify(0) \
+                mpverify(1) \
+                mpverify(2) \
+            end \
+        end";
+    assert_eq!(expected, format!("{program}"));
+}
+
 // NESTED CONTROL BLOCKS
 // ================================================================================================
 

--- a/core/src/operations/mod.rs
+++ b/core/src/operations/mod.rs
@@ -399,7 +399,7 @@ pub enum Operation {
     /// The Merkle path itself is expected to be provided by the prover non-deterministically (via
     /// merkle sets). If the prover is not able to provide the required path, the operation fails.
     /// The state of the stack does not change.
-    MpVerify,
+    MpVerify(u32),
 
     /// Computes a new root of a Merkle tree where a node at the specified position is updated to
     /// the specified value.
@@ -531,7 +531,7 @@ impl Operation {
             Self::U32madd       => 0b0100_1110,
 
             Self::HPerm         => 0b0101_0000,
-            Self::MpVerify      => 0b0101_0001,
+            Self::MpVerify(_)   => 0b0101_0001,
             Self::Pipe          => 0b0101_0010,
             Self::MStream       => 0b0101_0011,
             Self::Split         => 0b0101_0100,
@@ -704,7 +704,7 @@ impl fmt::Display for Operation {
 
             // ----- cryptographic operations -----------------------------------------------------
             Self::HPerm => write!(f, "hperm"),
-            Self::MpVerify => write!(f, "mpverify"),
+            Self::MpVerify(err_code) => write!(f, "mpverify({err_code})"),
             Self::MrUpdate => write!(f, "mrupdate"),
             Self::FriE2F4 => write!(f, "frie2f4"),
             Self::RCombBase => write!(f, "rcomb1"),

--- a/docs/src/user_docs/assembly/cryptographic_operations.md
+++ b/docs/src/user_docs/assembly/cryptographic_operations.md
@@ -12,4 +12,11 @@ Miden assembly provides a set of instructions for performing common cryptographi
 | mtree_get  <br> - *(9 cycles)*   | [d, i, R, ...]     | [V, R, ...]       | Fetches the node value from the advice provider and runs a verification equivalent to `mtree_verify`, returning the value if succeeded.                                                                                                                                                                                                                |
 | mtree_set <br> - *(29 cycles)*   | [d, i, R, V', ...] | [V, R', ...]      | Updates a node in the Merkle tree with root $R$ at depth $d$ and index $i$ to value $V'$. $R'$ is the Merkle root of the resulting tree and $V$ is old value of the node. Merkle tree with root $R$ must be present in the advice provider, otherwise execution fails. At the end of the operation the advice provider will contain both Merkle trees. |
 | mtree_merge <br> - *(16 cycles)* | [R, L, ...]        | [M, ...]          | Merges two Merkle trees with the provided roots R (right), L (left) into a new Merkle tree with root M (merged). The input trees are retained in the advice provider.                                                                                                                                                                                  |
-| mtree_verify  <br> - *(1 cycle)* | [V, d, i, R, ...]  | [V, d, i, R, ...] | Verifies that a Merkle tree with root $R$ opens to node $V$ at depth $d$ and index $i$. Merkle tree with root $R$ must be present in the advice provider, otherwise execution fails.                                                                                                                                                                   |
+| mtree_verify  <br> - *(1 cycle)* | [V, d, i, R, ...]  | [V, d, i, R, ...] | Verifies that a Merkle tree with root $R$ opens to node $V$ at depth $d$ and index $i$. Merkle tree with root $R$ must be present in the advice provider, otherwise execution fails. |
+
+The `mtree_verify` instruction can also be parametrized with an error code which can be any 32-bit value specified either directly or via a [named constant](./code_organization.md#constants). For example:
+```
+mtree_verify.err=123
+mtree_verify.err=MY_CONSTANT
+```
+If the error code is omitted, the default value of $0$ is assumed.

--- a/processor/src/chiplets/aux_trace/mod.rs
+++ b/processor/src/chiplets/aux_trace/mod.rs
@@ -38,7 +38,7 @@ const MSTORE: u8 = Operation::MStore.op_code();
 const MSTREAM: u8 = Operation::MStream.op_code();
 const RCOMBBASE: u8 = Operation::RCombBase.op_code();
 const HPERM: u8 = Operation::HPerm.op_code();
-const MPVERIFY: u8 = Operation::MpVerify.op_code();
+const MPVERIFY: u8 = Operation::MpVerify(0).op_code();
 const MRUPDATE: u8 = Operation::MrUpdate.op_code();
 const NUM_HEADER_ALPHAS: usize = 4;
 

--- a/processor/src/errors.rs
+++ b/processor/src/errors.rs
@@ -54,6 +54,7 @@ pub enum ExecutionError {
         value: Word,
         index: Felt,
         root: Digest,
+        err_code: u32,
     },
     MerkleStoreLookupFailed(MerkleError),
     MerkleStoreMergeFailed(MerkleError),
@@ -154,10 +155,15 @@ impl Display for ExecutionError {
             MemoryAddressOutOfBounds(addr) => {
                 write!(f, "Memory address cannot exceed 2^32 but was {addr}")
             }
-            MerklePathVerificationFailed { value, index, root } => {
+            MerklePathVerificationFailed {
+                value,
+                index,
+                root,
+                err_code,
+            } => {
                 let value = to_hex(Felt::elements_as_bytes(value))?;
                 let root = to_hex(&root.as_bytes())?;
-                write!(f, "Merkle path verification failed for value {value} at index {index}, in the Merkle tree with root {root}")
+                write!(f, "Merkle path verification failed for value {value} at index {index}, in the Merkle tree with root {root} (error code: {err_code})")
             }
             MerkleStoreLookupFailed(reason) => {
                 write!(f, "Advice provider Merkle store backend lookup failed: {reason}")

--- a/processor/src/operations/crypto_ops.rs
+++ b/processor/src/operations/crypto_ops.rs
@@ -67,7 +67,7 @@ where
     ///
     /// # Panics
     /// Panics if the computed root does not match the root provided via the stack.
-    pub(super) fn op_mpverify(&mut self) -> Result<(), ExecutionError> {
+    pub(super) fn op_mpverify(&mut self, err_code: u32) -> Result<(), ExecutionError> {
         // read node value, depth, index and root value from the stack
         let node = [self.stack.get(3), self.stack.get(2), self.stack.get(1), self.stack.get(0)];
         let index = self.stack.get(5);
@@ -82,7 +82,7 @@ where
 
         // save address(r) of the hasher trace from when the computation starts in the decoder
         // helper registers.
-        self.decoder.set_user_op_helpers(Operation::MpVerify, &[addr]);
+        self.decoder.set_user_op_helpers(Operation::MpVerify(err_code), &[addr]);
 
         if root != computed_root {
             // If the hasher chiplet doesn't compute the same root (using the same path),
@@ -91,6 +91,7 @@ where
                 value: node,
                 index,
                 root: root.into(),
+                err_code,
             });
         }
 
@@ -264,7 +265,7 @@ mod tests {
         let mut process =
             Process::new_dummy_with_inputs_and_decoder_helpers(stack_inputs, advice_inputs);
 
-        process.execute_op(Operation::MpVerify).unwrap();
+        process.execute_op(Operation::MpVerify(0)).unwrap();
         let expected_stack = build_expected(&[
             node[3], node[2], node[1], node[0], depth, index, root[3], root[2], root[1], root[0],
         ]);

--- a/processor/src/operations/mod.rs
+++ b/processor/src/operations/mod.rs
@@ -146,7 +146,7 @@ where
 
             // ----- cryptographic operations -----------------------------------------------------
             Operation::HPerm => self.op_hperm()?,
-            Operation::MpVerify => self.op_mpverify()?,
+            Operation::MpVerify(err_code) => self.op_mpverify(err_code)?,
             Operation::MrUpdate => self.op_mrupdate()?,
             Operation::FriE2F4 => self.op_fri_ext2fold4()?,
             Operation::RCombBase => self.op_rcomb_base()?,

--- a/processor/src/trace/tests/chiplets/hasher.rs
+++ b/processor/src/trace/tests/chiplets/hasher.rs
@@ -427,7 +427,7 @@ fn b_chip_mpverify() {
     let advice_inputs = AdviceInputs::default().with_merkle_store(store);
 
     let mut trace =
-        build_trace_from_ops_with_inputs(vec![Operation::MpVerify], stack_inputs, advice_inputs);
+        build_trace_from_ops_with_inputs(vec![Operation::MpVerify(0)], stack_inputs, advice_inputs);
     let alphas = rand_array::<Felt, AUX_TRACE_RAND_ELEMENTS>();
     let aux_columns = trace.build_aux_segment(&[], &alphas).unwrap();
     let b_chip = aux_columns.get_column(CHIPLETS_AUX_TRACE_OFFSET);

--- a/processor/src/trace/tests/hasher.rs
+++ b/processor/src/trace/tests/hasher.rs
@@ -32,7 +32,7 @@ fn hasher_p1_mp_verify() {
     let advice_inputs = AdviceInputs::default().with_merkle_store(store);
 
     // build execution trace and extract the sibling table column from it
-    let ops = vec![Operation::MpVerify];
+    let ops = vec![Operation::MpVerify(0)];
     let mut trace = build_trace_from_ops_with_inputs(ops, stack_inputs, advice_inputs);
     let alphas = rand_array::<Felt, AUX_TRACE_RAND_ELEMENTS>();
     let aux_columns = trace.build_aux_segment(&[], &alphas).unwrap();


### PR DESCRIPTION
This PR implements the ability to specify error codes for `mtree_verify` instruction the same way it is done for assert instructions. 

Related issue: #1264 
