### PR TITLE
feat(processor): expose the process api

### DIFF
--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -162,8 +162,17 @@ where
 // PROCESS
 // ================================================================================================
 
+/// A [Process] is the underlying execution engine for a Miden [Program].
+///
+/// Typically, you do not need to worry about, or use [Process] directly, instead you should prefer
+/// to use either [execute] or [execute_iter], which also handle setting up the process state,
+/// inputs, as well as compute the [ExecutionTrace] for the program.
+///
+/// However, for situations in which you want finer-grained control over those steps, you will need
+/// to construct an instance of [Process] using [Process::new], invoke [Process::execute], and then
+/// get the execution trace using [ExecutionTrace::new] using the outputs produced by execution.
 #[cfg(not(any(test, feature = "internals")))]
-struct Process<H>
+pub struct Process<H>
 where
     H: Host,
 {
@@ -175,6 +184,21 @@ where
     host: RefCell<H>,
     max_cycles: u32,
     enable_tracing: bool,
+}
+
+#[cfg(any(test, feature = "internals"))]
+pub struct Process<H>
+where
+    H: Host,
+{
+    pub system: System,
+    pub decoder: Decoder,
+    pub stack: Stack,
+    pub range: RangeChecker,
+    pub chiplets: Chiplets,
+    pub host: RefCell<H>,
+    pub max_cycles: u32,
+    pub enable_tracing: bool,
 }
 
 impl<H> Process<H>
@@ -644,22 +668,4 @@ impl<H: Host> ProcessState for Process<H> {
     fn get_mem_state(&self, ctx: ContextId) -> Vec<(u64, Word)> {
         self.chiplets.get_mem_state_at(ctx, self.system.clk())
     }
-}
-
-// INTERNALS
-// ================================================================================================
-
-#[cfg(any(test, feature = "internals"))]
-pub struct Process<H>
-where
-    H: Host,
-{
-    pub system: System,
-    pub decoder: Decoder,
-    pub stack: Stack,
-    pub range: RangeChecker,
-    pub chiplets: Chiplets,
-    pub host: RefCell<H>,
-    pub max_cycles: u32,
-    pub enable_tracing: bool,
 }


### PR DESCRIPTION
While doing some testing in the compiler where I wanted to set up some VM state and then execute a program on that state, I realized that there is no currently public API that allows one to access the state of the process to do so, short of using the `internals` feature flag of the crate.

Rather than requiring the use of that flag, this commit instead makes public the [Process] struct, but with all of its fields private unless the `internals` flag is enabled. This makes it possible to use the public APIs of the various traits implemented by `Process` to interact with it in a more fine-grained fashion.

It is still expected that most people will use the `execute` or `execute_iter` APIs, but this makes it possible to take control over that yourself when necessary/useful. I should also note that we were making the [Process] struct visible for ourselves under `#[cfg(test)]`, so it is clearly useful in certain cases (namely testing).
