### PR TITLE
feat(processor): allow public construction of vm state iterator

### DIFF
--- a/processor/src/debug.rs
+++ b/processor/src/debug.rs
@@ -63,7 +63,7 @@ pub struct VmStateIterator {
 }
 
 impl VmStateIterator {
-    pub(super) fn new<H>(process: Process<H>, result: Result<StackOutputs, ExecutionError>) -> Self
+    pub fn new<H>(process: Process<H>, result: Result<StackOutputs, ExecutionError>) -> Self
     where
         H: Host,
     {


### PR DESCRIPTION
Sorry for the noise, but found another API that should be public connected to `Process`. I _think_ this is the last one, but if you have any thoughts on others I may run into as I work through testing in the compiler, let me know.