### PR TITLE
Add `changelog.yml` file

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,27 @@
+# Runs changelog related jobs.
+
+name: changelog
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@main
+        with:
+          fetch-depth: 0
+      - name: Check if CHANGELOG.md is modified
+        run: |
+          # Get the list of changed files in the PR
+          changed_files=$(git diff --name-only origin/${{ github.event.pull_request.base.ref }}...${{ github.sha }})
+          # Check if CHANGELOG.md is in the list of changed files
+          if echo "$changed_files" | grep -q '^CHANGELOG.md$'; then
+            echo "CHANGELOG.md has been modified."
+          else
+            echo $'::warning file=CHANGELOG.md::CHANGELOG.md has not been modified.\n This warning can be ignored if is has been explicitely decided not to log changes.\n Except in this situation, make sure to add log changes.'
+            exit 1
+          fi

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,4 +1,5 @@
 # Runs changelog related jobs.
+# CI job heavily inspired by: https://github.com/tarides/changelog-check-action
 
 name: changelog
 
@@ -7,10 +8,8 @@ on:
     types: [opened, reopened, synchronize]
 
 jobs:
-  # CI job heavily inspired by: https://github.com/tarides/changelog-check-action
   changelog:
     runs-on: ubuntu-latest
-    using: "composite"
     steps:
       - name: Checkout code
         uses: actions/checkout@main

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -7,21 +7,18 @@ on:
     types: [opened, reopened, synchronize]
 
 jobs:
+  # CI job heavily inspired by: https://github.com/tarides/changelog-check-action
   changelog:
     runs-on: ubuntu-latest
+    using: "composite"
     steps:
       - name: Checkout code
         uses: actions/checkout@main
         with:
           fetch-depth: 0
-      - name: Check if CHANGELOG.md is modified
-        run: |
-          # Get the list of changed files in the PR
-          changed_files=$(git diff --name-only origin/${{ github.event.pull_request.base.ref }}...${{ github.sha }})
-          # Check if CHANGELOG.md is in the list of changed files
-          if echo "$changed_files" | grep -q '^CHANGELOG.md$'; then
-            echo "CHANGELOG.md has been modified."
-          else
-            echo $'::warning file=CHANGELOG.md::CHANGELOG.md has not been modified.\n This warning can be ignored if is has been explicitely decided not to log changes.\n Except in this situation, make sure to add log changes.'
-            exit 1
-          fi
+      - name: Check for changes in changelog
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          NO_CHANGELOG_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'no changelog') }}
+        run: ./scripts/check-changelog.sh "${{ inputs.changelog }}"
+        shell: bash

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -51,23 +51,3 @@ jobs:
           override: true
       - name: check rust versions
         run: ./scripts/check-rust-version.sh
-
-  changelog:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@main
-        with:
-          fetch-depth: 0
-      - name: Check if CHANGELOG.md is modified
-        run: |
-          # Get the list of changed files in the PR
-          changed_files=$(git diff --name-only origin/${{ github.event.pull_request.base.ref }}...${{ github.sha }})
-
-          # Check if CHANGELOG.md is in the list of changed files
-          if echo "$changed_files" | grep -q '^CHANGELOG.md$'; then
-            echo "CHANGELOG.md has been modified."
-          else
-            echo $'::warning file=CHANGELOG.md::CHANGELOG.md has not been modified.\n This warning can be ignored if is has been explicitely decided not to log changes.\n Except in this situation, make sure to add log changes.'
-            exit 1
-          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 #### Enhancements
 
