### PR TITLE
fix typo in docs

### DIFF
--- a/docs/src/user_docs/assembly/field_operations.md
+++ b/docs/src/user_docs/assembly/field_operations.md
@@ -23,7 +23,7 @@ If the error code is omitted, the default value of $0$ is assumed.
 
 ### Arithmetic and Boolean operations
 
-The arithmetic operations below are performed in a 64-bit [prime filed](https://en.wikipedia.org/wiki/Finite_field) defined by modulus $p = 2^{64} - 2^{32} + 1$. This means that overflow happens after a value exceeds $p$. Also, the result of divisions may appear counter-intuitive because divisions are defined via inversions.
+The arithmetic operations below are performed in a 64-bit [prime field](https://en.wikipedia.org/wiki/Finite_field) defined by modulus $p = 2^{64} - 2^{32} + 1$. This means that overflow happens after a value exceeds $p$. Also, the result of divisions may appear counter-intuitive because divisions are defined via inversions.
 
 | Instruction                                                                    | Stack_input | Stack_output  | Notes                                                                                                        |
 | ------------------------------------------------------------------------------ | ----------- | ------------- | ------------------------------------------------------------------------------------------------------------ |


### PR DESCRIPTION
fix typo: filed to field

## Describe your changes
found a typo when reading the docs 
