### PR TITLE
chore: increment all crates version to v0.10.0

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -5,7 +5,7 @@ name: changelog
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize]
+    types: [opened, reopened, synchronize, labeled, unlabeled]
 
 jobs:
   changelog:

--- a/air/Cargo.toml
+++ b/air/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "miden-air"
-version = "0.9.2"
+version = "0.10.0"
 description = "Algebraic intermediate representation of Miden VM processor"
-documentation = "https://docs.rs/miden-air/0.9.2"
+documentation = "https://docs.rs/miden-air/0.10.0"
 categories = ["cryptography", "no-std"]
 keywords = ["air", "arithmetization", "crypto", "miden"]
 readme.workspace = true
@@ -31,7 +31,7 @@ std = ["vm-core/std", "winter-air/std"]
 testing = []
 
 [dependencies]
-vm-core = { package = "miden-core", path = "../core", version = "0.9", default-features = false }
+vm-core = { package = "miden-core", path = "../core", version = "0.10", default-features = false }
 winter-air = { package = "winter-air", version = "0.9", default-features = false }
 winter-prover = { package = "winter-prover", version = "0.9", default-features = false }
 

--- a/assembly/Cargo.toml
+++ b/assembly/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "miden-assembly"
-version = "0.9.2"
+version = "0.10.0"
 description = "Miden VM assembly language"
-documentation = "https://docs.rs/miden-assembly/0.9.2"
+documentation = "https://docs.rs/miden-assembly/0.10.0"
 categories = ["compilers", "no-std"]
 keywords = ["assembler", "assembly", "language", "miden"]
 readme.workspace = true
@@ -49,7 +49,7 @@ tracing = { version = "0.1", default-features = false, features = [
 ] }
 thiserror = { version = "1.0", git = "https://github.com/bitwalker/thiserror", branch = "no-std", default-features = false }
 unicode-width = { version = "0.1", features = ["no_std"] }
-vm-core = { package = "miden-core", path = "../core", version = "0.9", default-features = false }
+vm-core = { package = "miden-core", path = "../core", version = "0.10", default-features = false }
 
 [dev-dependencies]
 pretty_assertions = "1.4"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "miden-core"
-version = "0.9.1"
+version = "0.10.0"
 description = "Miden VM core components"
-documentation = "https://docs.rs/miden-core/0.9.1"
+documentation = "https://docs.rs/miden-core/0.10.0"
 categories = ["emulators", "no-std"]
 keywords = ["instruction-set", "miden", "program"]
 readme.workspace = true

--- a/miden/Cargo.toml
+++ b/miden/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "miden-vm"
-version = "0.9.1"
+version = "0.10.0"
 description="Miden virtual machine"
-documentation = "https://docs.rs/miden-vm/0.9.1"
+documentation = "https://docs.rs/miden-vm/0.10.0"
 categories = ["cryptography", "emulators", "no-std"]
 keywords = ["miden", "stark", "virtual-machine", "zkp"]
 readme.workspace = true
@@ -57,17 +57,17 @@ metal = ["prover/metal", "std"]
 std = ["assembly/std", "processor/std", "prover/std", "verifier/std"]
 
 [dependencies]
-assembly = { package = "miden-assembly", path = "../assembly", version = "0.9", default-features = false }
+assembly = { package = "miden-assembly", path = "../assembly", version = "0.10", default-features = false }
 blake3 = "1.5"
 clap = { version = "4.4", features = ["derive"], optional = true }
 hex = { version = "0.4", optional = true }
-processor = { package = "miden-processor", path = "../processor", version = "0.9", default-features = false }
-prover = { package = "miden-prover", path = "../prover", version = "0.9", default-features = false }
+processor = { package = "miden-processor", path = "../processor", version = "0.10", default-features = false }
+prover = { package = "miden-prover", path = "../prover", version = "0.10", default-features = false }
 rustyline = { version = "13.0", default-features = false, optional = true }
 serde = { version = "1.0", optional = true }
 serde_derive = { version = "1.0", optional = true }
 serde_json = { version = "1.0", optional = true }