-- Updated CI and Makefile to standardise it accross Miden repositories (#1342).
 - Added error codes support for the `mtree_verify` instruction (#1328).
 - Added support for immediate values for `lt`, `lte`, `gt`, `gte` comparison instructions (#1346).
 - Change MAST to a table-based representation (#1349)
@@ -16,7 +15,9 @@
 - Relaxed the parser to allow one branch of an `if.(true|false)` to be empty
 - Added support for immediate values for `u32and`, `u32or`, `u32xor` and `u32not` bitwise instructions (#1362).
 - Optimized `std::sys::truncate_stuck` procedure (#1384).
+- Updated CI and Makefile to standardise it accross Miden repositories (#1342).
 - Add serialization/deserialization for `MastForest` (#1370)
+- Updated CI to support `CHANGELOG.md` modification checking and `no changelog` label (#1406)
 
 #### Changed
 

--- a/scripts/check-changelog.sh
+++ b/scripts/check-changelog.sh
@@ -5,15 +5,15 @@ CHANGELOG_FILE="${1:-CHANGES.md}"
 
 if [ "${NO_CHANGELOG_LABEL}" = "true" ]; then
     # 'no changelog' set, so finish successfully
-    echo "::info no changelog label has been set"
+    echo $'::info no changelog label has been set'
     exit 0
 else
     # a changelog check is required
     # fail if the diff is empty
     if git diff --exit-code "origin/${BASE_REF}" -- "${CHANGELOG_FILE}"; then
-        >&2 echo "::warning Changes should come with an entry in the CHANGELOG.md file. This behavior
+        >&2 echo $'::warning Changes should come with an entry in the CHANGELOG.md file. This behavior
 can be overridden by using the \"no changelog\" label, which is used for changes
-that trivial / explicitely decided not to need a changelog entry."
+that trivial / explicitely decided not to need a changelog entry.'
         exit 1
     fi
 fi

--- a/scripts/check-changelog.sh
+++ b/scripts/check-changelog.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -uo pipefail
+
+CHANGELOG_FILE="${1:-CHANGES.md}"
+
+if [ "${NO_CHANGELOG_LABEL}" = "true" ]; then
+    # 'no changelog' set, so finish successfully
+    echo "::info no changelog label has been set"
+    exit 0
+else
+    # a changelog check is required
+    # fail if the diff is empty
+    if git diff --exit-code "origin/${BASE_REF}" -- "${CHANGELOG_FILE}"; then
+        >&2 echo "::warning Changes should come with an entry in the CHANGELOG.md file. This behavior
+can be overridden by using the \"no changelog\" label, which is used for changes
+that trivial / explicitely decided not to need a changelog entry."
+        exit 1
+    fi
+fi

--- a/scripts/check-changelog.sh
+++ b/scripts/check-changelog.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -uo pipefail
 
-CHANGELOG_FILE="${1:-CHANGES.md}"
+CHANGELOG_FILE="${1:-CHANGELOG.md}"
 
 if [ "${NO_CHANGELOG_LABEL}" = "true" ]; then
     # 'no changelog' set, so finish successfully

--- a/scripts/check-changelog.sh
+++ b/scripts/check-changelog.sh
@@ -5,15 +5,15 @@ CHANGELOG_FILE="${1:-CHANGES.md}"
 
 if [ "${NO_CHANGELOG_LABEL}" = "true" ]; then
     # 'no changelog' set, so finish successfully
-    echo $'::info no changelog label has been set'
+    echo "\"no changelog\" label has been set"
     exit 0
 else
     # a changelog check is required
     # fail if the diff is empty
     if git diff --exit-code "origin/${BASE_REF}" -- "${CHANGELOG_FILE}"; then
-        >&2 echo $'::warning Changes should come with an entry in the CHANGELOG.md file. This behavior
+        >&2 echo "Changes should come with an entry in the CHANGELOG.md file. This behavior
 can be overridden by using the \"no changelog\" label, which is used for changes
-that trivial / explicitely decided not to need a changelog entry.'
+that are trivial / explicitely stated not to require a changelog entry."
         exit 1
     fi
 fi

--- a/scripts/check-changelog.sh
+++ b/scripts/check-changelog.sh
@@ -11,9 +11,11 @@ else
     # a changelog check is required
     # fail if the diff is empty
     if git diff --exit-code "origin/${BASE_REF}" -- "${CHANGELOG_FILE}"; then
-        >&2 echo "Changes should come with an entry in the CHANGELOG.md file. This behavior
+        >&2 echo "Changes should come with an entry in the \"CHANGELOG.md\" file. This behavior
 can be overridden by using the \"no changelog\" label, which is used for changes
 that are trivial / explicitely stated not to require a changelog entry."
         exit 1
     fi
+
+    echo "The \"CHANGELOG.md\" file has been updated."
 fi


### PR DESCRIPTION
In this PR I add a `changelog.yml` file. 

This should solve this issue of failing `changelog` CI job on push to `next` or `main`. 

My rationale is that the `CHANGELOG.md` file is considered modified when the PR is still opened but on merge this job should not be ran because the PR context does not exist anymore.

It also adds logic to support the `no changelog` label that can be put on a PR that does not require an update in the `CHANGELOG.md` file.

Once this PR is merged and we confirmed it's functionality I will port these changes to the:
- Node
- Base

And then follow your recommendations regarding other repositories.
