### PR TITLE
add `Assembler::assemble_library()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Added functions to `MastForestBuilder` to allow ensuring of nodes with fewer LOC (#1404)
 - Make `Assembler` single-use (#1409)
 - Remove `ProcedureCache` from the assembler (#1411).
+- Add `Assembler::assemble_library()` (#1413)
 
 #### Changed
 

--- a/assembly/src/assembler/module_graph/mod.rs
+++ b/assembly/src/assembler/module_graph/mod.rs
@@ -9,12 +9,15 @@ pub use self::name_resolver::{CallerInfo, ResolvedTarget};
 
 use alloc::{boxed::Box, collections::BTreeMap, sync::Arc, vec::Vec};
 use core::ops::Index;
+use std::borrow::Cow;
 use vm_core::Kernel;
 
 use smallvec::{smallvec, SmallVec};
 
 use self::{analysis::MaybeRewriteCheck, name_resolver::NameResolver, rewrites::ModuleRewriter};
 use super::{GlobalProcedureIndex, ModuleIndex};
+use crate::ast::ResolvedProcedure;
+use crate::diagnostics::{RelatedLabel, SourceFile};
 use crate::{
     ast::{
         Export, FullyQualifiedProcedureName, InvocationTarget, Module, Procedure, ProcedureIndex,
@@ -140,6 +143,16 @@ impl ModuleGraph {
 // ------------------------------------------------------------------------------------------------
 /// Analysis
 impl ModuleGraph {
+    /// Get a slice representing the topological ordering of this graph.
+    ///
+    /// The slice is ordered such that when a node is encountered, all of its dependencies come
+    /// after it in the slice. Thus, by walking the slice in reverse, we visit the leaves of the
+    /// graph before any of the dependents of those leaves. We use this property to resolve MAST
+    /// roots for the entire program, bottom-up.
+    pub fn topological_sort(&self) -> &[GlobalProcedureIndex] {
+        self.topo.as_slice()
+    }
+
     /// Recompute the module graph.
     ///
     /// This should be called any time `add_module`, `add_library`, etc., are called, when all such
@@ -414,6 +427,66 @@ impl ModuleGraph {
         }
 
         Ok(())
+    }
+
+    /// Resolves a [FullyQualifiedProcedureName] to its defining [Procedure].
+    pub fn find(
+        &self,
+        source_file: Option<Arc<SourceFile>>,
+        name: &FullyQualifiedProcedureName,
+    ) -> Result<GlobalProcedureIndex, AssemblyError> {
+        let mut next = Cow::Borrowed(name);
+        let mut caller = source_file.clone();
+        loop {
+            let module_index = self.find_module_index(&next.module).ok_or_else(|| {
+                AssemblyError::UndefinedModule {
+                    span: next.span(),
+                    source_file: caller.clone(),
+                    path: name.module.clone(),
+                }
+            })?;
+            let module = &self.modules[module_index.as_usize()];
+
+            match module.resolve(&next.name) {
+                Some(ResolvedProcedure::Local(index)) => {
+                    let id = GlobalProcedureIndex {
+                        module: module_index,
+                        index: index.into_inner(),
+                    };
+                    break Ok(id);
+                }
+                Some(ResolvedProcedure::External(fqn)) => {
+                    // If we see that we're about to enter an infinite resolver loop because
+                    // of a recursive alias, return an error
+                    if name == &fqn {
+                        break Err(AssemblyError::RecursiveAlias {
+                            source_file: caller.clone(),
+                            name: name.clone(),
+                        });
+                    }
+                    next = Cow::Owned(fqn);
+                    caller = module.source_file();
+                }
+                Some(ResolvedProcedure::MastRoot(ref digest)) => {
+                    if let Some(id) = self.get_procedure_index_by_digest(digest) {
+                        break Ok(id);
+                    }
+                    break Err(AssemblyError::Failed {
+                        labels: vec![RelatedLabel::error("undefined procedure")
+                            .with_source_file(source_file)
+                            .with_labeled_span(next.span(), "unable to resolve this reference")],
+                    });
+                }
+                None => {
+                    // No such procedure known to `module`
+                    break Err(AssemblyError::Failed {
+                        labels: vec![RelatedLabel::error("undefined procedure")
+                            .with_source_file(source_file)
+                            .with_labeled_span(next.span(), "unable to resolve this reference")],
+                    });
+                }
+            }
+        }
     }
 
     /// Resolve a [LibraryPath] to a [ModuleIndex] in this graph

--- a/assembly/src/library/error.rs
+++ b/assembly/src/library/error.rs
@@ -59,3 +59,13 @@ pub enum LibraryError {
     #[cfg(feature = "std")]
     Io(#[from] std::io::Error),
 }
+
+#[derive(Debug, thiserror::Error, Diagnostic)]
+pub enum CompiledLibraryError {
+    #[error("Invalid exports: MAST forest has {roots_len} procedure roots, but exports have {exports_len}")]
+    #[diagnostic()]
+    InvalidExports {
+        exports_len: usize,
+        roots_len: usize,
+    },
+}

--- a/assembly/src/library/mod.rs
+++ b/assembly/src/library/mod.rs
@@ -1,4 +1,10 @@
-use crate::ast;
+use std::collections::BTreeMap;
+use std::vec::Vec;
+
+use vm_core::crypto::hash::RpoDigest;
+use vm_core::mast::MastForest;
+
+use crate::ast::{self, FullyQualifiedProcedureName, ProcedureIndex, ProcedureName};
 
 mod error;
 mod masl;
@@ -6,7 +12,7 @@ mod namespace;
 mod path;
 mod version;
 
-pub use self::error::LibraryError;
+pub use self::error::{CompiledLibraryError, LibraryError};
 pub use self::masl::MaslLibrary;
 pub use self::namespace::{LibraryNamespace, LibraryNamespaceError};
 pub use self::path::{LibraryPath, LibraryPathComponent, PathError};
@@ -14,6 +20,150 @@ pub use self::version::{Version, VersionError};
 
 #[cfg(test)]
 mod tests;
+
+// COMPILED LIBRARY
+// ===============================================================================================
+
+/// Represents a library where all modules modules were compiled into a [`MastForest`].
+pub struct CompiledLibrary {
+    mast_forest: MastForest,
+    // a path for every `root` in the associated MAST forest
+    exports: Vec<FullyQualifiedProcedureName>,
+}
+
+/// Constructors
+impl CompiledLibrary {
+    /// Constructs a new [`CompiledLibrary`].
+    pub fn new(
+        mast_forest: MastForest,
+        exports: Vec<FullyQualifiedProcedureName>,
+    ) -> Result<Self, CompiledLibraryError> {
+        if mast_forest.num_procedures() as usize != exports.len() {
+            return Err(CompiledLibraryError::InvalidExports {
+                exports_len: exports.len(),
+                roots_len: mast_forest.num_procedures() as usize,
+            });
+        }
+
+        Ok(Self {
+            mast_forest,
+            exports,
+        })
+    }
+}
+
+impl CompiledLibrary {
+    /// Returns the inner [`MastForest`].
+    pub fn mast_forest(&self) -> &MastForest {
+        &self.mast_forest
+    }
+
+    /// Returns the fully qualified name of all procedures exported by the library.
+    pub fn exports(&self) -> &[FullyQualifiedProcedureName] {
+        &self.exports
+    }
+
+    /// Returns an iterator over the module infos of the library.
+    pub fn into_module_infos(self) -> impl Iterator<Item = ModuleInfo> {
+        let mut modules_by_path: BTreeMap<LibraryPath, ModuleInfo> = BTreeMap::new();
+
+        for (proc_index, proc_name) in self.exports.into_iter().enumerate() {
+            modules_by_path
+                .entry(proc_name.module.clone())
+                .and_modify(|compiled_module| {
+                    let proc_node_id = self.mast_forest.procedure_roots()[proc_index];
+                    let proc_digest = self.mast_forest[proc_node_id].digest();
+
+                    compiled_module.add_procedure_info(ProcedureInfo {
+                        name: proc_name.name.clone(),
+                        digest: proc_digest,
+                    })
+                })
+                .or_insert_with(|| {
+                    let proc_node_id = self.mast_forest.procedure_roots()[proc_index];
+                    let proc_digest = self.mast_forest[proc_node_id].digest();
+                    let proc = ProcedureInfo {
+                        name: proc_name.name,
+                        digest: proc_digest,
+                    };
+
+                    ModuleInfo::new(proc_name.module, vec![proc])
+                });
+        }
+
+        modules_by_path.into_values()
+    }
+}
+
+// MODULE INFO
+// ===============================================================================================
+
+/// Stores a module's path, as well as information about all exported procedures.
+#[derive(Debug, Clone)]
+pub struct ModuleInfo {
+    path: LibraryPath,
+    procedure_infos: Vec<ProcedureInfo>,
+}
+
+impl ModuleInfo {
+    /// Constructs a new [`ModuleInfo`].
+    pub fn new(path: LibraryPath, procedures: Vec<ProcedureInfo>) -> Self {
+        Self {
+            path,
+            procedure_infos: procedures,
+        }
+    }
+
+    /// Adds a [`ProcedureInfo`] to the module.
+    pub fn add_procedure_info(&mut self, procedure: ProcedureInfo) {
+        self.procedure_infos.push(procedure);
+    }
+
+    /// Returns the module's library path.
+    pub fn path(&self) -> &LibraryPath {
+        &self.path
+    }
+
+    /// Returns the number of procedures in the module.
+    pub fn num_procedures(&self) -> usize {
+        self.procedure_infos.len()
+    }
+
+    /// Returns an iterator over the procedure infos in the module with their corresponding
+    /// procedure index in the module.
+    pub fn procedure_infos(&self) -> impl Iterator<Item = (ProcedureIndex, &ProcedureInfo)> {
+        self.procedure_infos
+            .iter()
+            .enumerate()
+            .map(|(idx, proc)| (ProcedureIndex::new(idx), proc))
+    }
+
+    /// Returns the [`ProcedureInfo`] of the procedure at the provided index, if any.
+    pub fn get_proc_info_by_index(&self, index: ProcedureIndex) -> Option<&ProcedureInfo> {
+        self.procedure_infos.get(index.as_usize())
+    }
+
+    /// Returns the digest of the procedure with the provided name, if any.
+    pub fn get_proc_digest_by_name(&self, name: &ProcedureName) -> Option<RpoDigest> {
+        self.procedure_infos.iter().find_map(|proc_info| {
+            if &proc_info.name == name {
+                Some(proc_info.digest)
+            } else {
+                None
+            }
+        })
+    }
+}
+
+/// Stores the name and digest of a procedure.
+#[derive(Debug, Clone)]
+pub struct ProcedureInfo {
+    pub name: ProcedureName,
+    pub digest: RpoDigest,
+}
+
+// LIBRARY
+// ===============================================================================================
 
 /// Maximum number of modules in a library.
 const MAX_MODULES: usize = u16::MAX as usize;

--- a/core/src/mast/mod.rs
+++ b/core/src/mast/mod.rs
@@ -94,9 +94,9 @@ impl MastForest {
         self.roots.iter().find(|&&root_id| self[root_id].digest() == digest).copied()
     }
 
-    /// Returns an iterator over the digest of the procedures in this MAST forest.
-    pub fn procedure_roots(&self) -> impl Iterator<Item = RpoDigest> + '_ {
-        self.roots.iter().map(|&root_id| self[root_id].digest())
+    /// Returns an iterator over the IDs of the procedures in this MAST forest.
+    pub fn procedure_roots(&self) -> &[MastNodeId] {
+        &self.roots
     }
 
     /// Returns the number of procedures in this MAST forest.

--- a/processor/src/host/mast_forest_store.rs
+++ b/processor/src/host/mast_forest_store.rs
@@ -26,7 +26,8 @@ impl MemMastForestStore {
         let mast_forest = Arc::new(mast_forest);
 
         for root in mast_forest.procedure_roots() {
-            self.mast_forests.insert(root, mast_forest.clone());
+            let root_digest = mast_forest[*root].digest();
+            self.mast_forests.insert(root_digest, mast_forest.clone());
         }
     }
 }


### PR DESCRIPTION
Reimplements a subset of #1401 (only `Assembler::assemble_library()`).