### PR TITLE
Get program hash without iterating over entire trace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,19 +21,20 @@
 - Relaxed the parser to allow one branch of an `if.(true|false)` to be empty.
 - Optimized `std::sys::truncate_stuck` procedure (#1384).
 - Updated CI and Makefile to standardize it across Miden repositories (#1342).
-- Add serialization/deserialization for `MastForest` (#1370)
-- Updated CI to support `CHANGELOG.md` modification checking and `no changelog` label (#1406)
-- Introduced `MastForestError` to enforce `MastForest` node count invariant (#1394)
-- Added functions to `MastForestBuilder` to allow ensuring of nodes with fewer LOC (#1404)
+- Add serialization/deserialization for `MastForest` (#1370).
+- Updated CI to support `CHANGELOG.md` modification checking and `no changelog` label (#1406).
+- Introduced `MastForestError` to enforce `MastForest` node count invariant (#1394).
+- Added functions to `MastForestBuilder` to allow ensuring of nodes with fewer LOC (#1404).
 - [BREAKING] Made `Assembler` single-use (#1409).
 - Removed `ProcedureCache` from the assembler (#1411).
-- Added functions to `MastForest` and `MastForestBuilder` to add and ensure nodes with fewer LOC (#1404, #1412)
+- Added functions to `MastForest` and `MastForestBuilder` to add and ensure nodes with fewer LOC (#1404, #1412).
 - Added `Assembler::assemble_library()` and `Assembler::assemble_kernel()`  (#1413, #1418).
 - Added `miden_core::prettier::pretty_print_csv` helper, for formatting of iterators over `PrettyPrint` values as comma-separated items.
-- Added source code management primitives in `miden-core` (#1419)
+- Added source code management primitives in `miden-core` (#1419).
 - Added `make test-fast` and `make test-skip-proptests` Makefile targets for faster testing during local development.
 - Added `ProgramFile::read_with` constructor that takes a `SourceManager` impl to use for source management.
 - Added `RowIndex(u32)` (#1408).
+- Removed linear search of trace rows from `BlockHashTableRow::table_init()` (#1439).
 
 #### Changed
 

--- a/air/src/trace/main_trace.rs
+++ b/air/src/trace/main_trace.rs
@@ -35,7 +35,7 @@ const DECODER_HASHER_RANGE: Range<usize> =
 
 pub struct MainTrace {
     columns: ColMatrix<Felt>,
-    program_hash: Word,
+    last_program_row: RowIndex,
 }
 
 impl Deref for MainTrace {
@@ -47,16 +47,16 @@ impl Deref for MainTrace {
 }
 
 impl MainTrace {
-    pub fn new(main_trace: ColMatrix<Felt>, program_hash: Word) -> Self {
-        Self { columns: main_trace, program_hash }
+    pub fn new(main_trace: ColMatrix<Felt>, last_program_row: RowIndex) -> Self {
+        Self { columns: main_trace, last_program_row }
     }
 
     pub fn num_rows(&self) -> usize {
         self.columns.num_rows()
     }
 
-    pub fn program_hash(&self) -> Word {
-        self.program_hash
+    pub fn last_program_row(&self) -> RowIndex {
+        self.last_program_row
     }
 
     #[cfg(any(test, feature = "testing"))]

--- a/air/src/trace/main_trace.rs
+++ b/air/src/trace/main_trace.rs
@@ -35,6 +35,7 @@ const DECODER_HASHER_RANGE: Range<usize> =
 
 pub struct MainTrace {
     columns: ColMatrix<Felt>,
+    program_hash: Word,
 }
 
 impl Deref for MainTrace {
@@ -46,12 +47,16 @@ impl Deref for MainTrace {
 }
 
 impl MainTrace {
-    pub fn new(main_trace: ColMatrix<Felt>) -> Self {
-        Self { columns: main_trace }
+    pub fn new(main_trace: ColMatrix<Felt>, program_hash: Word) -> Self {
+        Self { columns: main_trace, program_hash }
     }
 
     pub fn num_rows(&self) -> usize {
         self.columns.num_rows()
+    }
+
+    pub fn program_hash(&self) -> Word {
+        self.program_hash
     }
 
     #[cfg(any(test, feature = "testing"))]

--- a/processor/src/decoder/aux_trace/block_hash_table.rs
+++ b/processor/src/decoder/aux_trace/block_hash_table.rs
@@ -5,6 +5,7 @@ use vm_core::{
 };
 
 use super::{AuxColumnBuilder, Felt, FieldElement, MainTrace, ONE};
+use crate::NUM_RAND_ROWS;
 
 // BLOCK HASH TABLE COLUMN BUILDER
 // ================================================================================================
@@ -88,14 +89,11 @@ impl BlockHashTableRow {
 
     // Computes the initial row in the block hash table.
     pub fn table_init(main_trace: &MainTrace) -> Self {
-        let program_hash = {
-            let row_with_halt = main_trace
-                .row_iter()
-                .find(|&row| main_trace.get_op_code(row) == Felt::from(OPCODE_HALT))
-                .expect("execution trace must include at least one occurrence of HALT");
-
-            main_trace.decoder_hasher_state_first_half(row_with_halt)
-        };
+        let last_row = main_trace
+            .row_iter()
+            .nth(main_trace.num_rows() - NUM_RAND_ROWS - 1)
+            .expect("trace must have more than NUM_RAND_ROWS rows");
+        let program_hash = main_trace.decoder_hasher_state_first_half(last_row);
 
         Self {
             parent_block_id: ZERO,

--- a/processor/src/decoder/aux_trace/block_hash_table.rs
+++ b/processor/src/decoder/aux_trace/block_hash_table.rs
@@ -5,7 +5,6 @@ use vm_core::{
 };
 
 use super::{AuxColumnBuilder, Felt, FieldElement, MainTrace, ONE};
-use crate::NUM_RAND_ROWS;
 
 // BLOCK HASH TABLE COLUMN BUILDER
 // ================================================================================================
@@ -26,7 +25,7 @@ pub struct BlockHashTableColumnBuilder {}
 
 impl<E: FieldElement<BaseField = Felt>> AuxColumnBuilder<E> for BlockHashTableColumnBuilder {
     fn init_responses(&self, main_trace: &MainTrace, alphas: &[E]) -> E {
-        BlockHashTableRow::table_init(main_trace).collapse(alphas)
+        BlockHashTableRow::table_init(main_trace.program_hash()).collapse(alphas)
     }
 
     /// Removes a row from the block hash table.
@@ -87,14 +86,8 @@ impl BlockHashTableRow {
     // CONSTRUCTORS
     // ----------------------------------------------------------------------------------------------
 
-    // Computes the initial row in the block hash table.
-    pub fn table_init(main_trace: &MainTrace) -> Self {
-        let last_row = main_trace
-            .row_iter()
-            .nth(main_trace.num_rows() - NUM_RAND_ROWS - 1)
-            .expect("trace must have more than NUM_RAND_ROWS rows");
-        let program_hash = main_trace.decoder_hasher_state_first_half(last_row);
-
+    // Instantiates the initial row in the block hash table.
+    pub fn table_init(program_hash: Word) -> Self {
         Self {
             parent_block_id: ZERO,
             child_block_hash: program_hash,

--- a/processor/src/decoder/aux_trace/block_hash_table.rs
+++ b/processor/src/decoder/aux_trace/block_hash_table.rs
@@ -25,7 +25,7 @@ pub struct BlockHashTableColumnBuilder {}
 
 impl<E: FieldElement<BaseField = Felt>> AuxColumnBuilder<E> for BlockHashTableColumnBuilder {
     fn init_responses(&self, main_trace: &MainTrace, alphas: &[E]) -> E {
-        BlockHashTableRow::table_init(main_trace.program_hash()).collapse(alphas)
+        BlockHashTableRow::table_init(main_trace).collapse(alphas)
     }
 
     /// Removes a row from the block hash table.
@@ -87,7 +87,9 @@ impl BlockHashTableRow {
     // ----------------------------------------------------------------------------------------------
 
     // Instantiates the initial row in the block hash table.
-    pub fn table_init(program_hash: Word) -> Self {
+    pub fn table_init(main_trace: &MainTrace) -> Self {
+        let program_hash =
+            main_trace.decoder_hasher_state_first_half(main_trace.last_program_row());
         Self {
             parent_block_id: ZERO,
             child_block_hash: program_hash,

--- a/processor/src/trace/mod.rs
+++ b/processor/src/trace/mod.rs
@@ -312,9 +312,6 @@ where
     let trace_len_summary =
         TraceLenSummary::new(clk.into(), range_table_len, ChipletsLengths::new(&chiplets));
 
-    // Extract the program hash before moving the decoder into a trace
-    let program_hash = decoder.program_hash();
-
     // Combine all trace segments into the main trace
     let system_trace = system.into_trace(trace_len, NUM_RAND_ROWS);
     let decoder_trace = decoder.into_trace(trace_len, NUM_RAND_ROWS);
@@ -346,7 +343,7 @@ where
         chiplets: chiplets_trace.aux_builder,
     };
 
-    let main_trace = MainTrace::new(ColMatrix::new(trace), program_hash);
+    let main_trace = MainTrace::new(ColMatrix::new(trace), clk);
 
     (main_trace, aux_trace_hints, trace_len_summary)
 }

--- a/processor/src/trace/mod.rs
+++ b/processor/src/trace/mod.rs
@@ -286,7 +286,7 @@ where
 
     let clk = system.clk();
 
-    // trace lengths of system and stack components must be equal to the number of executed cycles
+    // Trace lengths of system and stack components must be equal to the number of executed cycles
     assert_eq!(clk.as_usize(), system.trace_len(), "inconsistent system trace lengths");
     assert_eq!(clk.as_usize(), decoder.trace_len(), "inconsistent decoder trace length");
     assert_eq!(clk.as_usize(), stack.trace_len(), "inconsistent stack trace lengths");
@@ -300,25 +300,28 @@ where
     // Get the trace length required to hold all execution trace steps.
     let max_len = range_table_len.max(clk.into()).max(chiplets.trace_len());
 
-    // pad the trace length to the next power of two and ensure that there is space for the
-    // rows to hold random values
+    // Pad the trace length to the next power of two and ensure that there is space for the
+    // Rows to hold random values
     let trace_len = (max_len + NUM_RAND_ROWS).next_power_of_two();
     assert!(
         trace_len >= MIN_TRACE_LEN,
         "trace length must be at least {MIN_TRACE_LEN}, but was {trace_len}",
     );
 
-    // get the lengths of the traces: main, range, and chiplets
+    // Get the lengths of the traces: main, range, and chiplets
     let trace_len_summary =
         TraceLenSummary::new(clk.into(), range_table_len, ChipletsLengths::new(&chiplets));
 
-    // combine all trace segments into the main trace
+    // Extract the program hash before moving the decoder into a trace
+    let program_hash = decoder.program_hash();
+
+    // Combine all trace segments into the main trace
     let system_trace = system.into_trace(trace_len, NUM_RAND_ROWS);
     let decoder_trace = decoder.into_trace(trace_len, NUM_RAND_ROWS);
     let stack_trace = stack.into_trace(trace_len, NUM_RAND_ROWS);
     let chiplets_trace = chiplets.into_trace(trace_len, NUM_RAND_ROWS);
 
-    // combine the range trace segment using the support lookup table
+    // Combine the range trace segment using the support lookup table
     let range_check_trace = range.into_trace_with_table(range_table_len, trace_len, NUM_RAND_ROWS);
 
     let mut trace = system_trace
@@ -329,7 +332,7 @@ where
         .chain(chiplets_trace.trace)
         .collect::<Vec<_>>();
 
-    // inject random values into the last rows of the trace
+    // Inject random values into the last rows of the trace
     for i in trace_len - NUM_RAND_ROWS..trace_len {
         for column in trace.iter_mut() {
             column[i] = rng.draw().expect("failed to draw a random value");
@@ -343,7 +346,7 @@ where
         chiplets: chiplets_trace.aux_builder,
     };
 
-    let main_trace = MainTrace::new(ColMatrix::new(trace));
+    let main_trace = MainTrace::new(ColMatrix::new(trace), program_hash);
 
     (main_trace, aux_trace_hints, trace_len_summary)
 }


### PR DESCRIPTION
Closes #1344.

Small optimisation - instead of looping over the trace rows, go backwards based on known / expected row contents.