### PR TITLE
Rename `internals` feature to `testing`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 #### Changed
 
 - When using `if.(true|false) .. end`, the parser used to emit an empty block for the branch that was elided. The parser now emits a block containing a single `nop` instruction instead, which is equivalent to the code emitted by the assembler when lowering to MAST.
+- `internals` configuration feature was renamed to `testing` (#1399).
 
 ## 0.9.2 (2024-05-22) - `stdlib` crate only
 

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ mdbook: ## Generates mdbook documentation
 
 .PHONY: test
 test: ## Runs all tests
-	$(DEBUG_ASSERTIONS) cargo nextest run --cargo-profile test-release --features internals
+	$(DEBUG_ASSERTIONS) cargo nextest run --cargo-profile test-release --features testing
 
 # --- checking ------------------------------------------------------------------------------------
 

--- a/air/Cargo.toml
+++ b/air/Cargo.toml
@@ -28,7 +28,7 @@ harness = false
 [features]
 default = ["std"]
 std = ["vm-core/std", "winter-air/std"]
-internals = []
+testing = []
 
 [dependencies]
 vm-core = { package = "miden-core", path = "../core", version = "0.9", default-features = false }

--- a/air/src/trace/main_trace.rs
+++ b/air/src/trace/main_trace.rs
@@ -19,7 +19,7 @@ use super::{
 use core::ops::{Deref, Range};
 use vm_core::{utils::range, Felt, Word, ONE, ZERO};
 
-#[cfg(any(test, feature = "internals"))]
+#[cfg(any(test, feature = "testing"))]
 use alloc::vec::Vec;
 
 // CONSTANTS
@@ -54,7 +54,7 @@ impl MainTrace {
         self.columns.num_rows()
     }
 
-    #[cfg(any(test, feature = "internals"))]
+    #[cfg(any(test, feature = "testing"))]
     pub fn get_column_range(&self, range: Range<usize>) -> Vec<Vec<Felt>> {
         range.fold(vec![], |mut acc, col_idx| {
             acc.push(self.get_column(col_idx).to_vec());

--- a/processor/Cargo.toml
+++ b/processor/Cargo.toml
@@ -20,7 +20,7 @@ doctest = false
 [features]
 concurrent = ["std", "winter-prover/concurrent"]
 default = ["std"]
-internals = ["miden-air/internals"]
+testing = ["miden-air/testing"]
 std = ["vm-core/std", "winter-prover/std"]
 
 [dependencies]

--- a/processor/src/host/advice/inputs.rs
+++ b/processor/src/host/advice/inputs.rs
@@ -18,7 +18,7 @@ use vm_core::crypto::hash::RpoDigest;
 /// 2. Key-mapped element lists which can be pushed onto the advice stack.
 /// 3. Merkle store, which is used to provide nondeterministic inputs for instructions that operates
 ///    with Merkle trees.
-#[cfg(not(feature = "internals"))]
+#[cfg(not(feature = "testing"))]
 #[derive(Clone, Debug, Default)]
 pub struct AdviceInputs {
     stack: Vec<Felt>,
@@ -132,10 +132,10 @@ impl AdviceInputs {
     }
 }
 
-// INTERNALS
+// TESTING
 // ================================================================================================
 
-#[cfg(feature = "internals")]
+#[cfg(feature = "testing")]
 #[derive(Clone, Debug, Default)]
 pub struct AdviceInputs {
     pub stack: Vec<Felt>,

--- a/processor/src/host/advice/providers.rs
+++ b/processor/src/host/advice/providers.rs
@@ -243,7 +243,7 @@ impl From<AdviceInputs> for MemAdviceProvider {
 }
 
 /// Accessors to internal data structures of the provider used for testing purposes.
-#[cfg(any(test, feature = "internals"))]
+#[cfg(any(test, feature = "testing"))]
 impl MemAdviceProvider {
     /// Returns the current state of the advice stack.
     pub fn stack(&self) -> &[Felt] {
@@ -364,7 +364,7 @@ impl From<AdviceInputs> for RecAdviceProvider {
 }
 
 /// Accessors to internal data structures of the provider used for testing purposes.
-#[cfg(any(test, feature = "internals"))]
+#[cfg(any(test, feature = "testing"))]
 impl RecAdviceProvider {
     /// Returns the current state of the advice stack.
     pub fn stack(&self) -> &[Felt] {

--- a/processor/src/host/mod.rs
+++ b/processor/src/host/mod.rs
@@ -309,12 +309,12 @@ where
         self.store.insert(mast_forest)
     }
 
-    #[cfg(any(test, feature = "internals"))]
+    #[cfg(any(test, feature = "testing"))]
     pub fn advice_provider(&self) -> &A {
         &self.adv_provider
     }
 
-    #[cfg(any(test, feature = "internals"))]
+    #[cfg(any(test, feature = "testing"))]
     pub fn advice_provider_mut(&mut self) -> &mut A {
         &mut self.adv_provider
     }

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -171,7 +171,7 @@ where
 /// However, for situations in which you want finer-grained control over those steps, you will need
 /// to construct an instance of [Process] using [Process::new], invoke [Process::execute], and then
 /// get the execution trace using [ExecutionTrace::new] using the outputs produced by execution.
-#[cfg(not(any(test, feature = "internals")))]
+#[cfg(not(any(test, feature = "testing")))]
 pub struct Process<H>
 where
     H: Host,
@@ -186,7 +186,7 @@ where
     enable_tracing: bool,
 }
 
-#[cfg(any(test, feature = "internals"))]
+#[cfg(any(test, feature = "testing"))]
 pub struct Process<H>
 where
     H: Host,

--- a/processor/src/stack/mod.rs
+++ b/processor/src/stack/mod.rs
@@ -330,7 +330,7 @@ impl Stack {
 
     /// Returns state of stack item columns at the current clock cycle. This does not include stack
     /// values in the overflow table.
-    #[cfg(any(test, feature = "internals"))]
+    #[cfg(any(test, feature = "testing"))]
     pub fn trace_state(&self) -> [Felt; STACK_TOP_SIZE] {
         self.trace.get_stack_state_at(self.clk)
     }

--- a/processor/src/stack/trace.rs
+++ b/processor/src/stack/trace.rs
@@ -200,7 +200,7 @@ impl StackTrace {
     // --------------------------------------------------------------------------------------------
 
     /// Returns the stack trace state at the specified clock cycle.
-    #[cfg(any(test, feature = "internals"))]
+    #[cfg(any(test, feature = "testing"))]
     pub fn get_stack_state_at(&self, clk: u32) -> [Felt; STACK_TOP_SIZE] {
         let mut result = [ZERO; STACK_TOP_SIZE];
         for (result, column) in result.iter_mut().zip(self.stack.iter()) {

--- a/stdlib/Cargo.toml
+++ b/stdlib/Cargo.toml
@@ -35,7 +35,7 @@ num = "0.4.1"
 num-bigint = "0.4"
 pretty_assertions = "1.4"
 processor = { package = "miden-processor", path = "../processor", version = "0.9", default-features = false, features = [
-    "internals",
+    "testing",
 ] }
 rand = { version = "0.8.5", default-features = false }
 serde_json = "1.0"

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -28,7 +28,7 @@ assembly = { package = "miden-assembly", path = "../assembly", version = "0.9", 
     "testing",
 ] }
 processor = { package = "miden-processor", path = "../processor", version = "0.9", default-features = false, features = [
-    "internals",
+    "testing",
 ] }
 prover = { package = "miden-prover", path = "../prover", version = "0.9", default-features = false }
 test-case = "3.2"


### PR DESCRIPTION
This small PR renames the `internals` feature to `testing`. 

Related issue: #1396 