-stdlib = { package = "miden-stdlib", path = "../stdlib", version = "0.9", default-features = false }
+stdlib = { package = "miden-stdlib", path = "../stdlib", version = "0.10", default-features = false }
 tracing = { version = "0.1", default-features = false, features = [
     "attributes",
 ] }
@@ -79,8 +79,8 @@ tracing-forest = { version = "0.1", optional = true, features = [
     "ansi",
     "smallvec",
 ] }
-verifier = { package = "miden-verifier", path = "../verifier", version = "0.9", default-features = false }
-vm-core = { package = "miden-core", path = "../core", version = "0.9", default-features = false }
+verifier = { package = "miden-verifier", path = "../verifier", version = "0.10", default-features = false }
+vm-core = { package = "miden-core", path = "../core", version = "0.10", default-features = false }
 
 [dev-dependencies]
 assert_cmd = "2.0"
@@ -89,6 +89,6 @@ escargot = "0.5"
 num-bigint = "0.4"
 predicates = "3.0"
 test-utils = { package = "miden-test-utils", path = "../test-utils" }
-vm-core = { package = "miden-core", path = "../core", version = "0.9" }
+vm-core = { package = "miden-core", path = "../core", version = "0.10" }
 winter-fri = { package = "winter-fri", version = "0.8" }
 rand_chacha = "0.3.1"

--- a/processor/Cargo.toml
+++ b/processor/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "miden-processor"
-version = "0.9.2"
+version = "0.10.0"
 description = "Miden VM processor"
-documentation = "https://docs.rs/miden-processor/0.9.2"
+documentation = "https://docs.rs/miden-processor/0.10.0"
 categories = ["emulators", "no-std"]
 keywords = ["miden", "virtual-machine"]
 readme.workspace = true
@@ -27,13 +27,13 @@ std = ["vm-core/std", "winter-prover/std"]
 tracing = { version = "0.1", default-features = false, features = [
     "attributes",
 ] }
-vm-core = { package = "miden-core", path = "../core", version = "0.9", default-features = false }
-miden-air = { package = "miden-air", path = "../air", version = "0.9", default-features = false }
+vm-core = { package = "miden-core", path = "../core", version = "0.10", default-features = false }
+miden-air = { package = "miden-air", path = "../air", version = "0.10", default-features = false }
 winter-prover = { package = "winter-prover", version = "0.9", default-features = false }
 
 [dev-dependencies]
 logtest = { version = "2.0", default-features = false }
-assembly = { package = "miden-assembly", path = "../assembly", version = "0.9", default-features = false }
+assembly = { package = "miden-assembly", path = "../assembly", version = "0.10", default-features = false }
 test-utils = { package = "miden-test-utils", path = "../test-utils" }
 winter-fri = { package = "winter-fri", version = "0.9" }
 winter-utils = { package = "winter-utils", version = "0.9" }

--- a/prover/Cargo.toml
+++ b/prover/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "miden-prover"
-version = "0.9.1"
+version = "0.10.0"
 description = "Miden VM prover"
-documentation = "https://docs.rs/miden-prover/0.9.1"
+documentation = "https://docs.rs/miden-prover/0.10.0"
 categories = ["cryptography", "emulators", "no-std"]
 keywords = ["miden", "prover", "stark", "zkp"]
 readme.workspace = true
@@ -20,8 +20,8 @@ metal = ["dep:miden-gpu", "dep:elsa", "dep:pollster", "concurrent", "std"]
 std = ["air/std", "processor/std", "winter-prover/std"]
 
 [dependencies]
-air = { package = "miden-air", path = "../air", version = "0.9", default-features = false }
-processor = { package = "miden-processor", path = "../processor", version = "0.9", default-features = false }
+air = { package = "miden-air", path = "../air", version = "0.10", default-features = false }
+processor = { package = "miden-processor", path = "../processor", version = "0.10", default-features = false }
 tracing = { version = "0.1", default-features = false, features = ["attributes"] }
 winter-prover = { package = "winter-prover", version = "0.9", default-features = false }
 

--- a/stdlib/Cargo.toml
+++ b/stdlib/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "miden-stdlib"
-version = "0.9.2"
+version = "0.10.0"
 description = "Miden VM standard library"
 readme = "README.md"
