### PR TITLE
Minor refactoring of assembler API

### DIFF
--- a/assembly/src/assembler/mod.rs
+++ b/assembly/src/assembler/mod.rs
@@ -50,8 +50,8 @@ pub use self::{
 ///   [Assembler::assemble_program].
 /// * If you want to link your executable to a few other modules that implement supporting
 ///   procedures, build the assembler with them first, using the various builder methods on
-///   [Assembler], e.g. [Assembler::with_module], [Assembler::with_compiled_library], etc. Then,
-///   call [Assembler::assemble_program] to get your compiled program.
+///   [Assembler], e.g. [Assembler::with_module], [Assembler::with_library], etc. Then, call
+///   [Assembler::assemble_program] to get your compiled program.
 #[derive(Clone)]
 pub struct Assembler {
     /// The source manager to use for compilation and source location information
@@ -269,7 +269,9 @@ impl Assembler {
             exports
         };
 
-        Ok(Library::new(mast_forest_builder.build(), exports)?)
+        // TODO: show a warning if library exports are empty?
+
+        Ok(Library::new(mast_forest_builder.build(), exports))
     }
 
     /// Assembles the provided module into a [KernelLibrary] intended to be used as a Kernel.
@@ -308,7 +310,9 @@ impl Assembler {
             })
             .collect::<Result<BTreeMap<QualifiedProcedureName, RpoDigest>, Report>>()?;
 
-        let library = Library::new(mast_forest_builder.build(), exports)?;
+        // TODO: show a warning if library exports are empty?
+
+        let library = Library::new(mast_forest_builder.build(), exports);
         Ok(library.try_into()?)
     }
 

--- a/assembly/src/assembler/mod.rs
+++ b/assembly/src/assembler/mod.rs
@@ -177,10 +177,7 @@ impl Assembler {
     }
 
     /// Adds the compiled library to provide modules for the compilation.
