### PR TITLE
feat: expose pretty printing helper for mast nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+#### Enhancements
+
+- Exposed some pretty printing internals for `MastNode`
+- Made `KernelLibrary` impl `Clone` and `AsRef<Library>`
+
 ## 0.10.0 (2024-08-06)
 
 #### Features

--- a/assembly/src/library/mod.rs
+++ b/assembly/src/library/mod.rs
@@ -437,10 +437,18 @@ impl Export {
 /// - All exported procedures must be exported directly from the kernel namespace (i.e., `#sys`).
 /// - There must be at least one exported procedure.
 /// - The number of exported procedures cannot exceed [Kernel::MAX_NUM_PROCEDURES] (i.e., 256).
+#[derive(Clone)]
 pub struct KernelLibrary {
     kernel: Kernel,
     kernel_info: ModuleInfo,
     library: Library,
+}
+
+impl AsRef<Library> for KernelLibrary {
+    #[inline(always)]
+    fn as_ref(&self) -> &Library {
+        &self.library
+    }
 }
 
 impl KernelLibrary {

--- a/core/src/mast/node/mod.rs
+++ b/core/src/mast/node/mod.rs
@@ -113,10 +113,7 @@ impl MastNode {
         matches!(self, Self::Block(_))
     }
 
-    pub(crate) fn to_pretty_print<'a>(
-        &'a self,
-        mast_forest: &'a MastForest,
-    ) -> impl PrettyPrint + 'a {
+    pub fn to_pretty_print<'a>(&'a self, mast_forest: &'a MastForest) -> impl PrettyPrint + 'a {
         match self {
             MastNode::Block(basic_block_node) => {
                 MastNodePrettyPrint::new(Box::new(basic_block_node))


### PR DESCRIPTION
This PR exposes `MastNode::to_pretty_print`, which is too useful to keep internal to the crate, and without it, there is effectively no way to emit the textual MAST for specific nodes, such as in debug output. Strangely, `Program` itself implements `PrettyPrint`, but `Library` does not (and we would want to take advantage of the additional metadata in `Library` to `PrettyPrint` it differently anyway). The compiler use cases I have could probably be solved for by implementing pretty printers for `Library` and `ProcedureInfo` as MAST, with accompanying path/digest information, but I think there is value in exposing the pretty printer for `MastNode` directly anyway, since there may still be use cases where that is handy.

We should probably aim to make things like this public unless we have a good reason not to, because in many cases, if it was useful to us inside the crate, it will be useful for downstream users of the crate as well (especially the compiler).

I'm going to pin the compiler to the tip of this branch (and `next`, once merged) until we can make a release to crates.io that contains it, since it is used in debugging efforts at the moment.

