### PR TITLE
Remove usage of group_vector_elements() from combine_blocks()

### DIFF
--- a/assembly/src/assembler/mod.rs
+++ b/assembly/src/assembler/mod.rs
@@ -8,7 +8,7 @@ use super::{
 use alloc::collections::BTreeMap;
 use alloc::vec::Vec;
 use core::{borrow::Borrow, cell::RefCell};
-use vm_core::{utils::group_vector_elements, Decorator, DecoratorList};
+use vm_core::{Decorator, DecoratorList};
 
 mod instruction;
 
@@ -467,12 +467,13 @@ fn combine_blocks(mut blocks: Vec<CodeBlock>) -> CodeBlock {
     while blocks.len() > 1 {
         let last_block = if blocks.len() % 2 == 0 { None } else { blocks.pop() };
 
-        let mut grouped_blocks = Vec::new();
-        core::mem::swap(&mut blocks, &mut grouped_blocks);
-        let mut grouped_blocks = group_vector_elements::<CodeBlock, 2>(grouped_blocks);
-        grouped_blocks.drain(0..).for_each(|pair| {
-            blocks.push(CodeBlock::new_join(pair));
-        });
+        let mut source_blocks = Vec::new();
+        core::mem::swap(&mut blocks, &mut source_blocks);
+
+        let mut source_block_iter = source_blocks.drain(0..);
+        while let (Some(left), Some(right)) = (source_block_iter.next(), source_block_iter.next()) {
+            blocks.push(CodeBlock::new_join([left, right]));
+        }
 
         if let Some(block) = last_block {
             blocks.push(block);

--- a/stdlib/build.rs
+++ b/stdlib/build.rs
@@ -21,7 +21,6 @@ type ModuleMap = BTreeMap<String, ModuleAst>;
 
 /// Read and parse the contents from `./asm` into a `LibraryContents` struct, serializing it into
 /// `assets` folder under `std` namespace.
-#[cfg(not(feature = "docs-rs"))]
 fn main() -> io::Result<()> {
     // re-build the `[OUT_DIR]/assets/std.masl` file iff something in the `./asm` directory
     // or its builder changed:


### PR DESCRIPTION
This small PR removes the usage of `group_vector_elements()` function from `combine_blocks()` function which was causing issues in WASM compilation in the newer versions of Rust compiler (and `group_vector_elements()` is removed from Winterfell versions v0.9.0 and later).