-documentation = "https://docs.rs/miden-stdlib/0.9.2"
+documentation = "https://docs.rs/miden-stdlib/0.10.0"
 categories = ["cryptography", "mathematics"]
 keywords = ["miden", "program", "stdlib"]
 license.workspace = true
@@ -26,15 +26,15 @@ default = ["std"]
 std = ["assembly/std"]
 
 [dependencies]
-assembly = { package = "miden-assembly", path = "../assembly", version = "0.9", default-features = false }
+assembly = { package = "miden-assembly", path = "../assembly", version = "0.10", default-features = false }
 
 [dev-dependencies]
 blake3 = "1.5"
-miden-air = { package = "miden-air", path = "../air", version = "0.9", default-features = false }
+miden-air = { package = "miden-air", path = "../air", version = "0.10", default-features = false }
 num = "0.4.1"
 num-bigint = "0.4"
 pretty_assertions = "1.4"
-processor = { package = "miden-processor", path = "../processor", version = "0.9", default-features = false, features = [
+processor = { package = "miden-processor", path = "../processor", version = "0.10", default-features = false, features = [
     "testing",
 ] }
 rand = { version = "0.8.5", default-features = false }
@@ -47,4 +47,4 @@ winter-fri = { package = "winter-fri", version = "0.9" }
 
 
 [build-dependencies]
-assembly = { package = "miden-assembly", path = "../assembly", version = "0.9" }
+assembly = { package = "miden-assembly", path = "../assembly", version = "0.10" }

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -24,16 +24,16 @@ std = [
 ]
 
 [dependencies]
-assembly = { package = "miden-assembly", path = "../assembly", version = "0.9", default-features = false, features = [
+assembly = { package = "miden-assembly", path = "../assembly", version = "0.10", default-features = false, features = [
     "testing",
 ] }
-processor = { package = "miden-processor", path = "../processor", version = "0.9", default-features = false, features = [
+processor = { package = "miden-processor", path = "../processor", version = "0.10", default-features = false, features = [
     "testing",
 ] }
-prover = { package = "miden-prover", path = "../prover", version = "0.9", default-features = false }
+prover = { package = "miden-prover", path = "../prover", version = "0.10", default-features = false }
 test-case = "3.2"
-verifier = { package = "miden-verifier", path = "../verifier", version = "0.9", default-features = false }
-vm-core = { package = "miden-core", path = "../core", version = "0.9", default-features = false }
+verifier = { package = "miden-verifier", path = "../verifier", version = "0.10", default-features = false }
+vm-core = { package = "miden-core", path = "../core", version = "0.10", default-features = false }
 winter-prover = { package = "winter-prover", version = "0.9", default-features = false }
 
 [target.'cfg(target_family = "wasm")'.dependencies]

--- a/verifier/Cargo.toml
+++ b/verifier/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "miden-verifier"
-version = "0.9.1"
+version = "0.10.0"
 description="Miden VM execution verifier"
-documentation = "https://docs.rs/miden-verifier/0.9.1"
+documentation = "https://docs.rs/miden-verifier/0.10.0"
 categories = ["cryptography", "no-std"]
 keywords = ["miden", "stark", "verifier", "zkp"]
 readme.workspace = true
@@ -22,7 +22,7 @@ default = ["std"]
 std = ["air/std", "vm-core/std", "winter-verifier/std"]
 
 [dependencies]
-air = { package = "miden-air", path = "../air", version = "0.9", default-features = false }
+air = { package = "miden-air", path = "../air", version = "0.10", default-features = false }
 tracing = { version = "0.1", default-features = false, features = ["attributes"] }
-vm-core = { package = "miden-core", path = "../core", version = "0.9", default-features = false }
+vm-core = { package = "miden-core", path = "../core", version = "0.10", default-features = false }
 winter-verifier = { package = "winter-verifier", version = "0.9", default-features = false }


### PR DESCRIPTION
This PR increments all crates versions to v0.10.0 so that compiler crates be able to reference next published VM crates to test the compiler crates publishing.
