### PR TITLE
fix: support creation of raw identifiers when working with AST in memroy

### DIFF
--- a/assembly/build.rs
+++ b/assembly/build.rs
@@ -17,6 +17,7 @@ fn main() {
     //
     // To accomplish that goal, we set a `nightly` configuration variable, which can then be
     // referenced in `#[cfg]` directives, e.g. `#[cfg(nightly)]` or `#[cfg(not(nightly))]`.
+    println!("cargo:rustc-check-cfg=cfg(nightly)");
     if let Channel::Nightly = version_meta().unwrap().channel {
         println!("cargo:rustc-cfg=nightly")
     }

--- a/assembly/src/ast/ident.rs
+++ b/assembly/src/ast/ident.rs
@@ -85,7 +85,9 @@ impl Ident {
     /// a valid identifier, and so does not require re-parsing/re-validating. This must _not_ be
     /// used to bypass validation when you have an identifier that is not valid, and such
     /// identifiers will be caught during compilation and result in a panic being raised.
-    pub(crate) fn new_unchecked(name: Span<Arc<str>>) -> Self {
+    ///
+    /// NOTE: This function is perma-unstable, it may be removed or modified at any time.
+    pub fn new_unchecked(name: Span<Arc<str>>) -> Self {
         let (span, name) = name.into_parts();
         Self { span, name }
     }

--- a/assembly/src/ast/procedure/name.rs
+++ b/assembly/src/ast/procedure/name.rs
@@ -194,7 +194,9 @@ impl ProcedureName {
     /// It is expected that the caller has already validated that the name meets all validity
     /// criteria for procedure names, for example, the parser only lexes/parses valid identifiers,
     /// so by construction all such identifiers are valid.
-    pub(crate) fn new_unchecked(name: Ident) -> Self {
+    ///
+    /// NOTE: This function is perma-unstable, it may be removed or modified at any time.
+    pub fn new_unchecked(name: Ident) -> Self {
         Self(name)
     }
 

--- a/stdlib/build.rs
+++ b/stdlib/build.rs
@@ -19,7 +19,6 @@ const DOC_DIR_PATH: &str = "./docs";
 
 /// Read and parse the contents from `./asm` into a `LibraryContents` struct, serializing it into
 /// `assets` folder under `std` namespace.
-#[cfg(not(feature = "docs-rs"))]
 fn main() -> Result<()> {
     // re-build the `[OUT_DIR]/assets/std.masl` file iff something in the `./asm` directory
     // or its builder changed:


### PR DESCRIPTION
This was overlooked when merging the assembler refactoring, but is required by the compiler, as it is working directly with the AST in memory, rather than parsing MASM text.

Callers are expected to uphold the validity requirements of bare/quoted identifiers when using these APIs, but failure to do so doesn't really matter that much, aside from breaking the ability to round-trip code containing the invalid identifier through the text format (and making it all but impossible to reference from other code). As a result, I don't really see a need to treat these as particularly dangerous functions, so I haven't marked them `unsafe` (not that there is any potential for them to be unsafe in Rust terms, but occasionally `unsafe` is useful for flagging things that you want to be _really_ sure are done correctly for reasons other than memory safety).

Aside from that, I've added a note to their documentation to indicate that these are unstable functions that we can remove/change anytime, in case we later decide we would rather these not exist, we reserve the right to pull them without breaking any stability guarantees of the library.