### PR TITLE
feat(processor): allow public construction of execution trace

### DIFF
--- a/processor/src/trace/mod.rs
+++ b/processor/src/trace/mod.rs
@@ -66,7 +66,7 @@ impl ExecutionTrace {
     // CONSTRUCTOR
     // --------------------------------------------------------------------------------------------
     /// Builds an execution trace for the provided process.
-    pub(super) fn new<H>(process: Process<H>, stack_outputs: StackOutputs) -> Self
+    pub fn new<H>(process: Process<H>, stack_outputs: StackOutputs) -> Self
     where
         H: Host,
     {


### PR DESCRIPTION
Missed this when making `Process` public, but it is necessary to be able to construct an `ExecutionTrace` when you manually construct/execute a `Process`.