### PR TITLE
stdlib: adds native hasher init procedure without padding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 # Changelog
 
-## 0.9.0
+## 0.9.0 (TBD)
 
 #### Packaging
 - [BREAKING] The package `miden-vm` crate was renamed from `miden` to `miden-vm`. Now the package and crate names match (#1271).
+
+#### Stdlib
+- Added `init_no_padding` procedure to `std::crypto::hashes::native` (#1313).
 
 #### VM Internals
 - Removed unused `find_lone_leaf()` function from the Advice Provider (#1262).

--- a/stdlib/asm/crypto/hashes/native.masm
+++ b/stdlib/asm/crypto/hashes/native.masm
@@ -1,3 +1,15 @@
+#! Prepares the top of the stack with the hasher initial state.
+#!
+#! This procedures does not handle padding, therefore, the user is expected to
+#! consume an amount of data which is a multiple of the rate (2 words).
+#!
+#! Input: []
+#! Ouptut: [PERM, PERM, PERM, ...]
+#! Cycles: 12
+export.init_no_padding
+   padw padw padw
+end
+
 #! Given the hasher state, returns the hash output
 #!
 #! Input: [C, B, A, ...]


### PR DESCRIPTION
## Describe your changes

Adds a procedure to initialize the stack with the native hasher initial state. This only covers the case without the need for padding.

Related to https://github.com/0xPolygonMiden/miden-vm/issues/1311


## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
