### PR TITLE
feat: support absolute module/procedure paths

### DIFF
--- a/assembly/src/assembler/mod.rs
+++ b/assembly/src/assembler/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     ast::{
-        self, Export, FullyQualifiedProcedureName, Instruction, InvocationTarget, InvokeKind,
-        ModuleKind, ProcedureIndex,
+        self, AliasTarget, Export, FullyQualifiedProcedureName, Instruction, InvocationTarget,
+        InvokeKind, ModuleKind, ProcedureIndex,
     },
     diagnostics::{tracing::instrument, Report},
     sema::SemanticAnalysisError,
@@ -548,7 +548,22 @@ impl Assembler {
                     index: ProcedureIndex::new(index),
                 },
                 Export::Alias(ref alias) => {
-                    self.module_graph.find(alias.source_file(), alias.target())?
+                    match alias.target() {
+                        AliasTarget::MastRoot(digest) => {
+                            self.procedure_cache.contains_mast_root(digest)
+                                .unwrap_or_else(|| {
+                                    panic!(
+                                        "compilation apparently succeeded, but did not find a \
+                                                entry in the procedure cache for alias '{}', i.e. '{}'",
+                                        alias.name(),
+                                        digest
+                                    );
+                                })
+                        }
+                        AliasTarget::Path(ref name)=> {
+                            self.module_graph.find(alias.source_file(), name)?
+                        }
+                    }
                 }
             };
             let proc = self.procedure_cache.get(gid).unwrap_or_else(|| match procedure {

--- a/assembly/src/assembler/module_graph/mod.rs
+++ b/assembly/src/assembler/module_graph/mod.rs
@@ -577,6 +577,16 @@ impl ModuleGraph {
                     next = Cow::Owned(fqn);
                     caller = module.source_file();
                 }
+                Some(ResolvedProcedure::MastRoot(ref digest)) => {
+                    if let Some(id) = self.get_procedure_index_by_digest(digest) {
+                        break Ok(id);
+                    }
+                    break Err(AssemblyError::Failed {
+                        labels: vec![RelatedLabel::error("undefined procedure")
+                            .with_source_file(source_file)
+                            .with_labeled_span(next.span(), "unable to resolve this reference")],
+                    });
+                }
                 None => {
                     // No such procedure known to `module`
                     break Err(AssemblyError::Failed {

--- a/assembly/src/assembler/module_graph/procedure_cache.rs
+++ b/assembly/src/assembler/module_graph/procedure_cache.rs
@@ -137,10 +137,9 @@ impl ProcedureCache {
             .unwrap_or(false)
     }
 
-    /// Returns true if the procedure with the given MAST root is cached.
-    #[allow(unused)]
-    pub fn contains_mast_root(&self, hash: &RpoDigest) -> bool {
-        self.by_mast_root.contains_key(hash)
+    /// Returns the [GlobalProcedureIndex] of the procedure with the given MAST root, if cached.
+    pub fn contains_mast_root(&self, hash: &RpoDigest) -> Option<GlobalProcedureIndex> {
+        self.by_mast_root.get(hash).copied()
     }
 
     /// Inserts the given [Procedure] into this cache, using the [GlobalProcedureIndex] as the

--- a/assembly/src/ast/instruction/print.rs
+++ b/assembly/src/ast/instruction/print.rs
@@ -290,7 +290,7 @@ impl PrettyPrint for Instruction {
                 const_text("exec") + const_text(".") + text(format!("{}::{}", module, name))
             }
             Self::Exec(InvocationTarget::AbsoluteProcedurePath { name, path }) => {
-                const_text("exec") + const_text(".") + text(format!("{}::{}", path.last(), name))
+                const_text("exec") + const_text(".") + text(format!("::{}::{}", path.last(), name))
             }
             Self::Call(InvocationTarget::MastRoot(root)) => {
                 const_text("call")
@@ -304,7 +304,7 @@ impl PrettyPrint for Instruction {
                 const_text("call") + const_text(".") + text(format!("{}::{}", module, name))
             }
             Self::Call(InvocationTarget::AbsoluteProcedurePath { name, path }) => {
-                const_text("call") + const_text(".") + text(format!("{}::{}", path.last(), name))
+                const_text("call") + const_text(".") + text(format!("::{}::{}", path.last(), name))
             }
             Self::SysCall(InvocationTarget::MastRoot(root)) => {
                 const_text("syscall")
@@ -318,7 +318,9 @@ impl PrettyPrint for Instruction {
                 const_text("syscall") + const_text(".") + text(format!("{}::{}", module, name))
             }
             Self::SysCall(InvocationTarget::AbsoluteProcedurePath { name, path }) => {
-                const_text("syscall") + const_text(".") + text(format!("{}::{}", path.last(), name))
+                const_text("syscall")
+                    + const_text(".")
+                    + text(format!("::{}::{}", path.last(), name))
             }
             Self::DynExec => const_text("dynexec"),
             Self::DynCall => const_text("dyncall"),
@@ -334,7 +336,7 @@ impl PrettyPrint for Instruction {
             Self::ProcRef(InvocationTarget::AbsoluteProcedurePath { name, path }) => flatten(
                 const_text("procref")
                     + const_text(".")
-                    + text(format!("{}::{}", path.last(), name)),
+                    + text(format!("::{}::{}", path.last(), name)),
             ),
 
             // ----- debug decorators -------------------------------------------------------------

--- a/assembly/src/ast/instruction/print.rs
+++ b/assembly/src/ast/instruction/print.rs
@@ -290,7 +290,7 @@ impl PrettyPrint for Instruction {
                 const_text("exec") + const_text(".") + text(format!("{}::{}", module, name))
             }
             Self::Exec(InvocationTarget::AbsoluteProcedurePath { name, path }) => {
-                const_text("exec") + const_text(".") + text(format!("::{}::{}", path.last(), name))
+                const_text("exec") + const_text(".") + text(format!("::{}::{}", path, name))
             }
             Self::Call(InvocationTarget::MastRoot(root)) => {
                 const_text("call")
@@ -304,7 +304,7 @@ impl PrettyPrint for Instruction {
                 const_text("call") + const_text(".") + text(format!("{}::{}", module, name))
             }
             Self::Call(InvocationTarget::AbsoluteProcedurePath { name, path }) => {
-                const_text("call") + const_text(".") + text(format!("::{}::{}", path.last(), name))
+                const_text("call") + const_text(".") + text(format!("::{}::{}", path, name))
             }
             Self::SysCall(InvocationTarget::MastRoot(root)) => {
                 const_text("syscall")
@@ -318,9 +318,7 @@ impl PrettyPrint for Instruction {
                 const_text("syscall") + const_text(".") + text(format!("{}::{}", module, name))
             }
             Self::SysCall(InvocationTarget::AbsoluteProcedurePath { name, path }) => {
-                const_text("syscall")
-                    + const_text(".")
-                    + text(format!("::{}::{}", path.last(), name))
+                const_text("syscall") + const_text(".") + text(format!("::{}::{}", path, name))
             }
             Self::DynExec => const_text("dynexec"),
             Self::DynCall => const_text("dyncall"),
@@ -334,9 +332,7 @@ impl PrettyPrint for Instruction {
                 const_text("procref") + const_text(".") + text(format!("{}::{}", module, name)),
             ),
             Self::ProcRef(InvocationTarget::AbsoluteProcedurePath { name, path }) => flatten(
-                const_text("procref")
-                    + const_text(".")
-                    + text(format!("::{}::{}", path.last(), name)),
+                const_text("procref") + const_text(".") + text(format!("::{}::{}", path, name)),
             ),
 
             // ----- debug decorators -------------------------------------------------------------

--- a/assembly/src/ast/module.rs
+++ b/assembly/src/ast/module.rs
@@ -8,7 +8,7 @@ use core::fmt;
 
 use super::{Export, Import, LocalNameResolver, ProcedureIndex, ProcedureName, ResolvedProcedure};
 use crate::{
-    ast::{AstSerdeOptions, Ident},
+    ast::{AliasTarget, AstSerdeOptions, Ident},
     diagnostics::{Report, SourceFile},
     sema::SemanticAnalysisError,
     ByteReader, ByteWriter, Deserializable, DeserializationError, LibraryNamespace, LibraryPath,
@@ -418,7 +418,10 @@ impl Module {
             Export::Procedure(ref proc) => {
                 Some(ResolvedProcedure::Local(Span::new(proc.name().span(), index)))
             }
-            Export::Alias(ref alias) => Some(ResolvedProcedure::External(alias.target.clone())),
+            Export::Alias(ref alias) => match alias.target() {
+                AliasTarget::MastRoot(digest) => Some(ResolvedProcedure::MastRoot(*digest)),
+                AliasTarget::Path(path) => Some(ResolvedProcedure::External(path.clone())),
+            },
         }
     }
 
@@ -430,7 +433,11 @@ impl Module {
                 ResolvedProcedure::Local(Span::new(p.name().span(), ProcedureIndex::new(i))),
             ),
             Export::Alias(ref p) => {
-                (p.name().clone(), ResolvedProcedure::External(p.target.clone()))
+                let target = match p.target {
+                    AliasTarget::MastRoot(ref digest) => ResolvedProcedure::MastRoot(*digest),
+                    AliasTarget::Path(ref path) => ResolvedProcedure::External(path.clone()),
+                };
+                (p.name().clone(), target)
             }
         }))
         .with_imports(

--- a/assembly/src/ast/procedure/mod.rs
+++ b/assembly/src/ast/procedure/mod.rs
@@ -5,7 +5,7 @@ mod name;
 mod procedure;
 mod resolver;
 
-pub use self::alias::ProcedureAlias;
+pub use self::alias::{AliasTarget, ProcedureAlias};
 pub use self::id::ProcedureIndex;
 pub use self::name::{FullyQualifiedProcedureName, ProcedureName};
 pub use self::procedure::{Procedure, Visibility};

--- a/assembly/src/ast/procedure/name.rs
+++ b/assembly/src/ast/procedure/name.rs
@@ -311,7 +311,7 @@ impl FromStr for ProcedureName {
                             break Ok(Arc::from(tok.to_string().into_boxed_str()));
                         }
                         c if c.is_alphanumeric() => continue,
-                        '_' | '$' | '-' | '!' | '?' => continue,
+                        '_' | '$' | '-' | '!' | '?' | '<' | '>' | ':' | '.' => continue,
                         _ => break Err(IdentError::InvalidChars),
                     }
                 } else {

--- a/assembly/src/ast/procedure/resolver.rs
+++ b/assembly/src/ast/procedure/resolver.rs
@@ -1,5 +1,5 @@
 use super::{FullyQualifiedProcedureName, ProcedureIndex, ProcedureName};
-use crate::{ast::Ident, LibraryPath, SourceSpan, Span, Spanned};
+use crate::{ast::Ident, LibraryPath, RpoDigest, SourceSpan, Span, Spanned};
 use alloc::{collections::BTreeMap, vec::Vec};
 
 // RESOLVED PROCEDURE
@@ -12,6 +12,8 @@ pub enum ResolvedProcedure {
     Local(Span<ProcedureIndex>),
     /// The name was resolved to a procedure exported from another module
     External(FullyQualifiedProcedureName),
+    /// The name was resolved to a procedure with a known MAST root
+    MastRoot(Span<RpoDigest>),
 }
 
 impl Spanned for ResolvedProcedure {
@@ -19,6 +21,7 @@ impl Spanned for ResolvedProcedure {
         match self {
             Self::Local(ref spanned) => spanned.span(),
             Self::External(ref spanned) => spanned.span(),
+            Self::MastRoot(ref spanned) => spanned.span(),
         }
     }
 }

--- a/assembly/src/parser/error.rs
+++ b/assembly/src/parser/error.rs
@@ -203,6 +203,11 @@ pub enum ParsingError {
         #[label]
         span: SourceSpan,
     },
+    #[error("re-exporting a procedure identified by digest requires giving it a name, e.g. `export.DIGEST->foo`")]
+    UnnamedReexportOfMastRoot {
+        #[label]
+        span: SourceSpan,
+    },
 }
 
 impl ParsingError {

--- a/assembly/src/parser/grammar.lalrpop
+++ b/assembly/src/parser/grammar.lalrpop
@@ -301,18 +301,47 @@ Proc: Form = {
         Ok(Form::Procedure(Export::Procedure(procedure)))
     },
 
-    <l:@L> "export" "." <qualified_name:QualifiedName> <alias:("->" <BareIdent>)?> <r:@R> => {
-        let (name, path) = qualified_name;
-        let name = ProcedureName::new_unchecked(name.clone());
-        let export_name = alias.map(ProcedureName::new_unchecked).unwrap_or_else(|| name.clone());
-        let target = FullyQualifiedProcedureName {
-            span: span!(l, r),
-            module: path,
-            name,
+    <l:@L> "export" "." <name:MaybeQualifiedProcedurePath> <alias:("->" <ProcedureName>)?> <r:@R> =>? {
+        let span = span!(l, r);
+        let alias = match name {
+            InvocationTarget::ProcedureName(_) =>  return Err(ParseError::User {
+                error: ParsingError::UnqualifiedImport { span },
+            }),
+            InvocationTarget::MastRoot(digest) => {
+                if alias.is_none() {
+                    return Err(ParseError::User {
+                        error: ParsingError::UnnamedReexportOfMastRoot { span },
+                    });
+                }
+                ProcedureAlias::new(alias.unwrap(), digest, true)
+            }
+            InvocationTarget::ProcedurePath { name, module } => {
+                let export_name = alias.unwrap_or_else(|| name.clone());
+                let module = match module.as_str() {
+                    LibraryNamespace::KERNEL_PATH => LibraryPath::new_from_components(LibraryNamespace::Kernel, []),
+                    LibraryNamespace::EXEC_PATH => LibraryPath::new_from_components(LibraryNamespace::Exec, []),
+                    LibraryNamespace::ANON_PATH => LibraryPath::new_from_components(LibraryNamespace::Anon, []),
+                    _ => LibraryPath::new_from_components(LibraryNamespace::User(module.into_inner()), []),
+                };
+                let target = FullyQualifiedProcedureName {
+                    span,
+                    module,
+                    name,
+                };
+                ProcedureAlias::new(export_name, target, false)
+            }
+            InvocationTarget::AbsoluteProcedurePath { name, path } => {
+                let export_name = alias.unwrap_or_else(|| name.clone());
+                let target = FullyQualifiedProcedureName {
+                    span,
+                    module: path,
+                    name,
+                };
+                ProcedureAlias::new(export_name, target, true)
+            }
         };
-        let alias = ProcedureAlias::new(export_name, target)
-                        .with_source_file(Some(source_file.clone()));
-        Form::Procedure(Export::Alias(alias))
+        let alias = alias.with_source_file(Some(source_file.clone()));
+        Ok(Form::Procedure(Export::Alias(alias)))
     }
 }
 
@@ -543,20 +572,9 @@ MaybeAssertCode: Option<Immediate<u32>> = {
 }
 
 Call: Instruction = {
-    "exec" "." <callee:Callee> => Instruction::Exec(callee),
-    "call" "." <callee:Callee> => Instruction::Call(callee),
-    "syscall" "." <callee:Callee> => Instruction::SysCall(callee),
-}
-
-Callee: InvocationTarget = {
-    <MastRoot> => InvocationTarget::MastRoot(<>),
-    <module_name:(<BareIdent> "::")?> <name:BareProcedureName> => {
-        match module_name {
-            Some(module) => InvocationTarget::ProcedurePath { name, module },
-            None => InvocationTarget::ProcedureName(name),
-        }
-    },
-    <QuotedProcedureName> => InvocationTarget::ProcedureName(<>),
+    "exec" "." <callee:InvocationTarget> => Instruction::Exec(callee),
+    "call" "." <callee:InvocationTarget> => Instruction::Call(callee),
+    "syscall" "." <callee:InvocationTarget> => Instruction::SysCall(callee),
 }
 
 #[inline]
@@ -587,23 +605,8 @@ Debug: Instruction = {
 
 #[inline]
 ProcRef: Instruction = {
-    "procref" "." <l:@L> <target:MaybeQualifiedName> <r:@R> => {
-        match target {
-            (name, None) => {
-                let name = ProcedureName::new_unchecked(name);
-                Instruction::ProcRef(InvocationTarget::ProcedureName(name))
-            },
-            (name, Some(module)) => {
-                let module = match module.namespace() {
-                    LibraryNamespace::User(ns) => Ident::new_unchecked(Span::new(span!(l, r), ns.clone())),
-                    _ => unreachable!(),
-                };
-                Instruction::ProcRef(InvocationTarget::ProcedurePath {
-                    name: ProcedureName::new_unchecked(name),
-                    module,
-                })
-            }
-        }
+    "procref" "." <l:@L> <target:InvocationTarget> <r:@R> => {
+        Instruction::ProcRef(target)
     }
 }
 
@@ -1219,6 +1222,54 @@ QuotedProcedureName: ProcedureName = {
     }
 }
 
+InvocationTarget: InvocationTarget = {
+    <MastRoot> => InvocationTarget::MastRoot(<>),
+    MaybeQualifiedProcedurePath,
+}
+
+MaybeQualifiedProcedurePath: InvocationTarget = {
+    "::" <components:(<BareIdent> "::")*> <name:ProcedureName> =>? {
+        // A fully-qualified path without a module is routed to the anonymous namespace
+        if components.is_empty() {
+            let path = LibraryPath::new_from_components(LibraryNamespace::Anon, []);
+            return Ok(InvocationTarget::AbsoluteProcedurePath { name, path });
+        }
+
+        // Otherwise, use the path specified
+        let mut components = VecDeque::from(components);
+        let ns = components.pop_front().unwrap();
+        let ns = match ns.as_str() {
+            // Disallow the use of special namespaces with other components
+            special_ns @ (
+                LibraryNamespace::KERNEL_PATH
+                | LibraryNamespace::EXEC_PATH
+                | LibraryNamespace::ANON_PATH
+            ) if !components.is_empty() => {
+                return Err(ParseError::User {
+                    error: ParsingError::InvalidLibraryPath {
+                        span: ns.span(),
+                        message: format!("the {special_ns} namespace cannot have submodules")
+                    },
+                });
+            }
+            LibraryNamespace::KERNEL_PATH => LibraryNamespace::Kernel,
+            LibraryNamespace::EXEC_PATH => LibraryNamespace::Exec,
+            LibraryNamespace::ANON_PATH => LibraryNamespace::Anon,
+            _ => LibraryNamespace::User(ns.into_inner()),
+        };
+        let path = LibraryPath::new_from_components(ns, components);
+        Ok(InvocationTarget::AbsoluteProcedurePath { name, path })
+    },
+
+    <module:(<BareIdent> "::")?> <name:ProcedureName> => {
+        if let Some(module) = module {
+            InvocationTarget::ProcedurePath { name, module }
+        } else {
+            InvocationTarget::ProcedureName(name)
+        }
+    }
+}
+
 #[inline]
 BareIdent: Ident = {
     <l:@L> <name:bare_ident> <r:@R> => {
@@ -1243,6 +1294,19 @@ MaybeQualifiedName: (Ident, Option<LibraryPath>) = {
             let mut components = VecDeque::from(components);
             let ns = components.pop_front().unwrap();
             let ns = match ns.as_str() {
+                // Disallow the use of special namespaces with other components
+                special_ns @ (
+                    LibraryNamespace::KERNEL_PATH
+                    | LibraryNamespace::EXEC_PATH
+                    | LibraryNamespace::ANON_PATH
+                ) if !components.is_empty() => {
+                    return Err(ParseError::User {
+                        error: ParsingError::InvalidLibraryPath {
+                            span: ns.span(),
+                            message: format!("the {special_ns} namespace cannot have submodules")
+                        },
+                    });
+                }
                 LibraryNamespace::KERNEL_PATH => LibraryNamespace::Kernel,
                 LibraryNamespace::EXEC_PATH => LibraryNamespace::Exec,
                 LibraryNamespace::ANON_PATH => LibraryNamespace::Anon,
@@ -1259,6 +1323,19 @@ QualifiedName: (Ident, LibraryPath) = {
 
         let name = components.pop().unwrap();
         let ns = match first.as_str() {
+            // Disallow the use of special namespaces with other components
+            special_ns @ (
+                LibraryNamespace::KERNEL_PATH
+                | LibraryNamespace::EXEC_PATH
+                | LibraryNamespace::ANON_PATH
+            ) if !components.is_empty() => {
+                return Err(ParseError::User {
+                    error: ParsingError::InvalidLibraryPath {
+                        span: first.span(),
+                        message: format!("the {special_ns} namespace cannot have submodules")
+                    },
+                });
+            }
             LibraryNamespace::KERNEL_PATH => LibraryNamespace::Kernel,
             LibraryNamespace::EXEC_PATH => LibraryNamespace::Exec,
             LibraryNamespace::ANON_PATH => LibraryNamespace::Anon,

--- a/assembly/src/parser/lexer.rs
+++ b/assembly/src/parser/lexer.rs
@@ -426,7 +426,7 @@ impl<'input> Lexer<'input> {
                     self.skip();
                     continue;
                 }
-                '_' | '.' | '$' => {
+                '_' | '$' | '-' | '!' | '?' | '<' | '>' | ':' | '.' => {
                     self.skip();
                     continue;
                 }

--- a/assembly/src/sema/passes/verify_invoke.rs
+++ b/assembly/src/sema/passes/verify_invoke.rs
@@ -136,7 +136,12 @@ impl<'a> VisitMut for VerifyInvokeTargets<'a> {
     fn visit_mut_invoke_target(&mut self, target: &mut InvocationTarget) -> ControlFlow<()> {
         let span = target.span();
         match target {
-            InvocationTarget::MastRoot(_) | InvocationTarget::AbsoluteProcedurePath { .. } => (),
+            InvocationTarget::MastRoot(_) => (),
+            InvocationTarget::AbsoluteProcedurePath { name, path } => {
+                if self.module.path() == path && &self.current_procedure == name {
+                    self.analyzer.error(SemanticAnalysisError::SelfRecursive { span });
+                }
+            }
             InvocationTarget::ProcedureName(ref name) if name == &self.current_procedure => {
                 self.analyzer.error(SemanticAnalysisError::SelfRecursive { span });
             }


### PR DESCRIPTION
This PR does two things:

* Adds syntax for specifying absolute paths to procedures/modules in MASM, specifically, prefixing a path with `::` (just like in Rust) will treat the resulting path as absolute and fully-qualified, regardless of imports or other context.
* Ensures absolute paths are handled correctly throughout the assembler. Some support already existed, but was not complete due to lack of frontend implementation.

Additionally, it fixes some bugs with the current frontend around procedure paths and special namespaces.

When absolute paths are used, one does not need to explicitly import the module containing the referenced item, as there is no need for an import when the dependency is explicit.

**NOTE:** Due to uniformity of syntax representation in the parser, it is now possible to define procedure aliases for items referenced by MAST root. However, unless the module containing that root is provided during compilation (or the procedure is available in the procedure cache), then assembly will fail on these items. Additional refactoring will be required to support phantom references like this fully, as the lack of support at this time is due to the original assumptions of the assembler, i.e. that all code will be available during assembly.

## Example

There is a test case in the assembler, but the gist is:

```
# foo.masm

export.foo
    add
end

# bar.masm

export.::foo::foo->bar

# main.masm

begin
    exec.::bar::bar
end
```

As you can see above, no imports are required, and the code compiles/behaves as if the correct imports were present. Both procedure aliases and procedure calls, support the new syntax.

## Motivation

Supporting absolute paths means a compiler does not need to try and generate code with imports for all of the procedure calls in a given module, it can simply emit procedure calls in absolute form, and elide the imports entirely. Doing so made little sense anyway, as the assembler must resolve all callees to their absolute form during assembly anyway, so we would be doing unnecessary work for no reason.

This also reduces the importance of the MASM namespace/module system, since this PR also enables one to emit a module that can be parsed anonymously, with all calls specified absolutely (i.e. as a flat namespace).