-    pub fn add_compiled_library(
-        &mut self,
-        library: impl AsRef<CompiledLibrary>,
-    ) -> Result<(), Report> {
+    pub fn add_library(&mut self, library: impl AsRef<CompiledLibrary>) -> Result<(), Report> {
         self.module_graph
             .add_compiled_modules(library.as_ref().module_infos())
             .map_err(Report::from)?;
@@ -188,11 +185,8 @@ impl Assembler {
     }
 
     /// Adds the compiled library to provide modules for the compilation.
-    pub fn with_compiled_library(
-        mut self,
-        library: impl AsRef<CompiledLibrary>,
-    ) -> Result<Self, Report> {
-        self.add_compiled_library(library)?;
+    pub fn with_library(mut self, library: impl AsRef<CompiledLibrary>) -> Result<Self, Report> {
+        self.add_library(library)?;
         Ok(self)
     }
 }

--- a/assembly/src/assembler/mod.rs
+++ b/assembly/src/assembler/mod.rs
@@ -7,7 +7,7 @@ use vm_core::{mast::MastNodeId, Decorator, DecoratorList, Felt, Kernel, Operatio
 use crate::{
     ast::{self, Export, InvocationTarget, InvokeKind, ModuleKind, QualifiedProcedureName},
     diagnostics::Report,
-    library::{CompiledLibrary, KernelLibrary},
+    library::{KernelLibrary, Library},
     sema::SemanticAnalysisError,
     AssemblyError, Compile, CompileOptions, LibraryNamespace, LibraryPath, RpoDigest,
     SourceManager, Spanned,
@@ -177,7 +177,7 @@ impl Assembler {
     }
 
     /// Adds the compiled library to provide modules for the compilation.
-    pub fn add_library(&mut self, library: impl AsRef<CompiledLibrary>) -> Result<(), Report> {
+    pub fn add_library(&mut self, library: impl AsRef<Library>) -> Result<(), Report> {
         self.module_graph
             .add_compiled_modules(library.as_ref().module_infos())
             .map_err(Report::from)?;
@@ -185,7 +185,7 @@ impl Assembler {
     }
 
     /// Adds the compiled library to provide modules for the compilation.
-    pub fn with_library(mut self, library: impl AsRef<CompiledLibrary>) -> Result<Self, Report> {
+    pub fn with_library(mut self, library: impl AsRef<Library>) -> Result<Self, Report> {
         self.add_library(library)?;
         Ok(self)
     }
@@ -221,7 +221,7 @@ impl Assembler {
 // ------------------------------------------------------------------------------------------------
 /// Compilation/Assembly
 impl Assembler {
-    /// Assembles a set of modules into a [CompiledLibrary].
+    /// Assembles a set of modules into a [Library].
     ///
     /// # Errors
     ///
@@ -229,7 +229,7 @@ impl Assembler {
     pub fn assemble_library(
         mut self,
         modules: impl IntoIterator<Item = impl Compile>,
-    ) -> Result<CompiledLibrary, Report> {
+    ) -> Result<Library, Report> {
         let ast_module_indices =
             modules.into_iter().try_fold(Vec::default(), |mut acc, module| {
                 module
@@ -269,7 +269,7 @@ impl Assembler {
             exports
         };
 
-        Ok(CompiledLibrary::new(mast_forest_builder.build(), exports)?)
+        Ok(Library::new(mast_forest_builder.build(), exports)?)
     }
 
     /// Assembles the provided module into a [KernelLibrary] intended to be used as a Kernel.
@@ -308,7 +308,7 @@ impl Assembler {
             })
             .collect::<Result<BTreeMap<QualifiedProcedureName, RpoDigest>, Report>>()?;
 
-        let library = CompiledLibrary::new(mast_forest_builder.build(), exports)?;
+        let library = Library::new(mast_forest_builder.build(), exports)?;
         Ok(library.try_into()?)
     }
 

--- a/assembly/src/assembler/module_graph/debug.rs
+++ b/assembly/src/assembler/module_graph/debug.rs
@@ -36,7 +36,7 @@ impl<'a> fmt::Debug for DisplayModuleGraph<'a> {
                         })
                         .collect::<Vec<_>>(),
                     WrappedModule::Info(m) => m
-                        .procedure_infos()
+                        .procedures()
                         .map(|(proc_index, _proc)| {
                             let gid = GlobalProcedureIndex {
                                 module: ModuleIndex::new(module_index),
@@ -81,7 +81,7 @@ impl<'a> fmt::Debug for DisplayModuleGraphNodes<'a> {
                         })
                         .collect::<Vec<_>>(),
                     WrappedModule::Info(m) => m
-                        .procedure_infos()
+                        .procedures()
                         .map(|(proc_index, proc)| DisplayModuleGraphNode {
                             module: module_index,
                             index: proc_index,

--- a/assembly/src/assembler/module_graph/mod.rs
+++ b/assembly/src/assembler/module_graph/mod.rs
@@ -117,7 +117,7 @@ impl WrappedModule {
         match self {
             WrappedModule::Ast(module) => module.resolve(name),
             WrappedModule::Info(module) => {
-                module.get_proc_digest_by_name(name).map(ResolvedProcedure::MastRoot)
+                module.get_procedure_digest_by_name(name).map(ResolvedProcedure::MastRoot)
             },
         }
     }
@@ -196,9 +196,8 @@ impl ModuleGraph {
 
         // Register all procedures as roots
         for &module_index in module_indices.iter() {
-            for (proc_index, proc) in self[module_index].unwrap_info().clone().procedure_infos() {
-                let gid = GlobalProcedureIndex { module: module_index, index: proc_index };
-
+            for (proc_index, proc) in self[module_index].unwrap_info().clone().procedures() {
+                let gid = module_index + proc_index;
                 self.register_mast_root(gid, proc.digest)?;
             }
         }
@@ -364,7 +363,7 @@ impl ModuleGraph {
                     }
                 },
                 PendingWrappedModule::Info(pending_module) => {
-                    for (proc_index, _procedure) in pending_module.procedure_infos() {
+                    for (proc_index, _procedure) in pending_module.procedures() {
                         let global_id =
                             GlobalProcedureIndex { module: module_id, index: proc_index };
                         self.callgraph.get_or_insert_node(global_id);
@@ -516,7 +515,7 @@ impl ModuleGraph {
         match &self.modules[id.module.as_usize()] {
             WrappedModule::Ast(m) => ProcedureWrapper::Ast(&m[id.index]),
             WrappedModule::Info(m) => {
-                ProcedureWrapper::Info(m.get_proc_info_by_index(id.index).unwrap())
+                ProcedureWrapper::Info(m.get_procedure_by_index(id.index).unwrap())
             },
         }
     }

--- a/assembly/src/assembler/tests.rs
+++ b/assembly/src/assembler/tests.rs
@@ -34,7 +34,7 @@ fn nested_blocks() -> Result<(), Report> {
             .unwrap();
 
         let mut assembler = Assembler::with_kernel(context.source_manager(), kernel_lib);
-        assembler.add_compiled_library(dummy_library).unwrap();
+        assembler.add_library(dummy_library).unwrap();
 
         assembler
     };
@@ -255,9 +255,7 @@ fn explicit_fully_qualified_procedure_references() -> Result<(), Report> {
     let baz = context.parse_module_with_path(BAZ_NAME.parse().unwrap(), BAZ)?;
     let library = context.assemble_library([bar, baz]).unwrap();
 
-    let assembler = Assembler::new(context.source_manager())
-        .with_compiled_library(&library)
-        .unwrap();
+    let assembler = Assembler::new(context.source_manager()).with_library(&library).unwrap();
 
     let program = r#"
     begin
@@ -291,9 +289,7 @@ fn re_exports() -> Result<(), Report> {
     let baz = context.parse_module_with_path(BAZ_NAME.parse().unwrap(), BAZ)?;
     let library = context.assemble_library([bar, baz]).unwrap();
 
-    let assembler = Assembler::new(context.source_manager())
-        .with_compiled_library(&library)
-        .unwrap();
+    let assembler = Assembler::new(context.source_manager()).with_library(&library).unwrap();
 
     let program = r#"
     use.foo::baz

--- a/assembly/src/library/error.rs
+++ b/assembly/src/library/error.rs
@@ -1,77 +1,27 @@
-use alloc::{string::String, vec::Vec};
-
 use vm_core::errors::KernelError;
 
-use crate::{
-    ast::QualifiedProcedureName, diagnostics::Diagnostic, library::LibraryNamespaceError,
-    prettier::pretty_print_csv, DeserializationError, LibraryNamespace, LibraryPath, PathError,
-};
+use crate::{ast::QualifiedProcedureName, diagnostics::Diagnostic, LibraryNamespace, LibraryPath};
 
 #[derive(Debug, thiserror::Error, Diagnostic)]
 pub enum LibraryError {
+    #[error("library must contain at least one exported procedure")]
+    #[diagnostic()]
+    EmptyExports,
     #[error("library '{0}' does not contain any modules")]
     #[diagnostic()]
-    Empty(LibraryNamespace),
-    #[error("module '{0}' not found")]
-    #[diagnostic()]
-    ModuleNotFound(String),
+    EmptyModules(LibraryNamespace),
     #[error("duplicate module '{0}'")]
     #[diagnostic()]
     DuplicateModulePath(LibraryPath),
-    #[error("duplicate namespace '{0}'")]
-    #[diagnostic()]
-    DuplicateNamespace(LibraryNamespace),
-    #[error("inconsistent module namespace: expected '{expected}', but was {actual}")]
-    #[diagnostic()]
-    InconsistentNamespace {
-        expected: LibraryNamespace,
-        actual: LibraryNamespace,
-    },
-    #[error("library '{name}' contains {count} dependencies, but the max is {max}")]
-    #[diagnostic()]
-    TooManyDependenciesInLibrary {
-        name: LibraryNamespace,
-        count: usize,
-        max: usize,
-    },
+    #[error("invalid export in kernel library: {procedure_path}")]
+    InvalidKernelExport { procedure_path: QualifiedProcedureName },
+    #[error(transparent)]
+    Kernel(#[from] KernelError),
     #[error("library '{name}' contains {count} modules, but the max is {max}")]
     #[diagnostic()]
     TooManyModulesInLibrary {
         name: LibraryNamespace,
         count: usize,
         max: usize,
-    },
-    #[error("failed to deserialize library from '{path}': {error}")]
-    #[diagnostic()]
-    DeserializationFailed {
-        path: String,
-        error: DeserializationError,
-    },
-    #[error(transparent)]
-    #[diagnostic()]
-    Namespace(#[from] LibraryNamespaceError),
-    #[error(transparent)]
-    #[diagnostic()]
-    Path(#[from] PathError),
-    #[error(transparent)]
-    #[diagnostic()]
-    #[cfg(feature = "std")]
-    Io(#[from] std::io::Error),
-}
-
-#[derive(Debug, thiserror::Error, Diagnostic)]
-pub enum CompiledLibraryError {
-    #[error("Invalid exports: there must be at least one export")]
-    #[diagnostic()]
-    EmptyExports,
-    #[error("exports are not in the same namespace; all namespaces: {namespaces:?}")]
-    InconsistentNamespaces { namespaces: Vec<LibraryNamespace> },
-    #[error("invalid export in kernel library: {procedure_path}")]
-    InvalidKernelExport { procedure_path: QualifiedProcedureName },
-    #[error(transparent)]
-    Kernel(#[from] KernelError),
-    #[error("no MAST roots for the following exports: {}", pretty_print_csv(missing_exports.as_slice()))]
-    MissingExports {
-        missing_exports: Vec<QualifiedProcedureName>,
     },
 }

--- a/assembly/src/library/error.rs
+++ b/assembly/src/library/error.rs
@@ -4,12 +4,9 @@ use crate::{ast::QualifiedProcedureName, diagnostics::Diagnostic, LibraryNamespa
 
 #[derive(Debug, thiserror::Error, Diagnostic)]
 pub enum LibraryError {
-    #[error("library must contain at least one exported procedure")]
+    #[error("kernel library must contain at least one exported procedure")]
     #[diagnostic()]
-    EmptyExports,
-    #[error("library '{0}' does not contain any modules")]
-    #[diagnostic()]
-    EmptyModules(LibraryNamespace),
+    EmptyKernel,
     #[error("duplicate module '{0}'")]
     #[diagnostic()]
     DuplicateModulePath(LibraryPath),

--- a/assembly/src/library/error.rs
+++ b/assembly/src/library/error.rs
@@ -3,11 +3,8 @@ use alloc::{string::String, vec::Vec};
 use vm_core::errors::KernelError;
 
 use crate::{
-    ast::QualifiedProcedureName,
-    diagnostics::Diagnostic,
-    library::{LibraryNamespaceError, VersionError},
-    prettier::pretty_print_csv,
-    DeserializationError, LibraryNamespace, LibraryPath, PathError,
+    ast::QualifiedProcedureName, diagnostics::Diagnostic, library::LibraryNamespaceError,
+    prettier::pretty_print_csv, DeserializationError, LibraryNamespace, LibraryPath, PathError,
 };
 
 #[derive(Debug, thiserror::Error, Diagnostic)]
@@ -56,9 +53,6 @@ pub enum LibraryError {
     #[error(transparent)]
     #[diagnostic()]
     Path(#[from] PathError),
-    #[error(transparent)]
-    #[diagnostic()]
-    Version(#[from] VersionError),
     #[error(transparent)]
     #[diagnostic()]
     #[cfg(feature = "std")]

--- a/assembly/src/library/masl.rs
+++ b/assembly/src/library/masl.rs
@@ -41,7 +41,7 @@ impl<'a> WalkLibrary<'a> {
         let mut file_path = entry.path();
         let is_module = file_path
             .extension()
-            .map(|ext| ext == AsRef::<OsStr>::as_ref(CompiledLibrary::MODULE_EXTENSION))
+            .map(|ext| ext == AsRef::<OsStr>::as_ref(Library::MODULE_EXTENSION))
             .unwrap_or(false);
         if !is_module {
             return Ok(None);

--- a/assembly/src/library/module.rs
+++ b/assembly/src/library/module.rs
@@ -1,0 +1,75 @@
+use alloc::vec::Vec;
+
+use super::LibraryPath;
+use crate::{
+    ast::{ProcedureIndex, ProcedureName},
+    RpoDigest,
+};
+
+// MODULE INFO
+// ================================================================================================
+
+#[derive(Debug, Clone)]
+pub struct ModuleInfo {
+    path: LibraryPath,
+    procedures: Vec<ProcedureInfo>,
+}
+
+impl ModuleInfo {
+    /// Returns a new [`ModuleInfo`] instantiated library path.
+    pub(super) fn new(path: LibraryPath) -> Self {
+        Self { path, procedures: Vec::new() }
+    }
+
+    /// Adds a procedure to the module.
+    pub fn add_procedure(&mut self, name: ProcedureName, digest: RpoDigest) {
+        self.procedures.push(ProcedureInfo { name, digest });
+    }
+
+    /// Returns the module's library path.
+    pub fn path(&self) -> &LibraryPath {
+        &self.path
+    }
+
+    /// Returns the number of procedures in the module.
+    pub fn num_procedures(&self) -> usize {
+        self.procedures.len()
+    }
+
+    /// Returns the [`ProcedureInfo`] of the procedure at the provided index, if any.
+    pub fn get_procedure_by_index(&self, index: ProcedureIndex) -> Option<&ProcedureInfo> {
+        self.procedures.get(index.as_usize())
+    }
+
+    /// Returns the digest of the procedure with the provided name, if any.
+    pub fn get_procedure_digest_by_name(&self, name: &ProcedureName) -> Option<RpoDigest> {
+        self.procedures.iter().find_map(|proc_info| {
+            if &proc_info.name == name {
+                Some(proc_info.digest)
+            } else {
+                None
+            }
+        })
+    }
+
+    /// Returns an iterator over the procedure infos in the module with their corresponding
+    /// procedure index in the module.
+    pub fn procedures(&self) -> impl Iterator<Item = (ProcedureIndex, &ProcedureInfo)> {
+        self.procedures
+            .iter()
+            .enumerate()
+            .map(|(idx, proc)| (ProcedureIndex::new(idx), proc))
+    }
+
+    /// Returns an iterator over the MAST roots of procedures defined in this module.
+    pub fn procedure_digests(&self) -> impl Iterator<Item = RpoDigest> + '_ {
+        self.procedures.iter().map(|p| p.digest)
+    }
+}
+
+/// Stores the name and digest of a procedure.
+#[derive(Debug, Clone)]
+pub struct ProcedureInfo {
+    pub name: ProcedureName,
+    pub digest: RpoDigest,
+}

--- a/assembly/src/library/module.rs
+++ b/assembly/src/library/module.rs
@@ -17,7 +17,7 @@ pub struct ModuleInfo {
 
 impl ModuleInfo {
     /// Returns a new [`ModuleInfo`] instantiated library path.
-    pub(super) fn new(path: LibraryPath) -> Self {
+    pub fn new(path: LibraryPath) -> Self {
         Self { path, procedures: Vec::new() }
     }
 

--- a/assembly/src/library/namespace.rs
+++ b/assembly/src/library/namespace.rs
@@ -9,6 +9,9 @@ use crate::{
     DeserializationError, LibraryPath, Serializable, Span,
 };
 
+// LIBRARY NAMESPACE
+// ================================================================================================
+
 /// Represents an error when parsing or validating a library namespace
 #[derive(Debug, thiserror::Error, Diagnostic, PartialEq, Eq)]
 pub enum LibraryNamespaceError {
@@ -43,6 +46,8 @@ pub enum LibraryNamespace {
     User(Arc<str>),
 }
 
+// ------------------------------------------------------------------------------------------------
+/// Constants
 impl LibraryNamespace {
     /// Namespaces must be 255 bytes or less
     pub const MAX_LENGTH: usize = u8::MAX as usize;
@@ -55,7 +60,11 @@ impl LibraryNamespace {
 
     /// Path for a module without library path.
     pub const ANON_PATH: &'static str = "#anon";
+}
 
+// ------------------------------------------------------------------------------------------------
+/// Constructors
+impl LibraryNamespace {
     /// Construct a new [LibraryNamespace] from `source`
     pub fn new<S>(source: S) -> Result<Self, LibraryNamespaceError>
     where
@@ -84,36 +93,12 @@ impl LibraryNamespace {
             None => path.parse().map(|ns| (ns, "")),
         }
     }
+}
 
-    /// Get the string representation of this namespace
-    pub fn as_str(&self) -> &str {
-        match self {
-            Self::Kernel => Self::KERNEL_PATH,
-            Self::Exec => Self::EXEC_PATH,
-            Self::Anon => Self::ANON_PATH,
-            Self::User(ref path) => path,
-        }
-    }
-
-    /// Get an [`Arc<str>`] representing this namespace
-    pub fn as_refcounted_str(&self) -> Arc<str> {
-        match self {
-            Self::User(ref path) => path.clone(),
-            other => Arc::from(other.as_str().to_string().into_boxed_str()),
-        }
-    }
-
-    /// Create a [LibraryPath] representing this [LibraryNamespace]
-    pub fn to_path(&self) -> LibraryPath {
-        LibraryPath::from(self.clone())
-    }
-
-    /// Create an [Ident] representing this namespace
-    pub fn to_ident(&self) -> Ident {
-        Ident::new_unchecked(Span::unknown(self.as_refcounted_str()))
-    }
-
-    /// Returns true if this namespace is a reserved namespace
+// ------------------------------------------------------------------------------------------------
+/// Public accessors
+impl LibraryNamespace {
+    /// Returns true if this namespace is a reserved namespace.
     pub fn is_reserved(&self) -> bool {
         !matches!(self, Self::User(_))
     }
@@ -137,6 +122,38 @@ impl LibraryNamespace {
             return Err(LibraryNamespaceError::InvalidChars);
         }
         Ok(())
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+/// Conversions
+impl LibraryNamespace {
+    /// Get the string representation of this namespace.
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Kernel => Self::KERNEL_PATH,
+            Self::Exec => Self::EXEC_PATH,
+            Self::Anon => Self::ANON_PATH,
+            Self::User(ref path) => path,
+        }
+    }
+
+    /// Get an [`Arc<str>`] representing this namespace.
+    pub fn as_refcounted_str(&self) -> Arc<str> {
+        match self {
+            Self::User(ref path) => path.clone(),
+            other => Arc::from(other.as_str().to_string().into_boxed_str()),
+        }
+    }
+
+    /// Create a [LibraryPath] representing this [LibraryNamespace].
+    pub fn to_path(&self) -> LibraryPath {
+        LibraryPath::from(self.clone())
+    }
+
+    /// Create an [Ident] representing this namespace.
+    pub fn to_ident(&self) -> Ident {
+        Ident::new_unchecked(Span::unknown(self.as_refcounted_str()))
     }
 }
 
@@ -187,6 +204,9 @@ impl TryFrom<Ident> for LibraryNamespace {
         }
     }
 }
+
+// SERIALIZATION / DESERIALIZATION
+// ------------------------------------------------------------------------------------------------
 
 impl Serializable for LibraryNamespace {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {

--- a/assembly/src/library/tests.rs
+++ b/assembly/src/library/tests.rs
@@ -89,7 +89,7 @@ fn get_module_by_path() -> Result<(), Report> {
     let foo_module_info = bundle.module_infos().next().unwrap();
     assert_eq!(foo_module_info.path(), &LibraryPath::new("test::foo").unwrap());
 
-    let (_, foo_proc) = foo_module_info.procedure_infos().next().unwrap();
+    let (_, foo_proc) = foo_module_info.procedures().next().unwrap();
     assert_eq!(foo_proc.name, ProcedureName::new("foo").unwrap());
 
     Ok(())

--- a/assembly/src/library/tests.rs
+++ b/assembly/src/library/tests.rs
@@ -52,7 +52,7 @@ fn masl_locations_serialization() -> Result<(), Report> {
 
     let mut bytes = Vec::new();
     bundle.write_into_with_options(&mut bytes, AstSerdeOptions::new(true, true));
-    let deserialized = CompiledLibrary::read_from(&mut SliceReader::new(&bytes)).unwrap();
+    let deserialized = Library::read_from(&mut SliceReader::new(&bytes)).unwrap();
     assert_eq!(bundle, deserialized);
 
     // serialize/deserialize the bundle without locations
@@ -63,7 +63,7 @@ fn masl_locations_serialization() -> Result<(), Report> {
     // serialize/deserialize the bundle
     let mut bytes = Vec::new();
     bundle.write_into_with_options(&mut bytes, AstSerdeOptions::new(true, false));
-    let deserialized = CompiledLibrary::read_from(&mut SliceReader::new(&bytes)).unwrap();
+    let deserialized = Library::read_from(&mut SliceReader::new(&bytes)).unwrap();
     assert_eq!(bundle, deserialized);
 
     Ok(())

--- a/assembly/src/testing.rs
+++ b/assembly/src/testing.rs
@@ -316,7 +316,7 @@ impl TestContext {
     /// Add the modules of `library` to the [Assembler] constructed by this context.
     #[track_caller]
     pub fn add_library(&mut self, library: impl AsRef<CompiledLibrary>) -> Result<(), Report> {
-        self.assembler.add_compiled_library(library)
+        self.assembler.add_library(library)
     }
 
     /// Compile a [Program] from `source` using the [Assembler] constructed by this context.

--- a/assembly/src/testing.rs
+++ b/assembly/src/testing.rs
@@ -12,7 +12,7 @@ use crate::{
         reporting::{set_hook, ReportHandlerOpts},
         Report, SourceFile, SourceManager,
     },
-    library::CompiledLibrary,
+    library::Library,
     Compile, CompileOptions, LibraryPath, RpoDigest,
 };
 
@@ -315,7 +315,7 @@ impl TestContext {
 
     /// Add the modules of `library` to the [Assembler] constructed by this context.
     #[track_caller]
-    pub fn add_library(&mut self, library: impl AsRef<CompiledLibrary>) -> Result<(), Report> {
+    pub fn add_library(&mut self, library: impl AsRef<Library>) -> Result<(), Report> {
         self.assembler.add_library(library)
     }
 
@@ -328,7 +328,7 @@ impl TestContext {
         self.assembler.clone().assemble_program(source)
     }
 
-    /// Compile a [CompiledLibrary] from `modules` using the [Assembler] constructed by this
+    /// Compile a [Library] from `modules` using the [Assembler] constructed by this
     /// context.
     ///
     /// NOTE: Any modules added by, e.g. `add_module`, will be available to the library
@@ -336,7 +336,7 @@ impl TestContext {
     pub fn assemble_library(
         &self,
         modules: impl IntoIterator<Item = Box<Module>>,
-    ) -> Result<CompiledLibrary, Report> {
+    ) -> Result<Library, Report> {
         self.assembler.clone().assemble_library(modules)
     }
 

--- a/assembly/src/tests.rs
+++ b/assembly/src/tests.rs
@@ -2464,7 +2464,7 @@ fn test_compiled_library() {
     // Compile program that uses compiled library
     let mut assembler = Assembler::new(context.source_manager());
 
-    assembler.add_compiled_library(&compiled_library).unwrap();
+    assembler.add_library(&compiled_library).unwrap();
 
     let program_source = "
     use.mylib::mod1

--- a/miden/benches/program_compilation.rs
+++ b/miden/benches/program_compilation.rs
@@ -18,8 +18,7 @@ fn program_compilation(c: &mut Criterion) {
             end";
         bench.iter(|| {
             let mut assembler = Assembler::default();
-            assembler.add_compiled_library(&stdlib).expect("failed to load stdlib");
-
+            assembler.add_library(&stdlib).expect("failed to load stdlib");
             assembler.assemble_program(source).expect("Failed to compile test source.")
         });
     });

--- a/miden/benches/program_execution.rs
+++ b/miden/benches/program_execution.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use criterion::{criterion_group, criterion_main, Criterion};
 use miden_vm::{Assembler, DefaultHost, StackInputs};
-use processor::{execute, ExecutionOptions, Program};
+use processor::{execute, ExecutionOptions};
 use stdlib::StdLibrary;
 
 fn program_execution(c: &mut Criterion) {
@@ -21,9 +21,8 @@ fn program_execution(c: &mut Criterion) {
                 exec.sha256::hash_2to1
             end";
         let mut assembler = Assembler::default();
-        assembler.add_compiled_library(&stdlib).expect("failed to load stdlib");
-        let program: Program =
-            assembler.assemble_program(source).expect("Failed to compile test source.");
+        assembler.add_library(&stdlib).expect("failed to load stdlib");
+        let program = assembler.assemble_program(source).expect("Failed to compile test source.");
         bench.iter(|| {
             execute(&program, StackInputs::default(), host.clone(), ExecutionOptions::default())
         });

--- a/miden/src/cli/bundle.rs
+++ b/miden/src/cli/bundle.rs
@@ -3,7 +3,7 @@ use std::{path::PathBuf, sync::Arc};
 use assembly::{
     ast::AstSerdeOptions,
     diagnostics::{IntoDiagnostic, Report},
-    library::CompiledLibrary,
+    library::Library,
     LibraryNamespace, Version,
 };
 use clap::Parser;
@@ -46,14 +46,14 @@ impl BundleCmd {
             namespace.parse::<LibraryNamespace>().expect("invalid base namespace");
         // TODO: Add version to `Library`
         let _version = self.version.parse::<Version>().expect("invalid cargo version");
-        let stdlib = CompiledLibrary::from_dir(&self.dir, library_namespace, source_manager)?;
+        let stdlib = Library::from_dir(&self.dir, library_namespace, source_manager)?;
 
         // write the masl output
         let options = AstSerdeOptions::new(false, false);
         let output_file = self
             .dir
             .join(self.namespace.as_deref().unwrap_or("out"))
-            .with_extension(CompiledLibrary::LIBRARY_EXTENSION);
+            .with_extension(Library::LIBRARY_EXTENSION);
         stdlib.write_to_file(output_file, options).into_diagnostic()?;
 
         println!("Built library {}", namespace);

--- a/miden/src/cli/data.rs
+++ b/miden/src/cli/data.rs
@@ -9,7 +9,7 @@ use std::{
 use assembly::{
     ast::{Module, ModuleKind},
     diagnostics::{IntoDiagnostic, Report, WrapErr},
-    library::CompiledLibrary,
+    library::Library,
     Assembler, LibraryNamespace,
 };
 use miden_vm::{
@@ -424,7 +424,7 @@ impl ProgramFile {
     #[instrument(name = "compile_program", skip_all)]
     pub fn compile<'a, I>(&self, debug: &Debug, libraries: I) -> Result<Program, Report>
     where
-        I: IntoIterator<Item = &'a CompiledLibrary>,
+        I: IntoIterator<Item = &'a Library>,
     {
         // compile program
         let mut assembler =
@@ -545,7 +545,7 @@ impl ProgramHash {
 // LIBRARY FILE
 // ================================================================================================
 pub struct Libraries {
-    pub libraries: Vec<CompiledLibrary>,
+    pub libraries: Vec<Library>,
 }
 
 impl Libraries {
@@ -561,7 +561,7 @@ impl Libraries {
         for path in paths {
             // TODO(plafer): How to create a `Report` from an error that doesn't derive
             // `Diagnostic`?
-            let library = CompiledLibrary::deserialize_from_file(path).unwrap();
+            let library = Library::deserialize_from_file(path).unwrap();
             libraries.push(library);
         }
 

--- a/miden/src/cli/data.rs
+++ b/miden/src/cli/data.rs
@@ -429,12 +429,10 @@ impl ProgramFile {
         // compile program
         let mut assembler =
             Assembler::new(self.source_manager.clone()).with_debug_mode(debug.is_on());
-        assembler
-            .add_compiled_library(StdLibrary::default())
-            .wrap_err("Failed to load stdlib")?;
+        assembler.add_library(StdLibrary::default()).wrap_err("Failed to load stdlib")?;
 
         for library in libraries {
-            assembler.add_compiled_library(library).wrap_err("Failed to load libraries")?;
+            assembler.add_library(library).wrap_err("Failed to load libraries")?;
         }
 
         let program: Program = assembler

--- a/miden/src/examples/blake3.rs
+++ b/miden/src/examples/blake3.rs
@@ -46,7 +46,7 @@ fn generate_blake3_program(n: usize) -> Program {
     );
 
     Assembler::default()
-        .with_compiled_library(StdLibrary::default())
+        .with_library(StdLibrary::default())
         .unwrap()
         .assemble_program(program)
         .unwrap()

--- a/miden/src/repl/mod.rs
+++ b/miden/src/repl/mod.rs
@@ -1,6 +1,6 @@
 use std::{collections::BTreeSet, path::PathBuf};
 
-use assembly::{library::CompiledLibrary, Assembler};
+use assembly::{library::Library, Assembler};
 use miden_vm::{math::Felt, DefaultHost, StackInputs, Word};
 use processor::ContextId;
 use rustyline::{error::ReadlineError, DefaultEditor};
@@ -152,7 +152,7 @@ pub fn start_repl(library_paths: &Vec<PathBuf>, use_stdlib: bool) {
     // load libraries from files
     let mut provided_libraries = Vec::new();
     for path in library_paths {
-        let library = CompiledLibrary::deserialize_from_file(path)
+        let library = Library::deserialize_from_file(path)
             .map_err(|e| format!("Failed to read library: {e}"))
             .unwrap();
         provided_libraries.push(library);
@@ -304,7 +304,7 @@ pub fn start_repl(library_paths: &Vec<PathBuf>, use_stdlib: bool) {
 #[allow(clippy::type_complexity)]
 fn execute(
     program: String,
-    provided_libraries: &[CompiledLibrary],
+    provided_libraries: &[Library],
 ) -> Result<(Vec<(u64, Word)>, Vec<Felt>), String> {
     // compile program
     let mut assembler = Assembler::default();
@@ -361,7 +361,7 @@ fn read_mem_address(mem_str: &str) -> Result<u64, String> {
 /// all available modules if no module name was provided.
 fn handle_use_command(
     line: String,
-    provided_libraries: &[CompiledLibrary],
+    provided_libraries: &[Library],
     imported_modules: &mut BTreeSet<String>,
 ) {
     let tokens: Vec<&str> = line.split_whitespace().collect();

--- a/miden/src/repl/mod.rs
+++ b/miden/src/repl/mod.rs
@@ -310,7 +310,7 @@ fn execute(
     let mut assembler = Assembler::default();
 
     for library in provided_libraries {
-        assembler.add_compiled_library(library).map_err(|err| format!("{err}"))?;
+        assembler.add_library(library).map_err(|err| format!("{err}"))?;
     }
 
     let program = assembler.assemble_program(program).map_err(|err| format!("{err}"))?;

--- a/miden/src/tools/mod.rs
+++ b/miden/src/tools/mod.rs
@@ -217,7 +217,7 @@ where
     let stdlib = StdLibrary::default();
     let program = Assembler::default()
         .with_debug_mode(true)
-        .with_compiled_library(&stdlib)?
+        .with_library(&stdlib)?
         .assemble_program(program)?;
     let mut execution_details = ExecutionDetails::default();
 

--- a/miden/tests/integration/flow_control/mod.rs
+++ b/miden/tests/integration/flow_control/mod.rs
@@ -409,7 +409,7 @@ fn procref() -> Result<(), Report> {
         let mut parser = Module::parser(ModuleKind::Library);
         let module = parser.parse_str(module_path, module_source, &source_manager)?;
         let library = Assembler::new(source_manager)
-            .with_compiled_library(StdLibrary::default())
+            .with_library(StdLibrary::default())
             .unwrap()
             .assemble_library([module])
             .unwrap();

--- a/stdlib/build.rs
+++ b/stdlib/build.rs
@@ -3,7 +3,7 @@ use std::{env, path::Path, sync::Arc};
 use assembly::{
     ast::AstSerdeOptions,
     diagnostics::{IntoDiagnostic, Result},
-    library::CompiledLibrary,
+    library::Library,
     LibraryNamespace, Version,
 };
 
@@ -31,7 +31,7 @@ fn main() -> Result<()> {
     let namespace = "std".parse::<LibraryNamespace>().expect("invalid base namespace");
     // TODO: Add version to `Library`
     let _version = env!("CARGO_PKG_VERSION").parse::<Version>().expect("invalid cargo version");
-    let stdlib = CompiledLibrary::from_dir(asm_dir, namespace, source_manager)?;
+    let stdlib = Library::from_dir(asm_dir, namespace, source_manager)?;
 
     // write the masl output
     let build_dir = env::var("OUT_DIR").unwrap();
@@ -40,7 +40,7 @@ fn main() -> Result<()> {
     let output_file = build_dir
         .join(ASL_DIR_PATH)
         .join("std")
-        .with_extension(CompiledLibrary::LIBRARY_EXTENSION);
+        .with_extension(Library::LIBRARY_EXTENSION);
     stdlib.write_to_file(output_file, options).into_diagnostic()?;
 
     Ok(())

--- a/stdlib/src/lib.rs
+++ b/stdlib/src/lib.rs
@@ -42,7 +42,7 @@ mod tests {
         let stdlib = StdLibrary::default();
         let exists = stdlib.0.module_infos().any(|module| {
             module
-                .procedure_infos()
+                .procedures()
                 .any(|(_, proc)| module.path().clone().append(&proc.name).unwrap() == path)
         });
 

--- a/stdlib/src/lib.rs
+++ b/stdlib/src/lib.rs
@@ -2,21 +2,21 @@
 
 extern crate alloc;
 
-use assembly::{library::CompiledLibrary, utils::Deserializable};
+use assembly::{library::Library, utils::Deserializable};
 
 // STANDARD LIBRARY
 // ================================================================================================
 
 /// TODO: add docs
-pub struct StdLibrary(CompiledLibrary);
+pub struct StdLibrary(Library);
 
-impl AsRef<CompiledLibrary> for StdLibrary {
-    fn as_ref(&self) -> &CompiledLibrary {
+impl AsRef<Library> for StdLibrary {
+    fn as_ref(&self) -> &Library {
         &self.0
     }
 }
 
-impl From<StdLibrary> for CompiledLibrary {
+impl From<StdLibrary> for Library {
     fn from(value: StdLibrary) -> Self {
         value.0
     }
@@ -25,7 +25,7 @@ impl From<StdLibrary> for CompiledLibrary {
 impl Default for StdLibrary {
     fn default() -> Self {
         let bytes = include_bytes!(concat!(env!("OUT_DIR"), "/assets/std.masl"));
-        let contents = CompiledLibrary::read_from_bytes(bytes).expect("failed to read std masl!");
+        let contents = Library::read_from_bytes(bytes).expect("failed to read std masl!");
         Self(contents)
     }
 }

--- a/stdlib/tests/crypto/falcon.rs
+++ b/stdlib/tests/crypto/falcon.rs
@@ -200,7 +200,7 @@ fn falcon_prove_verify() {
     let (source, op_stack, _, _, advice_map) = generate_test(sk, message);
 
     let program: Program = Assembler::default()
-        .with_compiled_library(StdLibrary::default())
+        .with_library(StdLibrary::default())
         .expect("failed to load stdlib")
         .assemble_program(source)
         .expect("failed to compile test source");

--- a/stdlib/tests/mem/mod.rs
+++ b/stdlib/tests/mem/mod.rs
@@ -24,7 +24,7 @@ fn test_memcopy() {
 
     let stdlib = StdLibrary::default();
     let assembler = assembly::Assembler::default()
-        .with_compiled_library(&stdlib)
+        .with_library(&stdlib)
         .expect("failed to load stdlib");
 
     let program: Program =

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -311,7 +311,7 @@ impl Test {
             })
             .with_debug_mode(self.in_debug_mode);
         for library in &self.libraries {
-            assembler.add_compiled_library(library).unwrap();
+            assembler.add_library(library).unwrap();
         }
 
         Ok((assembler.assemble_program(self.source.clone())?, compiled_kernel))

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -16,7 +16,7 @@ use alloc::{
     vec::Vec,
 };
 
-use assembly::library::CompiledLibrary;
+use assembly::library::Library;
 // EXPORTS
 // ================================================================================================
 pub use assembly::{diagnostics::Report, LibraryPath, SourceFile, SourceManager};
@@ -175,7 +175,7 @@ pub struct Test {
     pub stack_inputs: StackInputs,
     pub advice_inputs: AdviceInputs,
     pub in_debug_mode: bool,
-    pub libraries: Vec<CompiledLibrary>,
+    pub libraries: Vec<Library>,
     pub add_modules: Vec<(LibraryPath, String)>,
 }
 


### PR DESCRIPTION
This PR performs minor cleanup of the `Assembler` API (though, I think we can clean things up a bit more). It consist of mostly renaming things and moving code around - but there should be no changes which affect the overall functionality or semantics.

The main changes are:
- Renamed `Assembler::add_compiled_library()` into `Assembler::add_library()`.
- Renamed `Assembler::with_compiled_library()` into `Assembler::with_library()`.
- Moved `ModuleInfo` and `ProcedureInfo` structs into a separate file and renamed some methods of `ModuleInfo`.
- Renamed `CompiledLibrary` into `Library`.
- Merged `LibraryError` with `CompiledLibraryError` and eliminated unused error variants.