### PR TITLE
Fixed imports serialization

### DIFF
--- a/assembly/src/ast/imports.rs
+++ b/assembly/src/ast/imports.rs
@@ -172,9 +172,9 @@ impl ModuleImports {
 impl Serializable for ModuleImports {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
         target.write_u16(self.imports.len() as u16);
-        // We don't need to serialize the library names if the library paths already contain the library names,
-        // which is true in the most cases
         self.imports.iter().for_each(|(name, path)| {
+            // We don't need to serialize the library names if the library paths already contain the library names,
+            // which is true in the most cases
             let name = (name != path.last()).then_some(name);
             name.write_into(target);
             path.write_into(target);

--- a/assembly/src/ast/imports.rs
+++ b/assembly/src/ast/imports.rs
@@ -173,8 +173,7 @@ impl Serializable for ModuleImports {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
         target.write_u16(self.imports.len() as u16);
         self.imports.iter().for_each(|(name, path)| {
-            // We don't need to serialize the library names if the library paths already contain the library names,
-            // which is true in the most cases
+            // We don't need to serialize the library names if the library wasn't renamed on import
             let name = (name != path.last()).then_some(name);
             name.write_into(target);
             path.write_into(target);
@@ -195,6 +194,7 @@ impl Deserializable for ModuleImports {
         for _ in 0..num_imports {
             let name = <Option<String>>::read_from(source)?;
             let path = LibraryPath::read_from(source)?;
+            // If library name wasn't serialized, get it from the path
             imports.insert(name.unwrap_or_else(|| path.last().to_string()), path);
         }
 

--- a/assembly/src/ast/tests.rs
+++ b/assembly/src/ast/tests.rs
@@ -972,6 +972,21 @@ fn test_ast_module_serde_imports_not_serialized() {
 }
 
 #[test]
+fn test_ast_program_serde_renamed_imports_serialized() {
+    let source = "\
+    use.std::math::u64
+    use.std::crypto::fri->renamed
+
+    begin
+        push.0
+        push.1
+        exec.u64::wrapping_add
+    end";
+    assert_correct_program_serialization(source, true);
+}
+
+
+#[test]
 fn test_repeat_with_constant_count() {
     let source = "\
     const.A=3

--- a/assembly/src/ast/tests.rs
+++ b/assembly/src/ast/tests.rs
@@ -985,7 +985,6 @@ fn test_ast_program_serde_renamed_imports_serialized() {
     assert_correct_program_serialization(source, true);
 }
 
-
 #[test]
 fn test_repeat_with_constant_count() {
     let source = "\


### PR DESCRIPTION
I've faced issue with imports serialization. We don't serialize import names due to the fact that name equals to the latest identifier in the path. Sometimes this rule doesn't work. For example, if we create new `TransactionKernel::assembler()` we can find this different name in its imports:
```
"wallet": LibraryPath { path: "miden::contracts::wallets::basic", num_components: 4 }
```
Thus, sometimes name differs from the last path element. 
This PR should fix this issue by optionally serializing name of import (if it differs).