### PR TITLE
Return proper message at underflow

### DIFF
--- a/assembly/src/assembler/instruction/mem_ops.rs
+++ b/assembly/src/assembler/instruction/mem_ops.rs
@@ -1,5 +1,6 @@
 use super::{push_felt, push_u32_value, validate_param, AssemblyContext, BasicBlockBuilder};
-use crate::AssemblyError;
+use crate::{diagnostics::Report, AssemblyError};
+use alloc::string::ToString;
 use vm_core::{Felt, Operation::*};
 
 // INSTRUCTION PARSERS
@@ -112,6 +113,16 @@ pub fn local_to_absolute_addr(
     index: u16,
     num_proc_locals: u16,
 ) -> Result<(), AssemblyError> {
+    if num_proc_locals == 0 {
+        return Err(AssemblyError::Other(
+            Report::msg(
+                "number of procedure locals was not set (or set to 0), but local values were used"
+                    .to_string(),
+            )
+            .into(),
+        ));
+    }
+
     let max = num_proc_locals - 1;
     validate_param(index, 0..=max)?;
 

--- a/assembly/src/tests.rs
+++ b/assembly/src/tests.rs
@@ -1355,6 +1355,31 @@ end";
 }
 
 #[test]
+fn program_with_proc_locals_fail() -> TestResult {
+    let mut context = TestContext::default();
+    let source = source_file!(
+        "\
+        proc.foo \
+            loc_store.0 \
+            add \
+            loc_load.0 \
+            mul \
+        end \
+        begin \
+            push.4 push.3 push.2 \
+            exec.foo \
+        end"
+    );
+    assert_assembler_diagnostic!(
+        context,
+        source,
+        "number of procedure locals was not set (or set to 0), but local values were used"
+    );
+
+    Ok(())
+}
+
+#[test]
 fn program_with_exported_procedure() -> TestResult {
     let mut context = TestContext::default();
     let source =


### PR DESCRIPTION
This small PR adds an underflow check in the [local_to_absolute_addr](https://github.com/0xPolygonMiden/miden-vm/blob/ddf536cd7157053f0940d7be41998b2a6546b4c1/assembly/src/assembler/instruction/mem_ops.rs#L110) function and return of proper error message instead of panic "subtract with underflow" one.

Related issue: #1372 
