### PR TITLE
Fix segment page alignment issue in metal prover

### DIFF
--- a/miden/src/examples/fibonacci.rs
+++ b/miden/src/examples/fibonacci.rs
@@ -1,5 +1,5 @@
 use super::{Example, ONE, ZERO};
-use miden::{math::Felt, Assembler, DefaultHost, MemAdviceProvider, Program, StackInputs};
+use miden::{math::Felt, Assembler, DefaultHost, MemAdviceProvider, Program, ProvingOptions, StackInputs};
 
 // EXAMPLE BUILDER
 // ================================================================================================
@@ -67,4 +67,10 @@ fn test_fib_example() {
 fn test_fib_example_fail() {
     let example = get_example(16);
     super::test_example(example, true);
+}
+
+#[test]
+fn test_fib_example_rpo() {
+    let example = get_example(16);
+    super::test_example_with_options(example, false, ProvingOptions::with_96_bit_security(true));
 }

--- a/miden/src/examples/mod.rs
+++ b/miden/src/examples/mod.rs
@@ -145,7 +145,7 @@ impl ExampleOptions {
 // ================================================================================================
 
 #[cfg(test)]
-pub fn test_example<H>(example: Example<H>, fail: bool)
+pub fn test_example_with_options<H>(example: Example<H>, fail: bool, options: ProvingOptions)
 where
     H: Host,
 {
@@ -158,7 +158,7 @@ where
     } = example;
 
     let (mut outputs, proof) =
-        miden::prove(&program, stack_inputs.clone(), host, ProvingOptions::default()).unwrap();
+        miden::prove(&program, stack_inputs.clone(), host, options).unwrap();
 
     assert_eq!(
         expected_result,
@@ -175,4 +175,13 @@ where
     } else {
         assert!(miden::verify(program_info, stack_inputs, outputs, proof).is_ok());
     }
+}
+
+
+#[cfg(test)]
+pub fn test_example<H>(example: Example<H>, fail: bool)
+where
+    H: Host,
+{
+    test_example_with_options(example, fail, ProvingOptions::default());
 }

--- a/prover/src/gpu.rs
+++ b/prover/src/gpu.rs
@@ -18,7 +18,7 @@ use processor::{utils::group_vector_elements, ONE};
 use std::time::Instant;
 use winter_prover::{
     crypto::MerkleTree,
-    matrix::{build_segments, get_evaluation_offsets, ColMatrix, RowMatrix, Segment},
+    matrix::{get_evaluation_offsets, ColMatrix, RowMatrix, Segment},
     proof::Queries,
     AuxTraceRandElements, CompositionPoly, CompositionPolyTrace, ConstraintCommitment,
     ConstraintCompositionCoefficients, DefaultConstraintEvaluator, EvaluationFrame, Prover,


### PR DESCRIPTION
## Describe your changes
1. Added test_example_with_options to miden/src/examples/mod.rs to allow for custom proving options (ex. ProvingOptions::with_96_bit_security(true))
2. Added a fibonacci test which uses ProvingOptions::with_96_bit_security(true)
3. Fixed the page alignment issue in `build_segments` by implementing a custom `build_aligned_segements` which uses `page_aligned_uninit_vector` to allocate the segment data (instead of the `uninit_vector` function used in winterfell's [original implementation])(https://github.com/facebook/winterfell/blob/23eb7132c60ab4132eefbfac117fe1fc55f02171/prover/src/matrix/segments.rs#L67)


Original bug writeup:
https://gist.github.com/cf/f5d582319d62ed0d7a7751c2001b6301/
