### PR TITLE
ci: add rust-toolchain.toml

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,5 @@
+[toolchain]
+channel = "1.78"
+components = ["rustfmt", "rust-src", "clippy"]
+targets = ["wasm32-unknown-unknown"]
+profile = "minimal"


### PR DESCRIPTION
This PR adds a `rust-toolchain.toml` file, which ensures that default Rust toolchain commands use the configured toolchain, rather than whatever the global toolchain on your machine happens to be. In this case, I've configured to use `1.78` explicitly.

So when you run, say, `cargo check`, this will ensure that the given Rust toolchain is installed, along with the configured targets and components, and will use that toolchain to run the given command. This applies to all Rust toolchain binaries, e.g. `rustc`, `clippy`, and so on.

If you wish to compile with `nightly`, simply run `cargo +nightly check` or whatever.

This also ensures that when CI runs, it uses the same toolchain as we are using locally (again, unless explicitly overridden, such as when specifying `nightly` as the toolchain via the GitHub Actions config). The result is less instability in CI as new releases drop.

@phklive I'm cc'ing you on this, since I know you've been making various CI-related changes, in case you have any opinions/thoughts on this.