### PR TITLE
Newtype RowIndex(u32)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Added source code management primitives in `miden-core` (#1419)
 - Added `make test-fast` and `make test-skip-proptests` Makefile targets for faster testing during local development
 - Added `ProgramFile::read_with` constructor that takes a `SourceManager` impl to use for source management
+- Added `RowIndex(u32)` (#1408)
 
 #### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -998,6 +998,7 @@ dependencies = [
  "criterion",
  "miden-core",
  "proptest",
+ "thiserror",
  "winter-air",
  "winter-prover",
  "winter-rand-utils",
@@ -1131,6 +1132,7 @@ dependencies = [
 name = "miden-test-utils"
 version = "0.1.0"
 dependencies = [
+ "miden-air",
  "miden-assembly",
  "miden-core",
  "miden-processor",

--- a/air/Cargo.toml
+++ b/air/Cargo.toml
@@ -27,13 +27,14 @@ harness = false
 
 [features]
 default = ["std"]
-std = ["vm-core/std", "winter-air/std"]
+std = ["vm-core/std", "winter-air/std", "thiserror/std"]
 testing = []
 
 [dependencies]
 vm-core = { package = "miden-core", path = "../core", version = "0.10", default-features = false }
 winter-air = { package = "winter-air", version = "0.9", default-features = false }
 winter-prover = { package = "winter-prover", version = "0.9", default-features = false }
+thiserror = { version = "1.0", git = "https://github.com/bitwalker/thiserror", branch = "no-std", default-features = false }
 
 [dev-dependencies]
 criterion = "0.5"

--- a/air/src/constraints/chiplets/bitwise/mod.rs
+++ b/air/src/constraints/chiplets/bitwise/mod.rs
@@ -418,16 +418,3 @@ pub fn agg_bits<E: FieldElement>(row: &[E], start_idx: usize) -> E {
 pub const BITWISE_K0_MASK: [Felt; OP_CYCLE_LEN] = [ONE, ZERO, ZERO, ZERO, ZERO, ZERO, ZERO, ZERO];
 
 pub const BITWISE_K1_MASK: [Felt; OP_CYCLE_LEN] = [ONE, ONE, ONE, ONE, ONE, ONE, ONE, ZERO];
-
-// TEST HELPERS
-// ================================================================================================
-
-/// Returns the values from the bitwise periodic columns for the specified cycle row.
-#[cfg(test)]
-fn get_periodic_values(cycle_row: usize) -> [Felt; 2] {
-    match cycle_row {
-        0 => [ONE, ONE],
-        8 => [ZERO, ZERO],
-        _ => [ZERO, ONE],
-    }
-}

--- a/air/src/lib.rs
+++ b/air/src/lib.rs
@@ -23,6 +23,7 @@ pub use constraints::stack;
 use constraints::{chiplets, range};
 
 pub mod trace;
+pub use trace::rows::RowIndex;
 use trace::*;
 
 mod errors;

--- a/air/src/trace/main_trace.rs
+++ b/air/src/trace/main_trace.rs
@@ -1,3 +1,5 @@
+use crate::RowIndex;
+
 use super::{
     super::ColMatrix,
     chiplets::{
@@ -66,17 +68,17 @@ impl MainTrace {
     // --------------------------------------------------------------------------------------------
 
     /// Returns the value of the clk column at row i.
-    pub fn clk(&self, i: usize) -> Felt {
+    pub fn clk(&self, i: RowIndex) -> Felt {
         self.columns.get_column(CLK_COL_IDX)[i]
     }
 
     /// Returns the value of the fmp column at row i.
-    pub fn fmp(&self, i: usize) -> Felt {
+    pub fn fmp(&self, i: RowIndex) -> Felt {
         self.columns.get_column(FMP_COL_IDX)[i]
     }
 
     /// Returns the value of the ctx column at row i.
-    pub fn ctx(&self, i: usize) -> Felt {
+    pub fn ctx(&self, i: RowIndex) -> Felt {
         self.columns.get_column(CTX_COL_IDX)[i]
     }
 
@@ -84,22 +86,22 @@ impl MainTrace {
     // --------------------------------------------------------------------------------------------
 
     /// Returns the value in the block address column at the row i.
-    pub fn addr(&self, i: usize) -> Felt {
+    pub fn addr(&self, i: RowIndex) -> Felt {
         self.columns.get_column(DECODER_TRACE_OFFSET)[i]
     }
 
     /// Helper method to detect change of address.
-    pub fn is_addr_change(&self, i: usize) -> bool {
+    pub fn is_addr_change(&self, i: RowIndex) -> bool {
         self.addr(i) != self.addr(i + 1)
     }
 
     /// The i-th decoder helper register at `row`.
-    pub fn helper_register(&self, i: usize, row: usize) -> Felt {
+    pub fn helper_register(&self, i: usize, row: RowIndex) -> Felt {
         self.columns.get_column(DECODER_TRACE_OFFSET + USER_OP_HELPERS_OFFSET + i)[row]
     }
 
     /// Returns the hasher state at row i.
-    pub fn decoder_hasher_state(&self, i: usize) -> [Felt; NUM_HASHER_COLUMNS] {
+    pub fn decoder_hasher_state(&self, i: RowIndex) -> [Felt; NUM_HASHER_COLUMNS] {
         let mut state = [ZERO; NUM_HASHER_COLUMNS];
         for (idx, col_idx) in DECODER_HASHER_RANGE.enumerate() {
             let column = self.columns.get_column(col_idx);
@@ -109,7 +111,7 @@ impl MainTrace {
     }
 
     /// Returns the first half of the hasher state at row i.
-    pub fn decoder_hasher_state_first_half(&self, i: usize) -> Word {
+    pub fn decoder_hasher_state_first_half(&self, i: RowIndex) -> Word {
         let mut state = [ZERO; DIGEST_LEN];
         for (col, s) in state.iter_mut().enumerate() {
             *s = self.columns.get_column(DECODER_TRACE_OFFSET + HASHER_STATE_OFFSET + col)[i];
@@ -118,7 +120,7 @@ impl MainTrace {
     }
 
     /// Returns the second half of the hasher state at row i.
-    pub fn decoder_hasher_state_second_half(&self, i: usize) -> Word {
+    pub fn decoder_hasher_state_second_half(&self, i: RowIndex) -> Word {
         const SECOND_WORD_OFFSET: usize = 4;
         let mut state = [ZERO; DIGEST_LEN];
         for (col, s) in state.iter_mut().enumerate() {
@@ -131,12 +133,12 @@ impl MainTrace {
     }
 
     /// Returns a specific element from the hasher state at row i.
-    pub fn decoder_hasher_state_element(&self, element: usize, i: usize) -> Felt {
+    pub fn decoder_hasher_state_element(&self, element: usize, i: RowIndex) -> Felt {
         self.columns.get_column(DECODER_TRACE_OFFSET + HASHER_STATE_OFFSET + element)[i + 1]
     }
 
     /// Returns the current function hash (i.e., root) at row i.
-    pub fn fn_hash(&self, i: usize) -> [Felt; DIGEST_LEN] {
+    pub fn fn_hash(&self, i: RowIndex) -> [Felt; DIGEST_LEN] {
         let mut state = [ZERO; DIGEST_LEN];
         for (col, s) in state.iter_mut().enumerate() {
             *s = self.columns.get_column(FN_HASH_OFFSET + col)[i];
@@ -145,53 +147,53 @@ impl MainTrace {
     }
 
     /// Returns the `is_loop_body` flag at row i.
-    pub fn is_loop_body_flag(&self, i: usize) -> Felt {
+    pub fn is_loop_body_flag(&self, i: RowIndex) -> Felt {
         self.columns.get_column(DECODER_TRACE_OFFSET + IS_LOOP_BODY_FLAG_COL_IDX)[i]
     }
 
     /// Returns the `is_loop` flag at row i.
-    pub fn is_loop_flag(&self, i: usize) -> Felt {
+    pub fn is_loop_flag(&self, i: RowIndex) -> Felt {
         self.columns.get_column(DECODER_TRACE_OFFSET + IS_LOOP_FLAG_COL_IDX)[i]
     }
 
     /// Returns the `is_call` flag at row i.
-    pub fn is_call_flag(&self, i: usize) -> Felt {
+    pub fn is_call_flag(&self, i: RowIndex) -> Felt {
         self.columns.get_column(DECODER_TRACE_OFFSET + IS_CALL_FLAG_COL_IDX)[i]
     }
 
     /// Returns the `is_syscall` flag at row i.
-    pub fn is_syscall_flag(&self, i: usize) -> Felt {
+    pub fn is_syscall_flag(&self, i: RowIndex) -> Felt {
         self.columns.get_column(DECODER_TRACE_OFFSET + IS_SYSCALL_FLAG_COL_IDX)[i]
     }
 
     /// Returns the operation batch flags at row i. This indicates the number of op groups in
     /// the current batch that is being processed.
-    pub fn op_batch_flag(&self, i: usize) -> [Felt; NUM_OP_BATCH_FLAGS] {
+    pub fn op_batch_flag(&self, i: RowIndex) -> [Felt; NUM_OP_BATCH_FLAGS] {
         [
-            self.columns.get(DECODER_TRACE_OFFSET + OP_BATCH_FLAGS_OFFSET, i),
-            self.columns.get(DECODER_TRACE_OFFSET + OP_BATCH_FLAGS_OFFSET + 1, i),
-            self.columns.get(DECODER_TRACE_OFFSET + OP_BATCH_FLAGS_OFFSET + 2, i),
+            self.columns.get(DECODER_TRACE_OFFSET + OP_BATCH_FLAGS_OFFSET, i.into()),
+            self.columns.get(DECODER_TRACE_OFFSET + OP_BATCH_FLAGS_OFFSET + 1, i.into()),
+            self.columns.get(DECODER_TRACE_OFFSET + OP_BATCH_FLAGS_OFFSET + 2, i.into()),
         ]
     }
 
     /// Returns the operation group count. This indicates the number of operation that remain
     /// to be executed in the current span block.
-    pub fn group_count(&self, i: usize) -> Felt {
+    pub fn group_count(&self, i: RowIndex) -> Felt {
         self.columns.get_column(DECODER_TRACE_OFFSET + GROUP_COUNT_COL_IDX)[i]
     }
 
     /// Returns the delta between the current and next group counts.
-    pub fn delta_group_count(&self, i: usize) -> Felt {
+    pub fn delta_group_count(&self, i: RowIndex) -> Felt {
         self.group_count(i) - self.group_count(i + 1)
     }
 
     /// Returns the `in_span` flag at row i.
-    pub fn is_in_span(&self, i: usize) -> Felt {
+    pub fn is_in_span(&self, i: RowIndex) -> Felt {
         self.columns.get_column(DECODER_TRACE_OFFSET + IN_SPAN_COL_IDX)[i]
     }
 
     /// Constructs the i-th op code value from its individual bits.
-    pub fn get_op_code(&self, i: usize) -> Felt {
+    pub fn get_op_code(&self, i: RowIndex) -> Felt {
         let col_b0 = self.columns.get_column(DECODER_TRACE_OFFSET + 1);
         let col_b1 = self.columns.get_column(DECODER_TRACE_OFFSET + 2);
         let col_b2 = self.columns.get_column(DECODER_TRACE_OFFSET + 3);
@@ -209,18 +211,23 @@ impl MainTrace {
             + b6.mul_small(64)
     }
 
+    /// Returns an iterator of [`RowIndex`] values over the row indices of this trace.
+    pub fn row_iter(&self) -> impl Iterator<Item = RowIndex> {
+        (0..self.num_rows()).map(RowIndex::from)
+    }
+
     /// Returns a flag indicating whether the current operation induces a left shift of the operand
     /// stack.
-    pub fn is_left_shift(&self, i: usize) -> bool {
-        let b0 = self.columns.get(DECODER_TRACE_OFFSET + 1, i);
-        let b1 = self.columns.get(DECODER_TRACE_OFFSET + 2, i);
-        let b2 = self.columns.get(DECODER_TRACE_OFFSET + 3, i);
-        let b3 = self.columns.get(DECODER_TRACE_OFFSET + 4, i);
-        let b4 = self.columns.get(DECODER_TRACE_OFFSET + 5, i);
-        let b5 = self.columns.get(DECODER_TRACE_OFFSET + 6, i);
-        let b6 = self.columns.get(DECODER_TRACE_OFFSET + 7, i);
-        let e0 = self.columns.get(DECODER_TRACE_OFFSET + OP_BITS_EXTRA_COLS_OFFSET, i);
-        let h5 = self.columns.get(DECODER_TRACE_OFFSET + IS_LOOP_FLAG_COL_IDX, i);
+    pub fn is_left_shift(&self, i: RowIndex) -> bool {
+        let b0 = self.columns.get(DECODER_TRACE_OFFSET + 1, i.into());
+        let b1 = self.columns.get(DECODER_TRACE_OFFSET + 2, i.into());
+        let b2 = self.columns.get(DECODER_TRACE_OFFSET + 3, i.into());
+        let b3 = self.columns.get(DECODER_TRACE_OFFSET + 4, i.into());
+        let b4 = self.columns.get(DECODER_TRACE_OFFSET + 5, i.into());
+        let b5 = self.columns.get(DECODER_TRACE_OFFSET + 6, i.into());
+        let b6 = self.columns.get(DECODER_TRACE_OFFSET + 7, i.into());
+        let e0 = self.columns.get(DECODER_TRACE_OFFSET + OP_BITS_EXTRA_COLS_OFFSET, i.into());
+        let h5 = self.columns.get(DECODER_TRACE_OFFSET + IS_LOOP_FLAG_COL_IDX, i.into());
 
         // group with left shift effect grouped by a common prefix
         ([b6, b5, b4] == [ZERO, ONE, ZERO])||
@@ -236,14 +243,14 @@ impl MainTrace {
 
     /// Returns a flag indicating whether the current operation induces a right shift of the operand
     /// stack.
-    pub fn is_right_shift(&self, i: usize) -> bool {
-        let b0 = self.columns.get(DECODER_TRACE_OFFSET + 1, i);
-        let b1 = self.columns.get(DECODER_TRACE_OFFSET + 2, i);
-        let b2 = self.columns.get(DECODER_TRACE_OFFSET + 3, i);
-        let b3 = self.columns.get(DECODER_TRACE_OFFSET + 4, i);
-        let b4 = self.columns.get(DECODER_TRACE_OFFSET + 5, i);
-        let b5 = self.columns.get(DECODER_TRACE_OFFSET + 6, i);
-        let b6 = self.columns.get(DECODER_TRACE_OFFSET + 7, i);
+    pub fn is_right_shift(&self, i: RowIndex) -> bool {
+        let b0 = self.columns.get(DECODER_TRACE_OFFSET + 1, i.into());
+        let b1 = self.columns.get(DECODER_TRACE_OFFSET + 2, i.into());
+        let b2 = self.columns.get(DECODER_TRACE_OFFSET + 3, i.into());
+        let b3 = self.columns.get(DECODER_TRACE_OFFSET + 4, i.into());
+        let b4 = self.columns.get(DECODER_TRACE_OFFSET + 5, i.into());
+        let b5 = self.columns.get(DECODER_TRACE_OFFSET + 6, i.into());
+        let b6 = self.columns.get(DECODER_TRACE_OFFSET + 7, i.into());
 
         // group with right shift effect grouped by a common prefix
         [b6, b5, b4] == [ZERO, ONE, ONE]||
@@ -257,22 +264,22 @@ impl MainTrace {
     // --------------------------------------------------------------------------------------------
 
     /// Returns the value of the stack depth column at row i.
-    pub fn stack_depth(&self, i: usize) -> Felt {
+    pub fn stack_depth(&self, i: RowIndex) -> Felt {
         self.columns.get_column(STACK_TRACE_OFFSET + B0_COL_IDX)[i]
     }
 
     /// Returns the element at row i in a given stack trace column.
-    pub fn stack_element(&self, column: usize, i: usize) -> Felt {
+    pub fn stack_element(&self, column: usize, i: RowIndex) -> Felt {
         self.columns.get_column(STACK_TRACE_OFFSET + column)[i]
     }
 
     /// Returns the address of the top element in the stack overflow table at row i.
-    pub fn parent_overflow_address(&self, i: usize) -> Felt {
+    pub fn parent_overflow_address(&self, i: RowIndex) -> Felt {
         self.columns.get_column(STACK_TRACE_OFFSET + B1_COL_IDX)[i]
     }
 
     /// Returns a flag indicating whether the overflow stack is non-empty.
-    pub fn is_non_empty_overflow(&self, i: usize) -> bool {
+    pub fn is_non_empty_overflow(&self, i: RowIndex) -> bool {
         let b0 = self.columns.get_column(STACK_TRACE_OFFSET + B0_COL_IDX)[i];
         let h0 = self.columns.get_column(STACK_TRACE_OFFSET + H0_COL_IDX)[i];
         (b0 - Felt::new(16)) * h0 == ONE
@@ -282,37 +289,37 @@ impl MainTrace {
     // --------------------------------------------------------------------------------------------
 
     /// Returns chiplet column number 0 at row i.
-    pub fn chiplet_selector_0(&self, i: usize) -> Felt {
+    pub fn chiplet_selector_0(&self, i: RowIndex) -> Felt {
         self.columns.get_column(CHIPLETS_OFFSET)[i]
     }
 
     /// Returns chiplet column number 1 at row i.
-    pub fn chiplet_selector_1(&self, i: usize) -> Felt {
+    pub fn chiplet_selector_1(&self, i: RowIndex) -> Felt {
         self.columns.get_column(CHIPLETS_OFFSET + 1)[i]
     }
 
     /// Returns chiplet column number 2 at row i.
-    pub fn chiplet_selector_2(&self, i: usize) -> Felt {
+    pub fn chiplet_selector_2(&self, i: RowIndex) -> Felt {
         self.columns.get_column(CHIPLETS_OFFSET + 2)[i]
     }
 
     /// Returns chiplet column number 3 at row i.
-    pub fn chiplet_selector_3(&self, i: usize) -> Felt {
+    pub fn chiplet_selector_3(&self, i: RowIndex) -> Felt {
         self.columns.get_column(CHIPLETS_OFFSET + 3)[i]
     }
 
     /// Returns chiplet column number 4 at row i.
-    pub fn chiplet_selector_4(&self, i: usize) -> Felt {
+    pub fn chiplet_selector_4(&self, i: RowIndex) -> Felt {
         self.columns.get_column(CHIPLETS_OFFSET + 4)[i]
     }
 
     /// Returns `true` if a row is part of the hash chiplet.
-    pub fn is_hash_row(&self, i: usize) -> bool {
+    pub fn is_hash_row(&self, i: RowIndex) -> bool {
         self.chiplet_selector_0(i) == ZERO
     }
 
     /// Returns the (full) state of the hasher chiplet at row i.
-    pub fn chiplet_hasher_state(&self, i: usize) -> [Felt; STATE_WIDTH] {
+    pub fn chiplet_hasher_state(&self, i: RowIndex) -> [Felt; STATE_WIDTH] {
         let mut state = [ZERO; STATE_WIDTH];
         for (idx, col_idx) in HASHER_STATE_COL_RANGE.enumerate() {
             let column = self.columns.get_column(col_idx);
@@ -322,74 +329,74 @@ impl MainTrace {
     }
 
     /// Returns the hasher's node index column at row i
-    pub fn chiplet_node_index(&self, i: usize) -> Felt {
-        self.columns.get(HASHER_NODE_INDEX_COL_IDX, i)
+    pub fn chiplet_node_index(&self, i: RowIndex) -> Felt {
+        self.columns.get(HASHER_NODE_INDEX_COL_IDX, i.into())
     }
 
     /// Returns `true` if a row is part of the bitwise chiplet.
-    pub fn is_bitwise_row(&self, i: usize) -> bool {
+    pub fn is_bitwise_row(&self, i: RowIndex) -> bool {
         self.chiplet_selector_0(i) == ONE && self.chiplet_selector_1(i) == ZERO
     }
 
     /// Returns the bitwise column holding the aggregated value of input `a` at row i.
-    pub fn chiplet_bitwise_a(&self, i: usize) -> Felt {
+    pub fn chiplet_bitwise_a(&self, i: RowIndex) -> Felt {
         self.columns.get_column(BITWISE_A_COL_IDX)[i]
     }
 
     /// Returns the bitwise column holding the aggregated value of input `b` at row i.
-    pub fn chiplet_bitwise_b(&self, i: usize) -> Felt {
+    pub fn chiplet_bitwise_b(&self, i: RowIndex) -> Felt {
         self.columns.get_column(BITWISE_B_COL_IDX)[i]
     }
 
     /// Returns the bitwise column holding the aggregated value of the output at row i.
-    pub fn chiplet_bitwise_z(&self, i: usize) -> Felt {
+    pub fn chiplet_bitwise_z(&self, i: RowIndex) -> Felt {
         self.columns.get_column(BITWISE_OUTPUT_COL_IDX)[i]
     }
 
     /// Returns `true` if a row is part of the memory chiplet.
-    pub fn is_memory_row(&self, i: usize) -> bool {
+    pub fn is_memory_row(&self, i: RowIndex) -> bool {
         self.chiplet_selector_0(i) == ONE
             && self.chiplet_selector_1(i) == ONE
             && self.chiplet_selector_2(i) == ZERO
     }
 
     /// Returns the i-th row of the chiplet column containing memory context.
-    pub fn chiplet_memory_ctx(&self, i: usize) -> Felt {
+    pub fn chiplet_memory_ctx(&self, i: RowIndex) -> Felt {
         self.columns.get_column(MEMORY_CTX_COL_IDX)[i]
     }
 
     /// Returns the i-th row of the chiplet column containing memory address.
-    pub fn chiplet_memory_addr(&self, i: usize) -> Felt {
+    pub fn chiplet_memory_addr(&self, i: RowIndex) -> Felt {
         self.columns.get_column(MEMORY_ADDR_COL_IDX)[i]
     }
 
     /// Returns the i-th row of the chiplet column containing clock cycle.
-    pub fn chiplet_memory_clk(&self, i: usize) -> Felt {
+    pub fn chiplet_memory_clk(&self, i: RowIndex) -> Felt {
         self.columns.get_column(MEMORY_CLK_COL_IDX)[i]
     }
 
     /// Returns the i-th row of the chiplet column containing the zeroth memory value element.
-    pub fn chiplet_memory_value_0(&self, i: usize) -> Felt {
+    pub fn chiplet_memory_value_0(&self, i: RowIndex) -> Felt {
         self.columns.get_column(MEMORY_V_COL_RANGE.start)[i]
     }
 
     /// Returns the i-th row of the chiplet column containing the first memory value element.
-    pub fn chiplet_memory_value_1(&self, i: usize) -> Felt {
+    pub fn chiplet_memory_value_1(&self, i: RowIndex) -> Felt {
         self.columns.get_column(MEMORY_V_COL_RANGE.start + 1)[i]
     }
 
     /// Returns the i-th row of the chiplet column containing the second memory value element.
-    pub fn chiplet_memory_value_2(&self, i: usize) -> Felt {
+    pub fn chiplet_memory_value_2(&self, i: RowIndex) -> Felt {
         self.columns.get_column(MEMORY_V_COL_RANGE.start + 2)[i]
     }
 
     /// Returns the i-th row of the chiplet column containing the third memory value element.
-    pub fn chiplet_memory_value_3(&self, i: usize) -> Felt {
+    pub fn chiplet_memory_value_3(&self, i: RowIndex) -> Felt {
         self.columns.get_column(MEMORY_V_COL_RANGE.start + 3)[i]
     }
 
     /// Returns `true` if a row is part of the kernel chiplet.
-    pub fn is_kernel_row(&self, i: usize) -> bool {
+    pub fn is_kernel_row(&self, i: RowIndex) -> bool {
         self.chiplet_selector_0(i) == ONE
             && self.chiplet_selector_1(i) == ONE
             && self.chiplet_selector_2(i) == ONE
@@ -397,31 +404,31 @@ impl MainTrace {
     }
 
     /// Returns the i-th row of the kernel chiplet `addr` column.
-    pub fn chiplet_kernel_addr(&self, i: usize) -> Felt {
+    pub fn chiplet_kernel_addr(&self, i: RowIndex) -> Felt {
         self.columns.get_column(CHIPLETS_OFFSET + 5)[i]
     }
 
     /// Returns the i-th row of the chiplet column containing the zeroth element of the kernel
     /// procedure root.
-    pub fn chiplet_kernel_root_0(&self, i: usize) -> Felt {
+    pub fn chiplet_kernel_root_0(&self, i: RowIndex) -> Felt {
         self.columns.get_column(CHIPLETS_OFFSET + 6)[i]
     }
 
     /// Returns the i-th row of the chiplet column containing the first element of the kernel
     /// procedure root.
-    pub fn chiplet_kernel_root_1(&self, i: usize) -> Felt {
+    pub fn chiplet_kernel_root_1(&self, i: RowIndex) -> Felt {
         self.columns.get_column(CHIPLETS_OFFSET + 7)[i]
     }
 
     /// Returns the i-th row of the chiplet column containing the second element of the kernel
     /// procedure root.
-    pub fn chiplet_kernel_root_2(&self, i: usize) -> Felt {
+    pub fn chiplet_kernel_root_2(&self, i: RowIndex) -> Felt {
         self.columns.get_column(CHIPLETS_OFFSET + 8)[i]
     }
 
     /// Returns the i-th row of the chiplet column containing the third element of the kernel
     /// procedure root.
-    pub fn chiplet_kernel_root_3(&self, i: usize) -> Felt {
+    pub fn chiplet_kernel_root_3(&self, i: RowIndex) -> Felt {
         self.columns.get_column(CHIPLETS_OFFSET + 9)[i]
     }
 
@@ -430,8 +437,8 @@ impl MainTrace {
 
     /// Returns `true` if the hasher chiplet flags indicate the initialization of verifying
     /// a Merkle path to an old node during Merkle root update procedure (MRUPDATE).
-    pub fn f_mv(&self, i: usize) -> bool {
-        (i % HASH_CYCLE_LEN == 0)
+    pub fn f_mv(&self, i: RowIndex) -> bool {
+        (usize::from(i) % HASH_CYCLE_LEN == 0)
             && self.chiplet_selector_0(i) == ZERO
             && self.chiplet_selector_1(i) == ONE
             && self.chiplet_selector_2(i) == ONE
@@ -440,8 +447,8 @@ impl MainTrace {
 
     /// Returns `true` if the hasher chiplet flags indicate the continuation of verifying
     /// a Merkle path to an old node during Merkle root update procedure (MRUPDATE).
-    pub fn f_mva(&self, i: usize) -> bool {
-        (i % HASH_CYCLE_LEN == HASH_CYCLE_LEN - 1)
+    pub fn f_mva(&self, i: RowIndex) -> bool {
+        (usize::from(i) % HASH_CYCLE_LEN == HASH_CYCLE_LEN - 1)
             && self.chiplet_selector_0(i) == ZERO
             && self.chiplet_selector_1(i) == ONE
             && self.chiplet_selector_2(i) == ONE
@@ -450,8 +457,8 @@ impl MainTrace {
 
     /// Returns `true` if the hasher chiplet flags indicate the initialization of verifying
     /// a Merkle path to a new node during Merkle root update procedure (MRUPDATE).
-    pub fn f_mu(&self, i: usize) -> bool {
-        (i % HASH_CYCLE_LEN == 0)
+    pub fn f_mu(&self, i: RowIndex) -> bool {
+        (usize::from(i) % HASH_CYCLE_LEN == 0)
             && self.chiplet_selector_0(i) == ZERO
             && self.chiplet_selector_1(i) == ONE
             && self.chiplet_selector_2(i) == ONE
@@ -460,8 +467,8 @@ impl MainTrace {
 
     /// Returns `true` if the hasher chiplet flags indicate the continuation of verifying
     /// a Merkle path to a new node during Merkle root update procedure (MRUPDATE).
-    pub fn f_mua(&self, i: usize) -> bool {
-        (i % HASH_CYCLE_LEN == HASH_CYCLE_LEN - 1)
+    pub fn f_mua(&self, i: RowIndex) -> bool {
+        (usize::from(i) % HASH_CYCLE_LEN == HASH_CYCLE_LEN - 1)
             && self.chiplet_selector_0(i) == ZERO
             && self.chiplet_selector_1(i) == ONE
             && self.chiplet_selector_2(i) == ONE

--- a/air/src/trace/mod.rs
+++ b/air/src/trace/mod.rs
@@ -5,6 +5,7 @@ pub mod chiplets;
 pub mod decoder;
 pub mod main_trace;
 pub mod range;
+pub mod rows;
 pub mod stack;
 
 // CONSTANTS

--- a/air/src/trace/rows.rs
+++ b/air/src/trace/rows.rs
@@ -120,14 +120,6 @@ impl Sub<usize> for RowIndex {
     }
 }
 
-impl Sub<RowIndex> for usize {
-    type Output = RowIndex;
-
-    fn sub(self, rhs: RowIndex) -> Self::Output {
-        (self - rhs.0 as usize).into()
-    }
-}
-
 impl SubAssign<u32> for RowIndex {
     fn sub_assign(&mut self, rhs: u32) {
         self.0 -= rhs;

--- a/air/src/trace/rows.rs
+++ b/air/src/trace/rows.rs
@@ -1,0 +1,309 @@
+use core::{
+    fmt::{Display, Formatter},
+    ops::{Add, AddAssign, Bound, Index, IndexMut, Mul, RangeBounds, Sub, SubAssign},
+};
+
+use vm_core::Felt;
+
+/// Represents the types of errors that can occur when converting from and into [`RowIndex`] and
+/// using its operations.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum RowIndexError<T> {
+    #[error("value is too large to be converted into RowIndex: {0}")]
+    InvalidSize(T),
+}
+
+// ROW INDEX
+// ================================================================================================
+
+/// A newtype wrapper around a usize value representing a step in the execution trace.
+#[derive(Debug, Copy, Clone, Eq, Ord, PartialOrd)]
+pub struct RowIndex(u32);
+
+impl Display for RowIndex {
+    fn fmt(&self, f: &mut Formatter) -> core::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+// FROM ROW INDEX
+// ================================================================================================
+
+impl From<RowIndex> for u32 {
+    fn from(step: RowIndex) -> u32 {
+        step.0
+    }
+}
+
+impl From<RowIndex> for u64 {
+    fn from(step: RowIndex) -> u64 {
+        step.0 as u64
+    }
+}
+
+impl From<RowIndex> for usize {
+    fn from(step: RowIndex) -> usize {
+        step.0 as usize
+    }
+}
+
+impl From<RowIndex> for Felt {
+    fn from(step: RowIndex) -> Felt {
+        Felt::from(step.0)
+    }
+}
+
+// INTO ROW INDEX
+// ================================================================================================
+
+/// Converts a usize value into a [`RowIndex`].
+///
+/// # Panics
+///
+/// This function will panic if the number represented by the usize is greater than the maximum
+/// [`RowIndex`] value, `u32::MAX`.
+impl From<usize> for RowIndex {
+    fn from(value: usize) -> Self {
+        let value = u32::try_from(value).map_err(|_| RowIndexError::InvalidSize(value)).unwrap();
+        value.into()
+    }
+}
+
+/// Converts a u64 value into a [`RowIndex`].
+///
+/// # Panics
+///
+/// This function will panic if the number represented by the u64 is greater than the maximum
+/// [`RowIndex`] value, `u32::MAX`.
+impl TryFrom<u64> for RowIndex {
+    type Error = RowIndexError<u64>;
+
+    fn try_from(value: u64) -> Result<Self, Self::Error> {
+        let value = u32::try_from(value).map_err(|_| RowIndexError::InvalidSize(value))?;
+        Ok(RowIndex::from(value))
+    }
+}
+
+impl From<u32> for RowIndex {
+    fn from(value: u32) -> Self {
+        Self(value)
+    }
+}
+
+/// Converts an i32 value into a [`RowIndex`].
+///
+/// # Panics
+///
+/// This function will panic if the number represented by the i32 is less than 0.
+impl From<i32> for RowIndex {
+    fn from(value: i32) -> Self {
+        let value = u32::try_from(value).map_err(|_| RowIndexError::InvalidSize(value)).unwrap();
+        RowIndex(value)
+    }
+}
+
+// ROW INDEX OPS
+// ================================================================================================
+
+/// Subtracts a usize from a [`RowIndex`].
+///
+/// # Panics
+///
+/// This function will panic if the number represented by the usize is greater than the maximum
+/// [`RowIndex`] value, `u32::MAX`.
+impl Sub<usize> for RowIndex {
+    type Output = RowIndex;
+
+    fn sub(self, rhs: usize) -> Self::Output {
+        let rhs = u32::try_from(rhs).map_err(|_| RowIndexError::InvalidSize(rhs)).unwrap();
+        RowIndex(self.0 - rhs)
+    }
+}
+
+impl Sub<RowIndex> for usize {
+    type Output = RowIndex;
+
+    fn sub(self, rhs: RowIndex) -> Self::Output {
+        (self - rhs.0 as usize).into()
+    }
+}
+
+impl SubAssign<u32> for RowIndex {
+    fn sub_assign(&mut self, rhs: u32) {
+        self.0 -= rhs;
+    }
+}
+
+impl RowIndex {
+    pub fn saturating_sub(self, rhs: u32) -> Self {
+        RowIndex(self.0.saturating_sub(rhs))
+    }
+
+    pub fn max(self, other: u32) -> Self {
+        RowIndex(self.0.max(other))
+    }
+}
+
+/// Adds a usize to a [`RowIndex`].
+///
+/// # Panics
+///
+/// This function will panic if the number represented by the usize is greater than the maximum
+/// [`RowIndex`] value, `u32::MAX`.
+impl Add<usize> for RowIndex {
+    type Output = RowIndex;
+
+    fn add(self, rhs: usize) -> Self::Output {
+        let rhs = u32::try_from(rhs).map_err(|_| RowIndexError::InvalidSize(rhs)).unwrap();
+        RowIndex(self.0 + rhs)
+    }
+}
+
+impl Add<RowIndex> for u32 {
+    type Output = RowIndex;
+
+    fn add(self, rhs: RowIndex) -> Self::Output {
+        RowIndex(self + rhs.0)
+    }
+}
+
+/// Adds a usize value to a RowIndex in place.
+///
+/// # Panics
+///
+/// This function will panic if the number represented by the usize is greater than the maximum
+/// [`RowIndex`] value, `u32::MAX`.
+impl AddAssign<usize> for RowIndex {
+    fn add_assign(&mut self, rhs: usize) {
+        let rhs: RowIndex = rhs.into();
+        self.0 += rhs.0;
+    }
+}
+
+impl Mul<RowIndex> for usize {
+    type Output = RowIndex;
+
+    fn mul(self, rhs: RowIndex) -> Self::Output {
+        (self * rhs.0 as usize).into()
+    }
+}
+
+// ROW INDEX EQUALITY AND ORDERING
+// ================================================================================================
+
+impl PartialEq<RowIndex> for RowIndex {
+    fn eq(&self, rhs: &RowIndex) -> bool {
+        self.0 == rhs.0
+    }
+}
+
+impl PartialEq<usize> for RowIndex {
+    fn eq(&self, rhs: &usize) -> bool {
+        self.0 == u32::try_from(*rhs).map_err(|_| RowIndexError::InvalidSize(*rhs)).unwrap()
+    }
+}
+
+impl PartialEq<RowIndex> for i32 {
+    fn eq(&self, rhs: &RowIndex) -> bool {
+        *self as u32 == u32::from(*rhs)
+    }
+}
+
+impl PartialOrd<usize> for RowIndex {
+    fn partial_cmp(&self, rhs: &usize) -> Option<core::cmp::Ordering> {
+        let rhs = u32::try_from(*rhs).map_err(|_| RowIndexError::InvalidSize(*rhs)).unwrap();
+        self.0.partial_cmp(&rhs)
+    }
+}
+
+impl<T> Index<RowIndex> for [T] {
+    type Output = T;
+    fn index(&self, i: RowIndex) -> &Self::Output {
+        &self[i.0 as usize]
+    }
+}
+
+impl<T> IndexMut<RowIndex> for [T] {
+    fn index_mut(&mut self, i: RowIndex) -> &mut Self::Output {
+        &mut self[i.0 as usize]
+    }
+}
+
+impl RangeBounds<RowIndex> for RowIndex {
+    fn start_bound(&self) -> Bound<&Self> {
+        Bound::Included(self)
+    }
+    fn end_bound(&self) -> Bound<&Self> {
+        Bound::Included(self)
+    }
+}
+
+// TESTS
+// ================================================================================================
+#[cfg(test)]
+mod tests {
+    use alloc::collections::BTreeMap;
+
+    #[test]
+    fn row_index_conversions() {
+        use super::RowIndex;
+        // Into
+        let _: RowIndex = 5.into();
+        let _: RowIndex = 5u32.into();
+        let _: RowIndex = (5usize).into();
+
+        // From
+        let _: u32 = RowIndex(5).into();
+        let _: u64 = RowIndex(5).into();
+        let _: usize = RowIndex(5).into();
+    }
+
+    #[test]
+    fn row_index_ops() {
+        use super::RowIndex;
+
+        // Equality
+        assert_eq!(RowIndex(5), 5);
+        assert_eq!(RowIndex(5), RowIndex(5));
+        assert!(RowIndex(5) == RowIndex(5));
+        assert!(RowIndex(5) >= RowIndex(5));
+        assert!(RowIndex(6) >= RowIndex(5));
+        assert!(RowIndex(5) > RowIndex(4));
+        assert!(RowIndex(5) <= RowIndex(5));
+        assert!(RowIndex(4) <= RowIndex(5));
+        assert!(RowIndex(5) < RowIndex(6));
+
+        // Arithmetic
+        assert_eq!(RowIndex(5) + 3, 8);
+        assert_eq!(RowIndex(5) - 3, 2);
+        assert_eq!(3 + RowIndex(5), 8);
+        assert_eq!(2 * RowIndex(5), 10);
+
+        // Add assign
+        let mut step = RowIndex(5);
+        step += 5;
+        assert_eq!(step, 10);
+    }
+
+    #[test]
+    fn row_index_range() {
+        use super::RowIndex;
+        let mut tree: BTreeMap<RowIndex, usize> = BTreeMap::new();
+        tree.insert(RowIndex(0), 0);
+        tree.insert(RowIndex(1), 1);
+        tree.insert(RowIndex(2), 2);
+        let acc =
+            tree.range(RowIndex::from(0)..RowIndex::from(tree.len()))
+                .fold(0, |acc, (key, val)| {
+                    assert_eq!(*key, RowIndex::from(acc));
+                    assert_eq!(*val, acc);
+                    acc + 1
+                });
+        assert_eq!(acc, 3);
+    }
+
+    #[test]
+    fn row_index_display() {
+        assert_eq!(format!("{}", super::RowIndex(5)), "5");
+    }
+}

--- a/air/src/utils.rs
+++ b/air/src/utils.rs
@@ -1,5 +1,6 @@
-use alloc::vec::Vec;
 use core::ops::Range;
+
+use alloc::vec::Vec;
 
 use super::FieldElement;
 use vm_core::utils::range as create_range;

--- a/miden/Cargo.toml
+++ b/miden/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "miden-vm"
 version = "0.10.0"
-description="Miden virtual machine"
+description = "Miden virtual machine"
 documentation = "https://docs.rs/miden-vm/0.10.0"
 categories = ["cryptography", "emulators", "no-std"]
 keywords = ["miden", "stark", "virtual-machine", "zkp"]

--- a/miden/tests/integration/exec_iters.rs
+++ b/miden/tests/integration/exec_iters.rs
@@ -1,3 +1,4 @@
+use processor::RowIndex;
 use processor::{AsmOpInfo, ContextId, VmState};
 use test_utils::{assert_eq, build_debug_test, Felt, ToElements, ONE};
 use vm_core::{debuginfo::Location, AssemblyOp, Operation};
@@ -39,7 +40,7 @@ fn test_exec_iter() {
     });
     let expected_states = vec![
         VmState {
-            clk: 0,
+            clk: RowIndex::from(0),
             ctx: ContextId::root(),
             op: None,
             asmop: None,
@@ -48,7 +49,7 @@ fn test_exec_iter() {
             memory: Vec::new(),
         },
         VmState {
-            clk: 1,
+            clk: RowIndex::from(1),
             ctx: ContextId::root(),
             op: Some(Operation::Join),
             asmop: None,
@@ -57,7 +58,7 @@ fn test_exec_iter() {
             memory: Vec::new(),
         },
         VmState {
-            clk: 2,
+            clk: RowIndex::from(2),
             ctx: ContextId::root(),
             op: Some(Operation::Span),
             asmop: None,
@@ -66,7 +67,7 @@ fn test_exec_iter() {
             memory: Vec::new(),
         },
         VmState {
-            clk: 3,
+            clk: RowIndex::from(3),
             ctx: ContextId::root(),
             op: Some(Operation::Pad),
             asmop: Some(AsmOpInfo::new(
@@ -84,7 +85,7 @@ fn test_exec_iter() {
             memory: Vec::new(),
         },
         VmState {
-            clk: 4,
+            clk: RowIndex::from(4),
             ctx: ContextId::root(),
             op: Some(Operation::Incr),
             asmop: Some(AsmOpInfo::new(
@@ -102,7 +103,7 @@ fn test_exec_iter() {
             memory: Vec::new(),
         },
         VmState {
-            clk: 5,
+            clk: RowIndex::from(5),
             ctx: ContextId::root(),
             op: Some(Operation::MStoreW),
             asmop: Some(AsmOpInfo::new(
@@ -120,7 +121,7 @@ fn test_exec_iter() {
             memory: mem.clone(),
         },
         VmState {
-            clk: 6,
+            clk: RowIndex::from(6),
             ctx: ContextId::root(),
             op: Some(Operation::Drop),
             asmop: Some(AsmOpInfo::new(
@@ -138,7 +139,7 @@ fn test_exec_iter() {
             memory: mem.clone(),
         },
         VmState {
-            clk: 7,
+            clk: RowIndex::from(7),
             ctx: ContextId::root(),
             op: Some(Operation::Drop),
             asmop: Some(AsmOpInfo::new(
@@ -156,7 +157,7 @@ fn test_exec_iter() {
             memory: mem.clone(),
         },
         VmState {
-            clk: 8,
+            clk: RowIndex::from(8),
             ctx: ContextId::root(),
             op: Some(Operation::Drop),
             asmop: Some(AsmOpInfo::new(
@@ -174,7 +175,7 @@ fn test_exec_iter() {
             memory: mem.clone(),
         },
         VmState {
-            clk: 9,
+            clk: RowIndex::from(9),
             ctx: ContextId::root(),
             op: Some(Operation::Drop),
             asmop: Some(AsmOpInfo::new(
@@ -192,7 +193,7 @@ fn test_exec_iter() {
             memory: mem.clone(),
         },
         VmState {
-            clk: 10,
+            clk: RowIndex::from(10),
             ctx: ContextId::root(),
             op: Some(Operation::Push(Felt::new(17))),
             asmop: Some(AsmOpInfo::new(
@@ -210,7 +211,7 @@ fn test_exec_iter() {
             memory: mem.clone(),
         },
         VmState {
-            clk: 11,
+            clk: RowIndex::from(11),
             ctx: ContextId::root(),
             op: Some(Operation::Noop),
             asmop: None,
@@ -219,7 +220,7 @@ fn test_exec_iter() {
             memory: mem.clone(),
         },
         VmState {
-            clk: 12,
+            clk: RowIndex::from(12),
             ctx: ContextId::root(),
             op: Some(Operation::End),
             asmop: None,
@@ -228,7 +229,7 @@ fn test_exec_iter() {
             memory: mem.clone(),
         },
         VmState {
-            clk: 13,
+            clk: RowIndex::from(13),
             ctx: ContextId::root(),
             op: Some(Operation::Span),
             asmop: None,
@@ -237,7 +238,7 @@ fn test_exec_iter() {
             memory: mem.clone(),
         },
         VmState {
-            clk: 14,
+            clk: RowIndex::from(14),
             ctx: ContextId::root(),
             op: Some(Operation::Push(ONE)),
             asmop: None,
@@ -246,7 +247,7 @@ fn test_exec_iter() {
             memory: mem.clone(),
         },
         VmState {
-            clk: 15,
+            clk: RowIndex::from(15),
             ctx: ContextId::root(),
             op: Some(Operation::FmpUpdate),
             asmop: None,
@@ -255,7 +256,7 @@ fn test_exec_iter() {
             memory: mem.clone(),
         },
         VmState {
-            clk: 16,
+            clk: RowIndex::from(16),
             ctx: ContextId::root(),
             op: Some(Operation::Pad),
             asmop: Some(AsmOpInfo::new(
@@ -273,7 +274,7 @@ fn test_exec_iter() {
             memory: mem.clone(),
         },
         VmState {
-            clk: 17,
+            clk: RowIndex::from(17),
             ctx: ContextId::root(),
             op: Some(Operation::FmpAdd),
             asmop: Some(AsmOpInfo::new(
@@ -292,7 +293,7 @@ fn test_exec_iter() {
             memory: mem,
         },
         VmState {
-            clk: 18,
+            clk: RowIndex::from(18),
             ctx: ContextId::root(),
             op: Some(Operation::MStore),
             asmop: Some(AsmOpInfo::new(
@@ -313,7 +314,7 @@ fn test_exec_iter() {
             ],
         },
         VmState {
-            clk: 19,
+            clk: RowIndex::from(19),
             ctx: ContextId::root(),
             op: Some(Operation::Drop),
             asmop: Some(AsmOpInfo::new(
@@ -334,7 +335,7 @@ fn test_exec_iter() {
             ],
         },
         VmState {
-            clk: 20,
+            clk: RowIndex::from(20),
             ctx: ContextId::root(),
             op: Some(Operation::Push(Felt::new(18446744069414584320))),
             asmop: None,
@@ -347,7 +348,7 @@ fn test_exec_iter() {
             ],
         },
         VmState {
-            clk: 21,
+            clk: RowIndex::from(21),
             ctx: ContextId::root(),
             op: Some(Operation::FmpUpdate),
             asmop: None,
@@ -359,7 +360,7 @@ fn test_exec_iter() {
             ],
         },
         VmState {
-            clk: 22,
+            clk: RowIndex::from(22),
             ctx: ContextId::root(),
             op: Some(Operation::Noop),
             asmop: None,
@@ -371,7 +372,7 @@ fn test_exec_iter() {
             ],
         },
         VmState {
-            clk: 23,
+            clk: RowIndex::from(23),
             ctx: ContextId::root(),
             op: Some(Operation::End),
             asmop: None,
@@ -383,7 +384,7 @@ fn test_exec_iter() {
             ],
         },
         VmState {
-            clk: 24,
+            clk: RowIndex::from(24),
             ctx: ContextId::root(),
             op: Some(Operation::End),
             asmop: None,

--- a/miden/tests/integration/operations/decorators/asmop.rs
+++ b/miden/tests/integration/operations/decorators/asmop.rs
@@ -1,3 +1,4 @@
+use processor::RowIndex;
 use processor::{AsmOpInfo, VmStateIterator};
 use test_utils::{assert_eq, build_debug_test};
 use vm_core::{debuginfo::Location, AssemblyOp, Felt, Operation};
@@ -25,17 +26,17 @@ fn asmop_one_span_block_test() {
     let vm_state_iterator = test.execute_iter();
     let expected_vm_state = vec![
         VmStatePartial {
-            clk: 0,
+            clk: RowIndex::from(0),
             asmop: None,
             op: None,
         },
         VmStatePartial {
-            clk: 1,
+            clk: RowIndex::from(1),
             asmop: None,
             op: Some(Operation::Span),
         },
         VmStatePartial {
-            clk: 2,
+            clk: RowIndex::from(2),
             asmop: Some(AsmOpInfo::new(
                 AssemblyOp::new(
                     push1_loc.clone(),
@@ -49,7 +50,7 @@ fn asmop_one_span_block_test() {
             op: Some(Operation::Pad),
         },
         VmStatePartial {
-            clk: 3,
+            clk: RowIndex::from(3),
             asmop: Some(AsmOpInfo::new(
                 AssemblyOp::new(
                     push1_loc,
@@ -63,7 +64,7 @@ fn asmop_one_span_block_test() {
             op: Some(Operation::Incr),
         },
         VmStatePartial {
-            clk: 4,
+            clk: RowIndex::from(4),
             asmop: Some(AsmOpInfo::new(
                 AssemblyOp::new(
                     push2_loc,
@@ -77,7 +78,7 @@ fn asmop_one_span_block_test() {
             op: Some(Operation::Push(Felt::new(2))),
         },
         VmStatePartial {
-            clk: 5,
+            clk: RowIndex::from(5),
             asmop: Some(AsmOpInfo::new(
                 AssemblyOp::new(add_loc, "#exec::#main".to_string(), 1, "add".to_string(), false),
                 1,
@@ -85,7 +86,7 @@ fn asmop_one_span_block_test() {
             op: Some(Operation::Add),
         },
         VmStatePartial {
-            clk: 6,
+            clk: RowIndex::from(6),
             asmop: None,
             op: Some(Operation::End),
         },
@@ -117,17 +118,17 @@ fn asmop_with_one_procedure() {
     let vm_state_iterator = test.execute_iter();
     let expected_vm_state = vec![
         VmStatePartial {
-            clk: 0,
+            clk: RowIndex::from(0),
             asmop: None,
             op: None,
         },
         VmStatePartial {
-            clk: 1,
+            clk: RowIndex::from(1),
             asmop: None,
             op: Some(Operation::Span),
         },
         VmStatePartial {
-            clk: 2,
+            clk: RowIndex::from(2),
             asmop: Some(AsmOpInfo::new(
                 AssemblyOp::new(
                     push1_loc.clone(),
@@ -141,7 +142,7 @@ fn asmop_with_one_procedure() {
             op: Some(Operation::Pad),
         },
         VmStatePartial {
-            clk: 3,
+            clk: RowIndex::from(3),
             asmop: Some(AsmOpInfo::new(
                 AssemblyOp::new(
                     push1_loc,
@@ -155,7 +156,7 @@ fn asmop_with_one_procedure() {
             op: Some(Operation::Incr),
         },
         VmStatePartial {
-            clk: 4,
+            clk: RowIndex::from(4),
             asmop: Some(AsmOpInfo::new(
                 AssemblyOp::new(
                     push2_loc,
@@ -169,7 +170,7 @@ fn asmop_with_one_procedure() {
             op: Some(Operation::Push(Felt::new(2))),
         },
         VmStatePartial {
-            clk: 5,
+            clk: RowIndex::from(5),
             asmop: Some(AsmOpInfo::new(
                 AssemblyOp::new(add_loc, "#exec::foo".to_string(), 1, "add".to_string(), false),
                 1,
@@ -177,7 +178,7 @@ fn asmop_with_one_procedure() {
             op: Some(Operation::Add),
         },
         VmStatePartial {
-            clk: 6,
+            clk: RowIndex::from(6),
             asmop: None,
             op: Some(Operation::End),
         },
@@ -213,27 +214,27 @@ fn asmop_repeat_test() {
     let vm_state_iterator = test.execute_iter();
     let expected_vm_state = vec![
         VmStatePartial {
-            clk: 0,
+            clk: RowIndex::from(0),
             asmop: None,
             op: None,
         },
         VmStatePartial {
-            clk: 1,
+            clk: RowIndex::from(1),
             asmop: None,
             op: Some(Operation::Join),
         },
         VmStatePartial {
-            clk: 2,
+            clk: RowIndex::from(2),
             asmop: None,
             op: Some(Operation::Join),
         },
         VmStatePartial {
-            clk: 3,
+            clk: RowIndex::from(3),
             asmop: None,
             op: Some(Operation::Span),
         },
         VmStatePartial {
-            clk: 4,
+            clk: RowIndex::from(4),
             asmop: Some(AsmOpInfo::new(
                 AssemblyOp::new(
                     push1_loc.clone(),
@@ -247,7 +248,7 @@ fn asmop_repeat_test() {
             op: Some(Operation::Pad),
         },
         VmStatePartial {
-            clk: 5,
+            clk: RowIndex::from(5),
             asmop: Some(AsmOpInfo::new(
                 AssemblyOp::new(
                     push1_loc.clone(),
@@ -261,7 +262,7 @@ fn asmop_repeat_test() {
             op: Some(Operation::Incr),
         },
         VmStatePartial {
-            clk: 6,
+            clk: RowIndex::from(6),
             asmop: Some(AsmOpInfo::new(
                 AssemblyOp::new(
                     push2_loc.clone(),
@@ -275,7 +276,7 @@ fn asmop_repeat_test() {
             op: Some(Operation::Push(Felt::new(2))),
         },
         VmStatePartial {
-            clk: 7,
+            clk: RowIndex::from(7),
             asmop: Some(AsmOpInfo::new(
                 AssemblyOp::new(
                     add_loc.clone(),
@@ -290,17 +291,17 @@ fn asmop_repeat_test() {
         },
         // End first Span
         VmStatePartial {
-            clk: 8,
+            clk: RowIndex::from(8),
             asmop: None,
             op: Some(Operation::End),
         },
         VmStatePartial {
-            clk: 9,
+            clk: RowIndex::from(9),
             asmop: None,
             op: Some(Operation::Span),
         },
         VmStatePartial {
-            clk: 10,
+            clk: RowIndex::from(10),
             asmop: Some(AsmOpInfo::new(
                 AssemblyOp::new(
                     push1_loc.clone(),
@@ -314,7 +315,7 @@ fn asmop_repeat_test() {
             op: Some(Operation::Pad),
         },
         VmStatePartial {
-            clk: 11,
+            clk: RowIndex::from(11),
             asmop: Some(AsmOpInfo::new(
                 AssemblyOp::new(
                     push1_loc.clone(),
@@ -328,7 +329,7 @@ fn asmop_repeat_test() {
             op: Some(Operation::Incr),
         },
         VmStatePartial {
-            clk: 12,
+            clk: RowIndex::from(12),
             asmop: Some(AsmOpInfo::new(
                 AssemblyOp::new(
                     push2_loc.clone(),
@@ -342,7 +343,7 @@ fn asmop_repeat_test() {
             op: Some(Operation::Push(Felt::new(2))),
         },
         VmStatePartial {
-            clk: 13,
+            clk: RowIndex::from(13),
             asmop: Some(AsmOpInfo::new(
                 AssemblyOp::new(
                     add_loc.clone(),
@@ -357,23 +358,23 @@ fn asmop_repeat_test() {
         },
         // End second Span
         VmStatePartial {
-            clk: 14,
+            clk: RowIndex::from(14),
             asmop: None,
             op: Some(Operation::End),
         },
         // End first Join
         VmStatePartial {
-            clk: 15,
+            clk: RowIndex::from(15),
             asmop: None,
             op: Some(Operation::End),
         },
         VmStatePartial {
-            clk: 16,
+            clk: RowIndex::from(16),
             asmop: None,
             op: Some(Operation::Span),
         },
         VmStatePartial {
-            clk: 17,
+            clk: RowIndex::from(17),
             asmop: Some(AsmOpInfo::new(
                 AssemblyOp::new(
                     push1_loc.clone(),
@@ -387,7 +388,7 @@ fn asmop_repeat_test() {
             op: Some(Operation::Pad),
         },
         VmStatePartial {
-            clk: 18,
+            clk: RowIndex::from(18),
             asmop: Some(AsmOpInfo::new(
                 AssemblyOp::new(
                     push1_loc,
@@ -401,7 +402,7 @@ fn asmop_repeat_test() {
             op: Some(Operation::Incr),
         },
         VmStatePartial {
-            clk: 19,
+            clk: RowIndex::from(19),
             asmop: Some(AsmOpInfo::new(
                 AssemblyOp::new(
                     push2_loc,
@@ -415,7 +416,7 @@ fn asmop_repeat_test() {
             op: Some(Operation::Push(Felt::new(2))),
         },
         VmStatePartial {
-            clk: 20,
+            clk: RowIndex::from(20),
             asmop: Some(AsmOpInfo::new(
                 AssemblyOp::new(add_loc, "#exec::#main".to_string(), 1, "add".to_string(), false),
                 1,
@@ -424,13 +425,13 @@ fn asmop_repeat_test() {
         },
         // End Span
         VmStatePartial {
-            clk: 21,
+            clk: RowIndex::from(21),
             asmop: None,
             op: Some(Operation::End),
         },
         // End second Join
         VmStatePartial {
-            clk: 22,
+            clk: RowIndex::from(22),
             asmop: None,
             op: Some(Operation::End),
         },
@@ -476,22 +477,22 @@ fn asmop_conditional_execution_test() {
     let vm_state_iterator = test.execute_iter();
     let expected_vm_state = vec![
         VmStatePartial {
-            clk: 0,
+            clk: RowIndex::from(0),
             asmop: None,
             op: None,
         },
         VmStatePartial {
-            clk: 1,
+            clk: RowIndex::from(1),
             asmop: None,
             op: Some(Operation::Join),
         },
         VmStatePartial {
-            clk: 2,
+            clk: RowIndex::from(2),
             asmop: None,
             op: Some(Operation::Span),
         },
         VmStatePartial {
-            clk: 3,
+            clk: RowIndex::from(3),
             asmop: Some(AsmOpInfo::new(
                 AssemblyOp::new(eq_loc, "#exec::#main".to_string(), 1, "eq".to_string(), false),
                 1,
@@ -499,22 +500,22 @@ fn asmop_conditional_execution_test() {
             op: Some(Operation::Eq),
         },
         VmStatePartial {
-            clk: 4,
+            clk: RowIndex::from(4),
             asmop: None,
             op: Some(Operation::End),
         },
         VmStatePartial {
-            clk: 5,
+            clk: RowIndex::from(5),
             asmop: None,
             op: Some(Operation::Split),
         },
         VmStatePartial {
-            clk: 6,
+            clk: RowIndex::from(6),
             asmop: None,
             op: Some(Operation::Span),
         },
         VmStatePartial {
-            clk: 7,
+            clk: RowIndex::from(7),
             asmop: Some(AsmOpInfo::new(
                 AssemblyOp::new(
                     push1_loc.clone(),
@@ -528,7 +529,7 @@ fn asmop_conditional_execution_test() {
             op: Some(Operation::Pad),
         },
         VmStatePartial {
-            clk: 8,
+            clk: RowIndex::from(8),
             asmop: Some(AsmOpInfo::new(
                 AssemblyOp::new(
                     push1_loc,
@@ -542,7 +543,7 @@ fn asmop_conditional_execution_test() {
             op: Some(Operation::Incr),
         },
         VmStatePartial {
-            clk: 9,
+            clk: RowIndex::from(9),
             asmop: Some(AsmOpInfo::new(
                 AssemblyOp::new(
                     push2_loc,
@@ -556,7 +557,7 @@ fn asmop_conditional_execution_test() {
             op: Some(Operation::Push(Felt::new(2))),
         },
         VmStatePartial {
-            clk: 10,
+            clk: RowIndex::from(10),
             asmop: Some(AsmOpInfo::new(
                 AssemblyOp::new(add_loc, "#exec::#main".to_string(), 1, "add".to_string(), false),
                 1,
@@ -564,17 +565,17 @@ fn asmop_conditional_execution_test() {
             op: Some(Operation::Add),
         },
         VmStatePartial {
-            clk: 11,
+            clk: RowIndex::from(11),
             asmop: None,
             op: Some(Operation::End),
         },
         VmStatePartial {
-            clk: 12,
+            clk: RowIndex::from(12),
             asmop: None,
             op: Some(Operation::End),
         },
         VmStatePartial {
-            clk: 13,
+            clk: RowIndex::from(13),
             asmop: None,
             op: Some(Operation::End),
         },
@@ -608,22 +609,22 @@ fn asmop_conditional_execution_test() {
     let vm_state_iterator = test.execute_iter();
     let expected_vm_state = vec![
         VmStatePartial {
-            clk: 0,
+            clk: RowIndex::from(0),
             asmop: None,
             op: None,
         },
         VmStatePartial {
-            clk: 1,
+            clk: RowIndex::from(1),
             asmop: None,
             op: Some(Operation::Join),
         },
         VmStatePartial {
-            clk: 2,
+            clk: RowIndex::from(2),
             asmop: None,
             op: Some(Operation::Span),
         },
         VmStatePartial {
-            clk: 3,
+            clk: RowIndex::from(3),
             asmop: Some(AsmOpInfo::new(
                 AssemblyOp::new(eq_loc, "#exec::#main".to_string(), 1, "eq".to_string(), false),
                 1,
@@ -631,22 +632,22 @@ fn asmop_conditional_execution_test() {
             op: Some(Operation::Eq),
         },
         VmStatePartial {
-            clk: 4,
+            clk: RowIndex::from(4),
             asmop: None,
             op: Some(Operation::End),
         },
         VmStatePartial {
-            clk: 5,
+            clk: RowIndex::from(5),
             asmop: None,
             op: Some(Operation::Split),
         },
         VmStatePartial {
-            clk: 6,
+            clk: RowIndex::from(6),
             asmop: None,
             op: Some(Operation::Span),
         },
         VmStatePartial {
-            clk: 7,
+            clk: RowIndex::from(7),
             asmop: Some(AsmOpInfo::new(
                 AssemblyOp::new(
                     push3_loc,
@@ -660,7 +661,7 @@ fn asmop_conditional_execution_test() {
             op: Some(Operation::Push(Felt::new(3))),
         },
         VmStatePartial {
-            clk: 8,
+            clk: RowIndex::from(8),
             asmop: Some(AsmOpInfo::new(
                 AssemblyOp::new(
                     push4_loc,
@@ -674,7 +675,7 @@ fn asmop_conditional_execution_test() {
             op: Some(Operation::Push(Felt::new(4))),
         },
         VmStatePartial {
-            clk: 9,
+            clk: RowIndex::from(9),
             asmop: Some(AsmOpInfo::new(
                 AssemblyOp::new(add_loc, "#exec::#main".to_string(), 1, "add".to_string(), false),
                 1,
@@ -682,22 +683,22 @@ fn asmop_conditional_execution_test() {
             op: Some(Operation::Add),
         },
         VmStatePartial {
-            clk: 10,
+            clk: RowIndex::from(10),
             asmop: None,
             op: Some(Operation::Noop),
         },
         VmStatePartial {
-            clk: 11,
+            clk: RowIndex::from(11),
             asmop: None,
             op: Some(Operation::End),
         },
         VmStatePartial {
-            clk: 12,
+            clk: RowIndex::from(12),
             asmop: None,
             op: Some(Operation::End),
         },
         VmStatePartial {
-            clk: 13,
+            clk: RowIndex::from(13),
             asmop: None,
             op: Some(Operation::End),
         },
@@ -726,7 +727,7 @@ fn build_vm_state(vm_state_iterator: VmStateIterator) -> Vec<VmStatePartial> {
 /// * op: Operation executed at the specific clock cycle
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct VmStatePartial {
-    clk: u32,
+    clk: RowIndex,
     asmop: Option<AsmOpInfo>,
     op: Option<Operation>,
 }

--- a/miden/tests/integration/operations/field_ops.rs
+++ b/miden/tests/integration/operations/field_ops.rs
@@ -212,7 +212,7 @@ fn div_fail() {
 
     // --- test divide by zero --------------------------------------------------------------------
     let test = build_op_test!(asm_op, &[1, 0]);
-    expect_exec_error!(test, ExecutionError::DivideByZero(1));
+    expect_exec_error!(test, ExecutionError::DivideByZero(1.into()));
 }
 
 #[test]
@@ -277,7 +277,7 @@ fn inv_fail() {
 
     // --- test no inv on 0 -----------------------------------------------------------------------
     let test = build_op_test!(asm_op, &[0]);
-    expect_exec_error!(test, ExecutionError::DivideByZero(1));
+    expect_exec_error!(test, ExecutionError::DivideByZero(1.into()));
 
     let asm_op = "inv.1";
 
@@ -318,7 +318,7 @@ fn pow2_fail() {
     expect_exec_error!(
         test,
         ExecutionError::FailedAssertion {
-            clk: 16,
+            clk: 16.into(),
             err_code: 0,
             err_msg: None,
         }
@@ -353,7 +353,7 @@ fn exp_bits_length_fail() {
     expect_exec_error!(
         test,
         ExecutionError::FailedAssertion {
-            clk: 18,
+            clk: 18.into(),
             err_code: 0,
             err_msg: None
         }
@@ -402,7 +402,7 @@ fn ilog2_fail() {
     let asm_op = "ilog2";
 
     let test = build_op_test!(asm_op, &[0]);
-    expect_exec_error!(test, ExecutionError::LogArgumentZero(1));
+    expect_exec_error!(test, ExecutionError::LogArgumentZero(1.into()));
 }
 
 // FIELD OPS BOOLEAN - MANUAL TESTS

--- a/miden/tests/integration/operations/io_ops/adv_ops.rs
+++ b/miden/tests/integration/operations/io_ops/adv_ops.rs
@@ -32,7 +32,7 @@ fn adv_push() {
 fn adv_push_invalid() {
     // attempting to read from empty advice stack should throw an error
     let test = build_op_test!("adv_push.1");
-    expect_exec_error!(test, ExecutionError::AdviceStackReadFailed(1));
+    expect_exec_error!(test, ExecutionError::AdviceStackReadFailed(1.into()));
 }
 
 // OVERWRITING VALUES ON THE STACK (LOAD)
@@ -53,7 +53,7 @@ fn adv_loadw() {
 fn adv_loadw_invalid() {
     // attempting to read from empty advice stack should throw an error
     let test = build_op_test!("adv_loadw", &[0, 0, 0, 0]);
-    expect_exec_error!(test, AdviceStackReadFailed(1));
+    expect_exec_error!(test, AdviceStackReadFailed(1.into()));
 }
 
 // MOVING ELEMENTS TO MEMORY VIA THE STACK (PIPE)

--- a/miden/tests/integration/operations/sys_ops.rs
+++ b/miden/tests/integration/operations/sys_ops.rs
@@ -24,7 +24,7 @@ fn assert_with_code() {
     expect_exec_error!(
         test,
         ExecutionError::FailedAssertion {
-            clk: 1,
+            clk: 1.into(),
             err_code: 123,
             err_msg: None,
         }
@@ -39,7 +39,7 @@ fn assert_fail() {
     expect_exec_error!(
         test,
         ExecutionError::FailedAssertion {
-            clk: 1,
+            clk: 1.into(),
             err_code: 0,
             err_msg: None,
         }
@@ -65,7 +65,7 @@ fn assert_eq_fail() {
     expect_exec_error!(
         test,
         ExecutionError::FailedAssertion {
-            clk: 2,
+            clk: 2.into(),
             err_code: 0,
             err_msg: None,
         }
@@ -75,7 +75,7 @@ fn assert_eq_fail() {
     expect_exec_error!(
         test,
         ExecutionError::FailedAssertion {
-            clk: 2,
+            clk: 2.into(),
             err_code: 0,
             err_msg: None,
         }

--- a/miden/tests/integration/operations/u32_ops/arithmetic_ops.rs
+++ b/miden/tests/integration/operations/u32_ops/arithmetic_ops.rs
@@ -470,7 +470,7 @@ fn u32div_fail() {
 
     // should fail if b == 0.
     let test = build_op_test!(asm_op, &[1, 0]);
-    expect_exec_error!(test, ExecutionError::DivideByZero(1));
+    expect_exec_error!(test, ExecutionError::DivideByZero(1.into()));
 }
 
 #[test]
@@ -511,7 +511,7 @@ fn u32mod_fail() {
 
     // should fail if b == 0
     let test = build_op_test!(asm_op, &[1, 0]);
-    expect_exec_error!(test, ExecutionError::DivideByZero(1));
+    expect_exec_error!(test, ExecutionError::DivideByZero(1.into()));
 }
 
 #[test]
@@ -557,7 +557,7 @@ fn u32divmod_fail() {
 
     // should fail if b == 0.
     let test = build_op_test!(asm_op, &[1, 0]);
-    expect_exec_error!(test, ExecutionError::DivideByZero(1));
+    expect_exec_error!(test, ExecutionError::DivideByZero(1.into()));
 }
 
 // U32 OPERATIONS TESTS - RANDOMIZED - ARITHMETIC OPERATIONS

--- a/processor/src/chiplets/hasher/tests.rs
+++ b/processor/src/chiplets/hasher/tests.rs
@@ -608,7 +608,6 @@ fn check_hasher_state_trace(trace: &[Vec<Felt>], row_idx: usize, init_state: Has
     }
 }
 
-/// Makes sure that the trace is copied correctly on memoization
 fn check_memoized_trace(
     trace: &[Vec<Felt>],
     start_row: usize,

--- a/processor/src/chiplets/kernel_rom/mod.rs
+++ b/processor/src/chiplets/kernel_rom/mod.rs
@@ -1,6 +1,6 @@
 use super::{Digest, ExecutionError, Felt, Kernel, TraceFragment, Word, ONE, ZERO};
 use alloc::collections::BTreeMap;
-use miden_air::trace::chiplets::kernel_rom::TRACE_WIDTH;
+use miden_air::{trace::chiplets::kernel_rom::TRACE_WIDTH, RowIndex};
 
 #[cfg(test)]
 mod tests;
@@ -99,7 +99,7 @@ impl KernelRom {
     /// Populates the provided execution trace fragment with execution trace of this kernel ROM.
     pub fn fill_trace(self, trace: &mut TraceFragment) {
         debug_assert_eq!(TRACE_WIDTH, trace.width(), "inconsistent trace fragment width");
-        let mut row = 0;
+        let mut row: RowIndex = 0.into();
         for (idx, access_info) in self.access_map.values().enumerate() {
             let idx = Felt::from(idx as u16);
 
@@ -145,7 +145,7 @@ impl ProcAccessInfo {
     }
 
     /// Writes a single row into the provided trace fragment for this procedure access entry.
-    pub fn write_into_trace(&self, trace: &mut TraceFragment, row: usize, idx: Felt) {
+    pub fn write_into_trace(&self, trace: &mut TraceFragment, row: RowIndex, idx: Felt) {
         let s0 = if self.num_accesses == 0 { ZERO } else { ONE };
         trace.set(row, 0, s0);
         trace.set(row, 1, idx);

--- a/processor/src/chiplets/memory/segment.rs
+++ b/processor/src/chiplets/memory/segment.rs
@@ -1,6 +1,7 @@
 use alloc::{collections::BTreeMap, vec::Vec};
-use miden_air::trace::chiplets::memory::{
-    Selectors, MEMORY_COPY_READ, MEMORY_INIT_READ, MEMORY_WRITE,
+use miden_air::{
+    trace::chiplets::memory::{Selectors, MEMORY_COPY_READ, MEMORY_INIT_READ, MEMORY_WRITE},
+    RowIndex,
 };
 
 use super::{Felt, Word, INIT_MEM_VALUE};
@@ -33,7 +34,7 @@ impl MemorySegmentTrace {
     }
 
     /// Returns the entire memory state at the beginning of the specified cycle.
-    pub fn get_state_at(&self, clk: u32) -> Vec<(u64, Word)> {
+    pub fn get_state_at(&self, clk: RowIndex) -> Vec<(u64, Word)> {
         let mut result: Vec<(u64, Word)> = Vec::new();
 
         if clk == 0 {
@@ -43,7 +44,7 @@ impl MemorySegmentTrace {
         // since we record memory state at the end of a given cycle, to get memory state at the end
         // of a cycle, we need to look at the previous cycle. that is, memory state at the end of
         // the previous cycle is the same as memory state the the beginning of the current cycle.
-        let search_clk = (clk - 1) as u64;
+        let search_clk: u64 = (clk - 1).into();
 
         for (&addr, addr_trace) in self.0.iter() {
             match addr_trace.binary_search_by(|access| access.clk().as_int().cmp(&search_clk)) {

--- a/processor/src/chiplets/memory/tests.rs
+++ b/processor/src/chiplets/memory/tests.rs
@@ -4,8 +4,12 @@ use super::{
 };
 use crate::ContextId;
 use alloc::vec::Vec;
-use miden_air::trace::chiplets::memory::{
-    Selectors, MEMORY_COPY_READ, MEMORY_INIT_READ, MEMORY_WRITE, TRACE_WIDTH as MEMORY_TRACE_WIDTH,
+use miden_air::{
+    trace::chiplets::memory::{
+        Selectors, MEMORY_COPY_READ, MEMORY_INIT_READ, MEMORY_WRITE,
+        TRACE_WIDTH as MEMORY_TRACE_WIDTH,
+    },
+    RowIndex,
 };
 use vm_core::Word;
 
@@ -22,27 +26,27 @@ fn mem_read() {
 
     // read a value from address 0; clk = 1
     let addr0 = 0;
-    let value = mem.read(ContextId::root(), addr0, 1);
+    let value = mem.read(ContextId::root(), addr0, 1.into());
     assert_eq!(EMPTY_WORD, value);
     assert_eq!(1, mem.size());
     assert_eq!(1, mem.trace_len());
 
     // read a value from address 3; clk = 2
     let addr3 = 3;
-    let value = mem.read(ContextId::root(), addr3, 2);
+    let value = mem.read(ContextId::root(), addr3, 2.into());
     assert_eq!(EMPTY_WORD, value);
     assert_eq!(2, mem.size());
     assert_eq!(2, mem.trace_len());
 
     // read a value from address 0 again; clk = 3
-    let value = mem.read(ContextId::root(), addr0, 3);
+    let value = mem.read(ContextId::root(), addr0, 3.into());
     assert_eq!(EMPTY_WORD, value);
     assert_eq!(2, mem.size());
     assert_eq!(3, mem.trace_len());
 
     // read a value from address 2; clk = 4
     let addr2 = 2;
-    let value = mem.read(ContextId::root(), addr2, 4);
+    let value = mem.read(ContextId::root(), addr2, 4.into());
     assert_eq!(EMPTY_WORD, value);
     assert_eq!(3, mem.size());
     assert_eq!(4, mem.trace_len());
@@ -53,18 +57,18 @@ fn mem_read() {
 
     // address 0
     let mut prev_row = [ZERO; MEMORY_TRACE_WIDTH];
-    let memory_access = MemoryAccess::new(ContextId::root(), addr0, 1, EMPTY_WORD);
+    let memory_access = MemoryAccess::new(ContextId::root(), addr0, 1.into(), EMPTY_WORD);
     prev_row = verify_memory_access(&trace, 0, MEMORY_INIT_READ, &memory_access, prev_row);
 
-    let memory_access = MemoryAccess::new(ContextId::root(), addr0, 3, EMPTY_WORD);
+    let memory_access = MemoryAccess::new(ContextId::root(), addr0, 3.into(), EMPTY_WORD);
     prev_row = verify_memory_access(&trace, 1, MEMORY_COPY_READ, &memory_access, prev_row);
 
     // address 2
-    let memory_access = MemoryAccess::new(ContextId::root(), addr2, 4, EMPTY_WORD);
+    let memory_access = MemoryAccess::new(ContextId::root(), addr2, 4.into(), EMPTY_WORD);
     prev_row = verify_memory_access(&trace, 2, MEMORY_INIT_READ, &memory_access, prev_row);
 
     // address 3
-    let memory_access = MemoryAccess::new(ContextId::root(), addr3, 2, EMPTY_WORD);
+    let memory_access = MemoryAccess::new(ContextId::root(), addr3, 2.into(), EMPTY_WORD);
     verify_memory_access(&trace, 3, MEMORY_INIT_READ, &memory_access, prev_row);
 }
 
@@ -75,7 +79,7 @@ fn mem_write() {
     // write a value into address 0; clk = 1
     let addr0 = 0;
     let value1 = [ONE, ZERO, ZERO, ZERO];
-    mem.write(ContextId::root(), addr0, 1, value1);
+    mem.write(ContextId::root(), addr0, 1.into(), value1);
     assert_eq!(value1, mem.get_value(ContextId::root(), addr0).unwrap());
     assert_eq!(1, mem.size());
     assert_eq!(1, mem.trace_len());
@@ -83,7 +87,7 @@ fn mem_write() {
     // write a value into address 2; clk = 2
     let addr2 = 2;
     let value5 = [Felt::new(5), ZERO, ZERO, ZERO];
-    mem.write(ContextId::root(), addr2, 2, value5);
+    mem.write(ContextId::root(), addr2, 2.into(), value5);
     assert_eq!(value5, mem.get_value(ContextId::root(), addr2).unwrap());
     assert_eq!(2, mem.size());
     assert_eq!(2, mem.trace_len());
@@ -91,14 +95,14 @@ fn mem_write() {
     // write a value into address 1; clk = 3
     let addr1 = 1;
     let value7 = [Felt::new(7), ZERO, ZERO, ZERO];
-    mem.write(ContextId::root(), addr1, 3, value7);
+    mem.write(ContextId::root(), addr1, 3.into(), value7);
     assert_eq!(value7, mem.get_value(ContextId::root(), addr1).unwrap());
     assert_eq!(3, mem.size());
     assert_eq!(3, mem.trace_len());
 
     // write a value into address 0; clk = 4
     let value9 = [Felt::new(9), ZERO, ZERO, ZERO];
-    mem.write(ContextId::root(), addr0, 4, value9);
+    mem.write(ContextId::root(), addr0, 4.into(), value9);
     assert_eq!(value7, mem.get_value(ContextId::root(), addr1).unwrap());
     assert_eq!(3, mem.size());
     assert_eq!(4, mem.trace_len());
@@ -109,18 +113,18 @@ fn mem_write() {
 
     // address 0
     let mut prev_row = [ZERO; MEMORY_TRACE_WIDTH];
-    let memory_access = MemoryAccess::new(ContextId::root(), addr0, 1, value1);
+    let memory_access = MemoryAccess::new(ContextId::root(), addr0, 1.into(), value1);
     prev_row = verify_memory_access(&trace, 0, MEMORY_WRITE, &memory_access, prev_row);
 
-    let memory_access = MemoryAccess::new(ContextId::root(), addr0, 4, value9);
+    let memory_access = MemoryAccess::new(ContextId::root(), addr0, 4.into(), value9);
     prev_row = verify_memory_access(&trace, 1, MEMORY_WRITE, &memory_access, prev_row);
 
     // address 1
-    let memory_access = MemoryAccess::new(ContextId::root(), addr1, 3, value7);
+    let memory_access = MemoryAccess::new(ContextId::root(), addr1, 3.into(), value7);
     prev_row = verify_memory_access(&trace, 2, MEMORY_WRITE, &memory_access, prev_row);
 
     // address 2
-    let memory_access = MemoryAccess::new(ContextId::root(), addr2, 2, value5);
+    let memory_access = MemoryAccess::new(ContextId::root(), addr2, 2.into(), value5);
     verify_memory_access(&trace, 3, MEMORY_WRITE, &memory_access, prev_row);
 }
 
@@ -131,35 +135,35 @@ fn mem_write_read() {
     // write 1 into address 5; clk = 1
     let addr5 = 5;
     let value1 = [ONE, ZERO, ZERO, ZERO];
-    mem.write(ContextId::root(), addr5, 1, value1);
+    mem.write(ContextId::root(), addr5, 1.into(), value1);
 
     // write 4 into address 2; clk = 2
     let addr2 = 2;
     let value4 = [Felt::new(4), ZERO, ZERO, ZERO];
-    mem.write(ContextId::root(), addr2, 2, value4);
+    mem.write(ContextId::root(), addr2, 2.into(), value4);
 
     // read a value from address 5; clk = 3
-    mem.read(ContextId::root(), addr5, 3);
+    mem.read(ContextId::root(), addr5, 3.into());
 
     // write 2 into address 5; clk = 4
     let value2 = [Felt::new(2), ZERO, ZERO, ZERO];
-    mem.write(ContextId::root(), addr5, 4, value2);
+    mem.write(ContextId::root(), addr5, 4.into(), value2);
 
     // read a value from address 2; clk = 5
-    mem.read(ContextId::root(), addr2, 5);
+    mem.read(ContextId::root(), addr2, 5.into());
 
     // write 7 into address 2; clk = 6
     let value7 = [Felt::new(7), ZERO, ZERO, ZERO];
-    mem.write(ContextId::root(), addr2, 6, value7);
+    mem.write(ContextId::root(), addr2, 6.into(), value7);
 
     // read a value from address 5; clk = 7
-    mem.read(ContextId::root(), addr5, 7);
+    mem.read(ContextId::root(), addr5, 7.into());
 
     // read a value from address 2; clk = 8
-    mem.read(ContextId::root(), addr2, 8);
+    mem.read(ContextId::root(), addr2, 8.into());
 
     // read a value from address 5; clk = 9
-    mem.read(ContextId::root(), addr5, 9);
+    mem.read(ContextId::root(), addr5, 9.into());
 
     // check generated trace and memory data provided to the ChipletsBus; rows should be sorted by
     // address and then clock cycle
@@ -167,32 +171,32 @@ fn mem_write_read() {
 
     // address 2
     let mut prev_row = [ZERO; MEMORY_TRACE_WIDTH];
-    let memory_access = MemoryAccess::new(ContextId::root(), addr2, 2, value4);
+    let memory_access = MemoryAccess::new(ContextId::root(), addr2, 2.into(), value4);
     prev_row = verify_memory_access(&trace, 0, MEMORY_WRITE, &memory_access, prev_row);
 
-    let memory_access = MemoryAccess::new(ContextId::root(), addr2, 5, value4);
+    let memory_access = MemoryAccess::new(ContextId::root(), addr2, 5.into(), value4);
     prev_row = verify_memory_access(&trace, 1, MEMORY_COPY_READ, &memory_access, prev_row);
 
-    let memory_access = MemoryAccess::new(ContextId::root(), addr2, 6, value7);
+    let memory_access = MemoryAccess::new(ContextId::root(), addr2, 6.into(), value7);
     prev_row = verify_memory_access(&trace, 2, MEMORY_WRITE, &memory_access, prev_row);
 
-    let memory_access = MemoryAccess::new(ContextId::root(), addr2, 8, value7);
+    let memory_access = MemoryAccess::new(ContextId::root(), addr2, 8.into(), value7);
     prev_row = verify_memory_access(&trace, 3, MEMORY_COPY_READ, &memory_access, prev_row);
 
     // address 5
-    let memory_access = MemoryAccess::new(ContextId::root(), addr5, 1, value1);
+    let memory_access = MemoryAccess::new(ContextId::root(), addr5, 1.into(), value1);
     prev_row = verify_memory_access(&trace, 4, MEMORY_WRITE, &memory_access, prev_row);
 
-    let memory_access = MemoryAccess::new(ContextId::root(), addr5, 3, value1);
+    let memory_access = MemoryAccess::new(ContextId::root(), addr5, 3.into(), value1);
     prev_row = verify_memory_access(&trace, 5, MEMORY_COPY_READ, &memory_access, prev_row);
 
-    let memory_access = MemoryAccess::new(ContextId::root(), addr5, 4, value2);
+    let memory_access = MemoryAccess::new(ContextId::root(), addr5, 4.into(), value2);
     prev_row = verify_memory_access(&trace, 6, MEMORY_WRITE, &memory_access, prev_row);
 
-    let memory_access = MemoryAccess::new(ContextId::root(), addr5, 7, value2);
+    let memory_access = MemoryAccess::new(ContextId::root(), addr5, 7.into(), value2);
     prev_row = verify_memory_access(&trace, 7, MEMORY_COPY_READ, &memory_access, prev_row);
 
-    let memory_access = MemoryAccess::new(ContextId::root(), addr5, 9, value2);
+    let memory_access = MemoryAccess::new(ContextId::root(), addr5, 9.into(), value2);
     verify_memory_access(&trace, 8, MEMORY_COPY_READ, &memory_access, prev_row);
 }
 
@@ -202,33 +206,33 @@ fn mem_multi_context() {
 
     // write a value into ctx = ContextId::root(), addr = 0; clk = 1
     let value1 = [ONE, ZERO, ZERO, ZERO];
-    mem.write(ContextId::root(), 0, 1, value1);
+    mem.write(ContextId::root(), 0, 1.into(), value1);
     assert_eq!(value1, mem.get_value(ContextId::root(), 0).unwrap());
     assert_eq!(1, mem.size());
     assert_eq!(1, mem.trace_len());
 
     // write a value into ctx = 3, addr = 1; clk = 4
     let value2 = [ZERO, ONE, ZERO, ZERO];
-    mem.write(3.into(), 1, 4, value2);
+    mem.write(3.into(), 1, 4.into(), value2);
     assert_eq!(value2, mem.get_value(3.into(), 1).unwrap());
     assert_eq!(2, mem.size());
     assert_eq!(2, mem.trace_len());
 
     // read a value from ctx = 3, addr = 1; clk = 6
-    let value = mem.read(3.into(), 1, 6);
+    let value = mem.read(3.into(), 1, 6.into());
     assert_eq!(value2, value);
     assert_eq!(2, mem.size());
     assert_eq!(3, mem.trace_len());
 
     // write a value into ctx = 3, addr = 0; clk = 7
     let value3 = [ZERO, ZERO, ONE, ZERO];
-    mem.write(3.into(), 0, 7, value3);
+    mem.write(3.into(), 0, 7.into(), value3);
     assert_eq!(value3, mem.get_value(3.into(), 0).unwrap());
     assert_eq!(3, mem.size());
     assert_eq!(4, mem.trace_len());
 
     // read a value from ctx = 0, addr = 0; clk = 9
-    let value = mem.read(ContextId::root(), 0, 9);
+    let value = mem.read(ContextId::root(), 0, 9.into());
     assert_eq!(value1, value);
     assert_eq!(3, mem.size());
     assert_eq!(5, mem.trace_len());
@@ -239,21 +243,21 @@ fn mem_multi_context() {
 
     // ctx = 0, addr = 0
     let mut prev_row = [ZERO; MEMORY_TRACE_WIDTH];
-    let memory_access = MemoryAccess::new(ContextId::root(), 0, 1, value1);
+    let memory_access = MemoryAccess::new(ContextId::root(), 0, 1.into(), value1);
     prev_row = verify_memory_access(&trace, 0, MEMORY_WRITE, &memory_access, prev_row);
 
-    let memory_access = MemoryAccess::new(ContextId::root(), 0, 9, value1);
+    let memory_access = MemoryAccess::new(ContextId::root(), 0, 9.into(), value1);
     prev_row = verify_memory_access(&trace, 1, MEMORY_COPY_READ, &memory_access, prev_row);
 
     // ctx = 3, addr = 0
-    let memory_access = MemoryAccess::new(3.into(), 0, 7, value3);
+    let memory_access = MemoryAccess::new(3.into(), 0, 7.into(), value3);
     prev_row = verify_memory_access(&trace, 2, MEMORY_WRITE, &memory_access, prev_row);
 
     // ctx = 3, addr = 1
-    let memory_access = MemoryAccess::new(3.into(), 1, 4, value2);
+    let memory_access = MemoryAccess::new(3.into(), 1, 4.into(), value2);
     prev_row = verify_memory_access(&trace, 3, MEMORY_WRITE, &memory_access, prev_row);
 
-    let memory_access = MemoryAccess::new(3.into(), 1, 6, value2);
+    let memory_access = MemoryAccess::new(3.into(), 1, 6.into(), value2);
     verify_memory_access(&trace, 4, MEMORY_COPY_READ, &memory_access, prev_row);
 }
 
@@ -264,33 +268,33 @@ fn mem_get_state_at() {
     // Write 1 into (ctx = 0, addr = 5) at clk = 1.
     // This means that mem[5] = 1 at the beginning of clk = 2
     let value1 = [ONE, ZERO, ZERO, ZERO];
-    mem.write(ContextId::root(), 5, 1, value1);
+    mem.write(ContextId::root(), 5, 1.into(), value1);
 
     // Write 4 into (ctx = 0, addr = 2) at clk = 2.
     // This means that mem[2] = 4 at the beginning of clk = 3
     let value4 = [Felt::new(4), ZERO, ZERO, ZERO];
-    mem.write(ContextId::root(), 2, 2, value4);
+    mem.write(ContextId::root(), 2, 2.into(), value4);
 
     // write 7 into (ctx = 3, addr = 3) at clk = 4
     // This means that mem[3] = 7 at the beginning of clk = 4
     let value7 = [Felt::new(7), ZERO, ZERO, ZERO];
-    mem.write(3.into(), 3, 4, value7);
+    mem.write(3.into(), 3, 4.into(), value7);
 
     // Check memory state at clk = 2
-    assert_eq!(mem.get_state_at(ContextId::root(), 2), vec![(5, value1)]);
-    assert_eq!(mem.get_state_at(3.into(), 2), vec![]);
+    assert_eq!(mem.get_state_at(ContextId::root(), 2.into()), vec![(5, value1)]);
+    assert_eq!(mem.get_state_at(3.into(), 2.into()), vec![]);
 
     // Check memory state at clk = 3
-    assert_eq!(mem.get_state_at(ContextId::root(), 3), vec![(2, value4), (5, value1)]);
-    assert_eq!(mem.get_state_at(3.into(), 3), vec![]);
+    assert_eq!(mem.get_state_at(ContextId::root(), 3.into()), vec![(2, value4), (5, value1)]);
+    assert_eq!(mem.get_state_at(3.into(), 3.into()), vec![]);
 
     // Check memory state at clk = 4
-    assert_eq!(mem.get_state_at(ContextId::root(), 4), vec![(2, value4), (5, value1)]);
-    assert_eq!(mem.get_state_at(3.into(), 4), vec![]);
+    assert_eq!(mem.get_state_at(ContextId::root(), 4.into()), vec![(2, value4), (5, value1)]);
+    assert_eq!(mem.get_state_at(3.into(), 4.into()), vec![]);
 
     // Check memory state at clk = 5
-    assert_eq!(mem.get_state_at(ContextId::root(), 5), vec![(2, value4), (5, value1)]);
-    assert_eq!(mem.get_state_at(3.into(), 5), vec![(3, value7)]);
+    assert_eq!(mem.get_state_at(ContextId::root(), 5.into()), vec![(2, value4), (5, value1)]);
+    assert_eq!(mem.get_state_at(3.into(), 5.into()), vec![(3, value7)]);
 }
 
 // HELPER STRUCT & FUNCTIONS
@@ -305,7 +309,7 @@ pub struct MemoryAccess {
 }
 
 impl MemoryAccess {
-    pub fn new(ctx: ContextId, addr: u32, clk: u32, word: Word) -> Self {
+    pub fn new(ctx: ContextId, addr: u32, clk: RowIndex, word: Word) -> Self {
         Self {
             ctx,
             addr: Felt::from(addr),

--- a/processor/src/decoder/aux_trace/block_stack_table.rs
+++ b/processor/src/decoder/aux_trace/block_stack_table.rs
@@ -1,3 +1,4 @@
+use miden_air::RowIndex;
 use vm_core::{
     OPCODE_CALL, OPCODE_DYN, OPCODE_END, OPCODE_JOIN, OPCODE_LOOP, OPCODE_RESPAN, OPCODE_SPAN,
     OPCODE_SPLIT, OPCODE_SYSCALL,
@@ -15,7 +16,7 @@ pub struct BlockStackColumnBuilder {}
 
 impl<E: FieldElement<BaseField = Felt>> AuxColumnBuilder<E> for BlockStackColumnBuilder {
     /// Removes a row from the block stack table.
-    fn get_requests_at(&self, main_trace: &MainTrace, alphas: &[E], i: usize) -> E {
+    fn get_requests_at(&self, main_trace: &MainTrace, alphas: &[E], i: RowIndex) -> E {
         let op_code_felt = main_trace.get_op_code(i);
         let op_code = op_code_felt.as_int() as u8;
 
@@ -29,7 +30,7 @@ impl<E: FieldElement<BaseField = Felt>> AuxColumnBuilder<E> for BlockStackColumn
     }
 
     /// Adds a row to the block stack table.
-    fn get_responses_at(&self, main_trace: &MainTrace, alphas: &[E], i: usize) -> E {
+    fn get_responses_at(&self, main_trace: &MainTrace, alphas: &[E], i: RowIndex) -> E {
         let op_code_felt = main_trace.get_op_code(i);
         let op_code = op_code_felt.as_int() as u8;
 
@@ -49,7 +50,7 @@ impl<E: FieldElement<BaseField = Felt>> AuxColumnBuilder<E> for BlockStackColumn
 /// Computes the multiplicand representing the removal of a row from the block stack table.
 fn get_block_stack_table_removal_multiplicand<E: FieldElement<BaseField = Felt>>(
     main_trace: &MainTrace,
-    i: usize,
+    i: RowIndex,
     is_respan: bool,
     alphas: &[E],
 ) -> E {
@@ -102,7 +103,7 @@ fn get_block_stack_table_removal_multiplicand<E: FieldElement<BaseField = Felt>>
 /// Computes the multiplicand representing the inclusion of a new row to the block stack table.
 fn get_block_stack_table_inclusion_multiplicand<E: FieldElement<BaseField = Felt>>(
     main_trace: &MainTrace,
-    i: usize,
+    i: RowIndex,
     alphas: &[E],
     op_code: u8,
 ) -> E {

--- a/processor/src/decoder/aux_trace/op_group_table.rs
+++ b/processor/src/decoder/aux_trace/op_group_table.rs
@@ -1,5 +1,8 @@
 use super::{AuxColumnBuilder, Felt, FieldElement, MainTrace, ONE};
-use miden_air::trace::decoder::{OP_BATCH_2_GROUPS, OP_BATCH_4_GROUPS, OP_BATCH_8_GROUPS};
+use miden_air::{
+    trace::decoder::{OP_BATCH_2_GROUPS, OP_BATCH_4_GROUPS, OP_BATCH_8_GROUPS},
+    RowIndex,
+};
 use vm_core::{OPCODE_PUSH, OPCODE_RESPAN, OPCODE_SPAN};
 
 // OP GROUP TABLE COLUMN
@@ -12,7 +15,7 @@ pub struct OpGroupTableColumnBuilder {}
 
 impl<E: FieldElement<BaseField = Felt>> AuxColumnBuilder<E> for OpGroupTableColumnBuilder {
     /// Removes a row from the block hash table.
-    fn get_requests_at(&self, main_trace: &MainTrace, alphas: &[E], i: usize) -> E {
+    fn get_requests_at(&self, main_trace: &MainTrace, alphas: &[E], i: RowIndex) -> E {
         let delete_group_flag = main_trace.delta_group_count(i) * main_trace.is_in_span(i);
 
         if delete_group_flag == ONE {
@@ -23,7 +26,7 @@ impl<E: FieldElement<BaseField = Felt>> AuxColumnBuilder<E> for OpGroupTableColu
     }
 
     /// Adds a row to the block hash table.
-    fn get_responses_at(&self, main_trace: &MainTrace, alphas: &[E], i: usize) -> E {
+    fn get_responses_at(&self, main_trace: &MainTrace, alphas: &[E], i: RowIndex) -> E {
         let op_code_felt = main_trace.get_op_code(i);
         let op_code = op_code_felt.as_int() as u8;
 
@@ -42,7 +45,7 @@ impl<E: FieldElement<BaseField = Felt>> AuxColumnBuilder<E> for OpGroupTableColu
 /// Computes the multiplicand representing the inclusion of a new row to the op group table.
 fn get_op_group_table_inclusion_multiplicand<E: FieldElement<BaseField = Felt>>(
     main_trace: &MainTrace,
-    i: usize,
+    i: RowIndex,
     alphas: &[E],
 ) -> E {
     let block_id = main_trace.addr(i + 1);
@@ -79,7 +82,7 @@ fn get_op_group_table_inclusion_multiplicand<E: FieldElement<BaseField = Felt>>(
 /// Computes the multiplicand representing the removal of a row from the op group table.
 fn get_op_group_table_removal_multiplicand<E: FieldElement<BaseField = Felt>>(
     main_trace: &MainTrace,
-    i: usize,
+    i: RowIndex,
     alphas: &[E],
 ) -> E {
     let group_count = main_trace.group_count(i);

--- a/processor/src/decoder/mod.rs
+++ b/processor/src/decoder/mod.rs
@@ -3,12 +3,15 @@ use super::{
     ZERO,
 };
 use alloc::vec::Vec;
-use miden_air::trace::{
-    chiplets::hasher::DIGEST_LEN,
-    decoder::{
-        NUM_HASHER_COLUMNS, NUM_OP_BATCH_FLAGS, NUM_OP_BITS, NUM_OP_BITS_EXTRA_COLS,
-        OP_BATCH_1_GROUPS, OP_BATCH_2_GROUPS, OP_BATCH_4_GROUPS, OP_BATCH_8_GROUPS,
+use miden_air::{
+    trace::{
+        chiplets::hasher::DIGEST_LEN,
+        decoder::{
+            NUM_HASHER_COLUMNS, NUM_OP_BATCH_FLAGS, NUM_OP_BITS, NUM_OP_BITS_EXTRA_COLS,
+            OP_BATCH_1_GROUPS, OP_BATCH_2_GROUPS, OP_BATCH_4_GROUPS, OP_BATCH_8_GROUPS,
+        },
     },
+    RowIndex,
 };
 use vm_core::{
     mast::{
@@ -700,7 +703,7 @@ impl Decoder {
     // --------------------------------------------------------------------------------------------
 
     /// Appends an asmop decorator at the specified clock cycle to the asmop list in debug mode.
-    pub fn append_asmop(&mut self, clk: u32, asmop: AssemblyOp) {
+    pub fn append_asmop(&mut self, clk: RowIndex, asmop: AssemblyOp) {
         self.debug_info.append_asmop(clk, asmop);
     }
 
@@ -821,7 +824,7 @@ impl DebugInfo {
     }
 
     /// Appends an asmop decorator at the specified clock cycle to the asmop list in debug mode.
-    pub fn append_asmop(&mut self, clk: u32, asmop: AssemblyOp) {
-        self.assembly_ops.push((clk as usize, asmop));
+    pub fn append_asmop(&mut self, clk: RowIndex, asmop: AssemblyOp) {
+        self.assembly_ops.push((clk.into(), asmop));
     }
 }

--- a/processor/src/errors.rs
+++ b/processor/src/errors.rs
@@ -5,6 +5,7 @@ use super::{
 };
 use alloc::string::String;
 use core::fmt::{Display, Formatter};
+use miden_air::RowIndex;
 use vm_core::{mast::MastNodeId, stack::STACK_TOP_SIZE, utils::to_hex};
 use winter_prover::{math::FieldElement, ProverError};
 
@@ -17,15 +18,15 @@ use std::error::Error;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ExecutionError {
     AdviceMapKeyNotFound(Word),
-    AdviceStackReadFailed(u32),
+    AdviceStackReadFailed(RowIndex),
     CallerNotInSyscall,
     CycleLimitExceeded(u32),
-    DivideByZero(u32),
+    DivideByZero(RowIndex),
     DynamicNodeNotFound(Digest),
     EventError(String),
     Ext2InttError(Ext2InttError),
     FailedAssertion {
-        clk: u32,
+        clk: RowIndex,
         err_code: u32,
         err_msg: Option<String>,
     },
@@ -46,7 +47,7 @@ pub enum ExecutionError {
         depth: Felt,
         value: Felt,
     },
-    LogArgumentZero(u32),
+    LogArgumentZero(RowIndex),
     MalformedSignatureKey(&'static str),
     MalformedMastForestInHost {
         root_digest: Digest,

--- a/processor/src/host/debug.rs
+++ b/processor/src/host/debug.rs
@@ -1,4 +1,5 @@
 use alloc::vec::Vec;
+use miden_air::RowIndex;
 use std::{print, println};
 
 use vm_core::{DebugOptions, Word};
@@ -35,13 +36,13 @@ pub fn print_debug_info<S: ProcessState>(process: &S, options: &DebugOptions) {
 // ================================================================================================
 
 struct Printer {
-    clk: u32,
+    clk: RowIndex,
     ctx: ContextId,
     fmp: u32,
 }
 
 impl Printer {
-    fn new(clk: u32, ctx: ContextId, fmp: u64) -> Self {
+    fn new(clk: RowIndex, ctx: ContextId, fmp: u64) -> Self {
         Self {
             clk,
             ctx,

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -13,6 +13,7 @@ use miden_air::trace::{
     CHIPLETS_WIDTH, DECODER_TRACE_WIDTH, MIN_TRACE_LEN, RANGE_CHECK_TRACE_WIDTH, STACK_TRACE_WIDTH,
     SYS_TRACE_WIDTH,
 };
+pub use miden_air::RowIndex;
 pub use miden_air::{ExecutionOptions, ExecutionOptionsError};
 pub use vm_core::{
     chiplets::hasher::Digest,
@@ -597,7 +598,7 @@ where
 /// A trait that defines a set of methods which allow access to the state of the process.
 pub trait ProcessState {
     /// Returns the current clock cycle of a process.
-    fn clk(&self) -> u32;
+    fn clk(&self) -> RowIndex;
 
     /// Returns the current execution context ID.
     fn ctx(&self) -> ContextId;
@@ -637,7 +638,7 @@ pub trait ProcessState {
 }
 
 impl<H: Host> ProcessState for Process<H> {
-    fn clk(&self) -> u32 {
+    fn clk(&self) -> RowIndex {
         self.system.clk()
     }
 

--- a/processor/src/range/aux_trace.rs
+++ b/processor/src/range/aux_trace.rs
@@ -2,6 +2,7 @@ use alloc::{collections::BTreeMap, vec::Vec};
 
 use miden_air::trace::main_trace::MainTrace;
 use miden_air::trace::range::{M_COL_IDX, V_COL_IDX};
+use miden_air::RowIndex;
 
 use super::{uninit_vector, Felt, FieldElement, NUM_RAND_ROWS};
 
@@ -15,7 +16,7 @@ pub struct AuxTraceBuilder {
     lookup_values: Vec<u16>,
     /// Range check lookups performed by all user operations, grouped and sorted by the clock cycle
     /// at which they are requested.
-    cycle_lookups: BTreeMap<u32, Vec<u16>>,
+    cycle_lookups: BTreeMap<RowIndex, Vec<u16>>,
     // The index of the first row of Range Checker's trace when the padded rows end and values to
     // be range checked start.
     values_start: usize,
@@ -26,7 +27,7 @@ impl AuxTraceBuilder {
     // --------------------------------------------------------------------------------------------
     pub fn new(
         lookup_values: Vec<u16>,
-        cycle_lookups: BTreeMap<u32, Vec<u16>>,
+        cycle_lookups: BTreeMap<RowIndex, Vec<u16>>,
         values_start: usize,
     ) -> Self {
         Self {
@@ -71,8 +72,10 @@ impl AuxTraceBuilder {
         let mut b_range_idx = 0_usize;
 
         // the first half of the trace only includes values from the operations.
-        for (clk, range_checks) in self.cycle_lookups.range(0..self.values_start as u32) {
-            let clk = *clk as usize;
+        for (clk, range_checks) in
+            self.cycle_lookups.range(RowIndex::from(0)..RowIndex::from(self.values_start))
+        {
+            let clk: usize = (*clk).into();
 
             // if we skipped some cycles since the last update was processed, values in the last
             // updated row should be copied over until the current cycle.
@@ -121,7 +124,7 @@ impl AuxTraceBuilder {
             }
 
             // subtract the range checks requested by operations
-            if let Some(range_checks) = self.cycle_lookups.get(&(row_idx as u32)) {
+            if let Some(range_checks) = self.cycle_lookups.get(&(row_idx as u32).into()) {
                 for lookup in range_checks.iter() {
                     let value = divisors.get(lookup).expect("invalid lookup value");
                     b_range[b_range_idx] -= *value;

--- a/processor/src/range/mod.rs
+++ b/processor/src/range/mod.rs
@@ -1,4 +1,5 @@
 use alloc::{collections::BTreeMap, vec::Vec};
+use miden_air::RowIndex;
 
 use super::{trace::NUM_RAND_ROWS, Felt, FieldElement, RangeCheckTrace, ZERO};
 use crate::utils::uninit_vector;
@@ -43,7 +44,7 @@ pub struct RangeChecker {
     /// Range check lookups performed by all user operations, grouped and sorted by clock cycle.
     /// Each cycle is mapped to a vector of the range checks requested at that cycle, which can
     /// come from the stack, memory, or both.
-    cycle_lookups: BTreeMap<u32, Vec<u16>>,
+    cycle_lookups: BTreeMap<RowIndex, Vec<u16>>,
 }
 
 impl RangeChecker {
@@ -71,7 +72,7 @@ impl RangeChecker {
     }
 
     /// Adds range check lookups from the stack or memory to this [RangeChecker] instance.
-    pub fn add_range_checks(&mut self, clk: u32, values: &[u16]) {
+    pub fn add_range_checks(&mut self, clk: RowIndex, values: &[u16]) {
         // range checks requests only come from memory or from the stack, which always request 2 or
         // 4 lookups respectively.
         debug_assert!(values.len() == 2 || values.len() == 4);

--- a/processor/src/stack/aux_trace.rs
+++ b/processor/src/stack/aux_trace.rs
@@ -1,7 +1,7 @@
 use super::{Felt, FieldElement, OverflowTableRow};
 use crate::trace::AuxColumnBuilder;
 use alloc::vec::Vec;
-use miden_air::trace::main_trace::MainTrace;
+use miden_air::{trace::main_trace::MainTrace, RowIndex};
 
 // AUXILIARY TRACE BUILDER
 // ================================================================================================
@@ -40,7 +40,7 @@ impl<E: FieldElement<BaseField = Felt>> AuxColumnBuilder<E> for AuxTraceBuilder 
     }
 
     /// Removes a row from the stack overflow table.
-    fn get_requests_at(&self, main_trace: &MainTrace, alphas: &[E], i: usize) -> E {
+    fn get_requests_at(&self, main_trace: &MainTrace, alphas: &[E], i: RowIndex) -> E {
         let is_left_shift = main_trace.is_left_shift(i);
         let is_non_empty_overflow = main_trace.is_non_empty_overflow(i);
 
@@ -57,7 +57,7 @@ impl<E: FieldElement<BaseField = Felt>> AuxColumnBuilder<E> for AuxTraceBuilder 
     }
 
     /// Adds a row to the stack overflow table.
-    fn get_responses_at(&self, main_trace: &MainTrace, alphas: &[E], i: usize) -> E {
+    fn get_responses_at(&self, main_trace: &MainTrace, alphas: &[E], i: RowIndex) -> E {
         let is_right_shift = main_trace.is_right_shift(i);
 
         if is_right_shift {

--- a/processor/src/stack/mod.rs
+++ b/processor/src/stack/mod.rs
@@ -1,6 +1,7 @@
 use super::{Felt, FieldElement, StackInputs, StackOutputs, ONE, STACK_TRACE_WIDTH, ZERO};
 use alloc::vec::Vec;
 use core::cmp;
+use miden_air::RowIndex;
 use vm_core::{stack::STACK_TOP_SIZE, Word, WORD_SIZE};
 
 mod trace;
@@ -52,7 +53,7 @@ const MAX_TOP_IDX: usize = STACK_TOP_SIZE - 1;
 ///   column are set by the prover non-deterministically to 1 / (b0−16) when b0 != 16, and to any
 ///   other value otherwise.
 pub struct Stack {
-    clk: u32,
+    clk: RowIndex,
     trace: StackTrace,
     overflow: OverflowTable,
     active_depth: usize,
@@ -86,7 +87,7 @@ impl Stack {
         };
 
         Self {
-            clk: 0,
+            clk: RowIndex::from(0),
             trace,
             overflow,
             active_depth: depth,
@@ -103,7 +104,7 @@ impl Stack {
     }
 
     /// Returns the current clock cycle of the execution trace.
-    pub fn current_clk(&self) -> u32 {
+    pub fn current_clk(&self) -> RowIndex {
         self.clk
     }
 
@@ -111,7 +112,7 @@ impl Stack {
     ///
     /// Trace length of the stack is equal to the number of cycles executed by the VM.
     pub fn trace_len(&self) -> usize {
-        self.clk as usize
+        self.clk.into()
     }
 
     /// Returns a copy of the item currently at the top of the stack.
@@ -125,13 +126,13 @@ impl Stack {
     /// # Panics
     /// Panics if invoked for non-last clock cycle on a stack instantiated with
     /// `keep_overflow_trace` set to false.
-    pub fn get_state_at(&self, clk: u32) -> Vec<Felt> {
+    pub fn get_state_at(&self, clk: RowIndex) -> Vec<Felt> {
         let mut result = Vec::with_capacity(self.active_depth);
         self.trace.append_state_into(&mut result, clk);
         if clk == self.clk {
             self.overflow.append_into(&mut result);
         } else {
-            self.overflow.append_state_into(&mut result, clk as u64);
+            self.overflow.append_state_into(&mut result, clk.into());
         }
 
         result
@@ -186,7 +187,7 @@ impl Stack {
     /// same position at the next clock cycle.
     pub fn copy_state(&mut self, start_pos: usize) {
         self.trace.copy_stack_state_at(
-            self.clk,
+            self.clk.into(),
             start_pos,
             // TODO: change type of `active_depth` to `u32`
             Felt::try_from(self.active_depth as u64)
@@ -213,7 +214,7 @@ impl Stack {
             }
             _ => {
                 // Update the stack & overflow table.
-                let from_overflow = self.overflow.pop(self.clk as u64);
+                let from_overflow = self.overflow.pop(u64::from(self.clk));
                 self.trace.stack_shift_left_at(
                     self.clk,
                     start_pos,
@@ -287,7 +288,7 @@ impl Stack {
     /// overwritten with random values. This parameter is unused because last rows are just
     /// duplicates of the prior rows and thus can be safely overwritten.
     pub fn into_trace(self, trace_len: usize, num_rand_rows: usize) -> super::StackTrace {
-        let clk = self.current_clk() as usize;
+        let clk = usize::from(self.current_clk());
         // make sure that only the duplicate rows will be overwritten with random values
         assert!(clk + num_rand_rows <= trace_len, "target trace length too small");
 

--- a/processor/src/stack/tests.rs
+++ b/processor/src/stack/tests.rs
@@ -97,7 +97,7 @@ fn shift_left() {
 
     // Shift right twice to add 2 items to the overflow table.
     stack.shift_right(0);
-    let prev_overflow_addr = stack.current_clk() as usize;
+    let prev_overflow_addr: usize = stack.current_clk().into();
     stack.advance_clock();
     stack.shift_right(0);
     stack.advance_clock();
@@ -137,7 +137,7 @@ fn shift_right() {
 
     // ---- right shift an entire stack of minimum depth ------------------------------------------
     let expected_stack = build_stack(&[0, 4, 3, 2, 1]);
-    let expected_helpers = build_helpers_partial(1, stack.current_clk() as usize);
+    let expected_helpers = build_helpers_partial(1, stack.current_clk().into());
 
     stack.shift_right(0);
     stack.advance_clock();
@@ -150,7 +150,7 @@ fn shift_right() {
 
     // ---- right shift when the overflow table is non-empty --------------------------------------
     let expected_stack = build_stack(&[0, 0, 4, 3, 2, 1]);
-    let expected_helpers = build_helpers_partial(2, stack.current_clk() as usize);
+    let expected_helpers = build_helpers_partial(2, stack.current_clk().into());
 
     stack.shift_right(0);
     stack.advance_clock();

--- a/processor/src/trace/mod.rs
+++ b/processor/src/trace/mod.rs
@@ -285,9 +285,9 @@ where
     let clk = system.clk();
 
     // trace lengths of system and stack components must be equal to the number of executed cycles
-    assert_eq!(clk as usize, system.trace_len(), "inconsistent system trace lengths");
-    assert_eq!(clk as usize, decoder.trace_len(), "inconsistent decoder trace length");
-    assert_eq!(clk as usize, stack.trace_len(), "inconsistent stack trace lengths");
+    assert_eq!(usize::from(clk), system.trace_len(), "inconsistent system trace lengths");
+    assert_eq!(usize::from(clk), decoder.trace_len(), "inconsistent decoder trace length");
+    assert_eq!(usize::from(clk), stack.trace_len(), "inconsistent stack trace lengths");
 
     // Add the range checks required by the chiplets to the range checker.
     chiplets.append_range_checks(&mut range);
@@ -296,7 +296,7 @@ where
     let range_table_len = range.get_number_range_checker_rows();
 
     // Get the trace length required to hold all execution trace steps.
-    let max_len = range_table_len.max(clk as usize).max(chiplets.trace_len());
+    let max_len = range_table_len.max(clk.into()).max(chiplets.trace_len());
 
     // pad the trace length to the next power of two and ensure that there is space for the
     // rows to hold random values
@@ -308,7 +308,7 @@ where
 
     // get the lengths of the traces: main, range, and chiplets
     let trace_len_summary =
-        TraceLenSummary::new(clk as usize, range_table_len, ChipletsLengths::new(&chiplets));
+        TraceLenSummary::new(clk.into(), range_table_len, ChipletsLengths::new(&chiplets));
 
     // combine all trace segments into the main trace
     let system_trace = system.into_trace(trace_len, NUM_RAND_ROWS);

--- a/processor/src/trace/tests/chiplets/bitwise.rs
+++ b/processor/src/trace/tests/chiplets/bitwise.rs
@@ -2,9 +2,12 @@ use super::{
     build_trace_from_ops, rand_array, rand_value, ExecutionTrace, Felt, FieldElement, Operation,
     Trace, AUX_TRACE_RAND_ELEMENTS, CHIPLETS_AUX_TRACE_OFFSET, HASH_CYCLE_LEN, NUM_RAND_ROWS, ONE,
 };
-use miden_air::trace::chiplets::{
-    bitwise::{BITWISE_AND, BITWISE_AND_LABEL, BITWISE_XOR, BITWISE_XOR_LABEL, OP_CYCLE_LEN},
-    BITWISE_A_COL_IDX, BITWISE_B_COL_IDX, BITWISE_OUTPUT_COL_IDX, BITWISE_TRACE_OFFSET,
+use miden_air::{
+    trace::chiplets::{
+        bitwise::{BITWISE_AND, BITWISE_AND_LABEL, BITWISE_XOR, BITWISE_XOR_LABEL, OP_CYCLE_LEN},
+        BITWISE_A_COL_IDX, BITWISE_B_COL_IDX, BITWISE_OUTPUT_COL_IDX, BITWISE_TRACE_OFFSET,
+    },
+    RowIndex,
 };
 
 /// Tests the generation of the `b_chip` bus column when only bitwise lookups are included. It
@@ -121,7 +124,8 @@ fn b_chip_trace_bitwise() {
         Felt::from(a ^ b),
     );
     expected *= value.inv();
-    expected *= build_expected_bitwise_from_trace(&trace, &rand_elements, response_1_row - 1);
+    expected *=
+        build_expected_bitwise_from_trace(&trace, &rand_elements, (response_1_row - 1).into());
     assert_eq!(expected, b_chip[response_1_row]);
 
     // Nothing changes until the decoder requests the result of the `SPAN` hash at cycle 21.
@@ -142,7 +146,8 @@ fn b_chip_trace_bitwise() {
 
     // At the end of the next bitwise cycle, the response for `U32and` is provided by the Bitwise
     // chiplet.
-    expected *= build_expected_bitwise_from_trace(&trace, &rand_elements, response_2_row - 1);
+    expected *=
+        build_expected_bitwise_from_trace(&trace, &rand_elements, (response_2_row - 1).into());
     assert_eq!(expected, b_chip[response_2_row]);
 
     // Nothing changes until the next time the Bitwise chiplet responds.
@@ -152,7 +157,8 @@ fn b_chip_trace_bitwise() {
 
     // At the end of the next bitwise cycle, the response for `U32and` is provided by the Bitwise
     // chiplet.
-    expected *= build_expected_bitwise_from_trace(&trace, &rand_elements, response_3_row - 1);
+    expected *=
+        build_expected_bitwise_from_trace(&trace, &rand_elements, (response_3_row - 1).into());
     assert_eq!(expected, b_chip[response_3_row]);
 
     // The value in b_chip should be ONE now and for the rest of the trace.
@@ -168,7 +174,11 @@ fn build_expected_bitwise(alphas: &[Felt], label: Felt, a: Felt, b: Felt, result
     alphas[0] + alphas[1] * label + alphas[2] * a + alphas[3] * b + alphas[4] * result
 }
 
-fn build_expected_bitwise_from_trace(trace: &ExecutionTrace, alphas: &[Felt], row: usize) -> Felt {
+fn build_expected_bitwise_from_trace(
+    trace: &ExecutionTrace,
+    alphas: &[Felt],
+    row: RowIndex,
+) -> Felt {
     let selector = trace.main_trace.get_column(BITWISE_TRACE_OFFSET)[row];
 
     let op_id = if selector == BITWISE_AND {

--- a/processor/src/trace/tests/chiplets/memory.rs
+++ b/processor/src/trace/tests/chiplets/memory.rs
@@ -2,10 +2,13 @@ use super::{
     build_trace_from_ops, rand_array, ExecutionTrace, Felt, FieldElement, Operation, Trace, Word,
     AUX_TRACE_RAND_ELEMENTS, CHIPLETS_AUX_TRACE_OFFSET, NUM_RAND_ROWS, ONE, ZERO,
 };
-use miden_air::trace::chiplets::{
-    memory::{MEMORY_READ_LABEL, MEMORY_WRITE, MEMORY_WRITE_LABEL, NUM_ELEMENTS},
-    MEMORY_ADDR_COL_IDX, MEMORY_CLK_COL_IDX, MEMORY_CTX_COL_IDX, MEMORY_SELECTORS_COL_IDX,
-    MEMORY_V_COL_RANGE,
+use miden_air::{
+    trace::chiplets::{
+        memory::{MEMORY_READ_LABEL, MEMORY_WRITE, MEMORY_WRITE_LABEL, NUM_ELEMENTS},
+        MEMORY_ADDR_COL_IDX, MEMORY_CLK_COL_IDX, MEMORY_CTX_COL_IDX, MEMORY_SELECTORS_COL_IDX,
+        MEMORY_V_COL_RANGE,
+    },
+    RowIndex,
 };
 
 /// Tests the generation of the `b_chip` bus column when only memory lookups are included. It
@@ -83,15 +86,15 @@ fn b_chip_trace_mem() {
     let value =
         build_expected_memory(&rand_elements, MEMORY_READ_LABEL, ZERO, ZERO, Felt::new(8), word);
     expected *= value.inv();
-    expected *= build_expected_memory_from_trace(&trace, &rand_elements, 8);
+    expected *= build_expected_memory_from_trace(&trace, &rand_elements, 8.into());
     assert_eq!(expected, b_chip[9]);
 
     // At cycle 9, `MLoad` is provided by memory.
-    expected *= build_expected_memory_from_trace(&trace, &rand_elements, 9);
+    expected *= build_expected_memory_from_trace(&trace, &rand_elements, 9.into());
     assert_eq!(expected, b_chip[10]);
 
     // At cycle 10,  `MLoadW` is provided by memory.
-    expected *= build_expected_memory_from_trace(&trace, &rand_elements, 10);
+    expected *= build_expected_memory_from_trace(&trace, &rand_elements, 10.into());
     assert_eq!(expected, b_chip[11]);
 
     // At cycle 11, `MStore` is requested by the stack and the first read of `MStream` is provided
@@ -105,11 +108,11 @@ fn b_chip_trace_mem() {
         [ONE, ZERO, ZERO, ZERO],
     );
     expected *= value.inv();
-    expected *= build_expected_memory_from_trace(&trace, &rand_elements, 11);
+    expected *= build_expected_memory_from_trace(&trace, &rand_elements, 11.into());
     assert_eq!(expected, b_chip[12]);
 
     // At cycle 12, `MStore` is provided by the memory
-    expected *= build_expected_memory_from_trace(&trace, &rand_elements, 12);
+    expected *= build_expected_memory_from_trace(&trace, &rand_elements, 12.into());
     assert_eq!(expected, b_chip[13]);
 
     // At cycle 13, `MStream` is requested by the stack, and the second read of `MStream` is
@@ -125,7 +128,7 @@ fn b_chip_trace_mem() {
         [ONE, ZERO, ZERO, ZERO],
     );
     expected *= (value1 * value2).inv();
-    expected *= build_expected_memory_from_trace(&trace, &rand_elements, 13);
+    expected *= build_expected_memory_from_trace(&trace, &rand_elements, 13.into());
     assert_eq!(expected, b_chip[14]);
 
     // At cycle 14 the decoder requests the span hash. We set this as the inverse of the previously
@@ -164,7 +167,11 @@ fn build_expected_memory(
         + word_value
 }
 
-fn build_expected_memory_from_trace(trace: &ExecutionTrace, alphas: &[Felt], row: usize) -> Felt {
+fn build_expected_memory_from_trace(
+    trace: &ExecutionTrace,
+    alphas: &[Felt],
+    row: RowIndex,
+) -> Felt {
     // get the memory access operation
     let s0 = trace.main_trace.get_column(MEMORY_SELECTORS_COL_IDX)[row];
     let s1 = trace.main_trace.get_column(MEMORY_SELECTORS_COL_IDX + 1)[row];

--- a/processor/src/trace/utils.rs
+++ b/processor/src/trace/utils.rs
@@ -2,7 +2,7 @@ use super::{Felt, FieldElement, NUM_RAND_ROWS};
 use crate::{chiplets::Chiplets, utils::uninit_vector};
 use alloc::vec::Vec;
 use core::slice;
-use miden_air::trace::main_trace::MainTrace;
+use miden_air::{trace::main_trace::MainTrace, RowIndex};
 
 #[cfg(test)]
 use vm_core::{utils::ToElements, Operation};
@@ -41,7 +41,7 @@ impl<'a> TraceFragment<'a> {
 
     /// Updates a single cell in this fragment with provided value.
     #[inline(always)]
-    pub fn set(&mut self, row_idx: usize, col_idx: usize, value: Felt) {
+    pub fn set(&mut self, row_idx: RowIndex, col_idx: usize, value: Felt) {
         self.data[col_idx][row_idx] = value;
     }
 
@@ -148,10 +148,13 @@ pub struct ChipletsLengths {
 impl ChipletsLengths {
     pub fn new(chiplets: &Chiplets) -> Self {
         ChipletsLengths {
-            hash_chiplet_len: chiplets.bitwise_start(),
-            bitwise_chiplet_len: chiplets.memory_start() - chiplets.bitwise_start(),
-            memory_chiplet_len: chiplets.kernel_rom_start() - chiplets.memory_start(),
-            kernel_rom_len: chiplets.padding_start() - chiplets.kernel_rom_start(),
+            hash_chiplet_len: chiplets.bitwise_start().into(),
+            bitwise_chiplet_len: usize::from(chiplets.memory_start())
+                - usize::from(chiplets.bitwise_start()),
+            memory_chiplet_len: usize::from(chiplets.kernel_rom_start())
+                - usize::from(chiplets.memory_start()),
+            kernel_rom_len: usize::from(chiplets.padding_start())
+                - usize::from(chiplets.kernel_rom_start()),
         }
     }
 
@@ -210,9 +213,9 @@ pub trait AuxColumnBuilder<E: FieldElement<BaseField = Felt>> {
     // REQUIRED METHODS
     // --------------------------------------------------------------------------------------------
 
-    fn get_requests_at(&self, main_trace: &MainTrace, alphas: &[E], row_idx: usize) -> E;
+    fn get_requests_at(&self, main_trace: &MainTrace, alphas: &[E], row: RowIndex) -> E;
 
-    fn get_responses_at(&self, main_trace: &MainTrace, alphas: &[E], row_idx: usize) -> E;
+    fn get_responses_at(&self, main_trace: &MainTrace, alphas: &[E], row: RowIndex) -> E;
 
     // PROVIDED METHODS
     // --------------------------------------------------------------------------------------------
@@ -235,9 +238,10 @@ pub trait AuxColumnBuilder<E: FieldElement<BaseField = Felt>> {
 
         let mut requests_running_prod = E::ONE;
         for row_idx in 0..main_trace.num_rows() - 1 {
+            let row = row_idx.into();
             responses_prod[row_idx + 1] =
-                responses_prod[row_idx] * self.get_responses_at(main_trace, alphas, row_idx);
-            requests[row_idx + 1] = self.get_requests_at(main_trace, alphas, row_idx);
+                responses_prod[row_idx] * self.get_responses_at(main_trace, alphas, row);
+            requests[row_idx + 1] = self.get_requests_at(main_trace, alphas, row);
             requests_running_prod *= requests[row_idx + 1];
         }
 

--- a/stdlib/tests/crypto/falcon.rs
+++ b/stdlib/tests/crypto/falcon.rs
@@ -173,7 +173,7 @@ fn test_falcon512_probabilistic_product_failure() {
     expect_exec_error!(
         test,
         ExecutionError::FailedAssertion {
-            clk: 31615,
+            clk: 31615.into(),
             err_code: 0,
             err_msg: None,
         }

--- a/stdlib/tests/crypto/native.rs
+++ b/stdlib/tests/crypto/native.rs
@@ -18,7 +18,7 @@ fn test_invalid_end_addr() {
     expect_exec_error!(
         test,
         ExecutionError::FailedAssertion {
-            clk: 18,
+            clk: 18.into(),
             err_code: 0,
             err_msg: None,
         }
@@ -39,7 +39,7 @@ fn test_invalid_end_addr() {
     expect_exec_error!(
         test,
         ExecutionError::FailedAssertion {
-            clk: 18,
+            clk: 18.into(),
             err_code: 0,
             err_msg: None,
         }

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -24,6 +24,7 @@ std = [
 ]
 
 [dependencies]
+air = { package = "miden-air", path = "../air", version = "0.10", default-features = false }
 assembly = { package = "miden-assembly", path = "../assembly", version = "0.10", default-features = false, features = [
     "testing",
 ] }


### PR DESCRIPTION
Closes #1236.

* Add `struct RowIndex(u32)` in air crate
* Replace `usize` with `Step` for all variables pertaining to execution trace rows
* Implement operator overrides to allow Step to replace `usize`  in arithmetic, indexing, equality, and ordering operations