### PR TITLE
Only register local procedures in the MAST forest store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 - Added `new_unsafe()` constructors to MAST node types which do not compute node hashes (#1453).
 - Consolidated `BasicBlockNode` constructors and converted assert flow to `MastForestError::EmptyBasicBlock` (#1453).
 
+#### Fixes
+
+- Fixed an issue with registering non-local procedures in `MemMastForestStore` (#1462).
+
 ## 0.10.4 (2024-08-15) - `miden-processor` crate only
 
 #### Enhancements

--- a/core/src/mast/mod.rs
+++ b/core/src/mast/mod.rs
@@ -304,14 +304,14 @@ impl MastForest {
 
     /// Returns an iterator over the digests of local procedures in this MAST forest.
     ///
-    /// A local procedure is defined as a procedure which is not a single external or dyn node.
+    /// A local procedure is defined as a procedure which is not a single external node.
     pub fn local_procedure_digests(&self) -> impl Iterator<Item = RpoDigest> + '_ {
         self.roots.iter().filter_map(|&root_id| {
             let node = &self[root_id];
-            if node.is_local() {
-                Some(node.digest())
-            } else {
+            if node.is_external() {
                 None
+            } else {
+                Some(node.digest())
             }
         })
     }

--- a/core/src/mast/mod.rs
+++ b/core/src/mast/mod.rs
@@ -297,9 +297,23 @@ impl MastForest {
         self.roots.contains(&node_id)
     }
 
-    /// Returns an iterator over the digest of the procedures in this MAST forest.
+    /// Returns an iterator over the digests of all procedures in this MAST forest.
     pub fn procedure_digests(&self) -> impl Iterator<Item = RpoDigest> + '_ {
         self.roots.iter().map(|&root_id| self[root_id].digest())
+    }
+
+    /// Returns an iterator over the digests of local procedures in this MAST forest.
+    ///
+    /// A local procedure is defined as a procedure which is not a single external or dyn node.
+    pub fn local_procedure_digests(&self) -> impl Iterator<Item = RpoDigest> + '_ {
+        self.roots.iter().filter_map(|&root_id| {
+            let node = &self[root_id];
+            if node.is_local() {
+                Some(node.digest())
+            } else {
+                None
+            }
+        })
     }
 
     /// Returns an iterator over the IDs of the procedures in this MAST forest.

--- a/core/src/mast/node/mod.rs
+++ b/core/src/mast/node/mod.rs
@@ -106,9 +106,14 @@ impl MastNode {
 // ------------------------------------------------------------------------------------------------
 /// Public accessors
 impl MastNode {
-    /// Returns true if this node is a local node (i.e., not an External or Dyn node).
-    pub fn is_local(&self) -> bool {
-        !matches!(self, MastNode::External(_) | MastNode::Dyn)
+    /// Returns true if this node is an external node.
+    pub fn is_external(&self) -> bool {
+        matches!(self, MastNode::External(_))
+    }
+
+    /// Returns true if this node is a Dyn node.
+    pub fn is_dyn(&self) -> bool {
+        matches!(self, MastNode::Dyn)
     }
 
     /// Returns true if this node is a basic block.

--- a/core/src/mast/node/mod.rs
+++ b/core/src/mast/node/mod.rs
@@ -106,6 +106,12 @@ impl MastNode {
 // ------------------------------------------------------------------------------------------------
 /// Public accessors
 impl MastNode {
+    /// Returns true if this node is a local node (i.e., not an External or Dyn node).
+    pub fn is_local(&self) -> bool {
+        !matches!(self, MastNode::External(_) | MastNode::Dyn)
+    }
+
+    /// Returns true if this node is a basic block.
     pub fn is_basic_block(&self) -> bool {
         matches!(self, Self::Block(_))
     }

--- a/processor/src/host/mast_forest_store.rs
+++ b/processor/src/host/mast_forest_store.rs
@@ -26,7 +26,8 @@ impl MemMastForestStore {
     pub fn insert(&mut self, mast_forest: MastForest) {
         let mast_forest = Arc::new(mast_forest);
 
-        for proc_digest in mast_forest.procedure_digests() {
+        // only register the procedures which are local to this forest
+        for proc_digest in mast_forest.local_procedure_digests() {
             self.mast_forests.insert(proc_digest, mast_forest.clone());
         }
     }


### PR DESCRIPTION
This PR fixes an issue when having a procedure in the `MastForest` which is defined by a single `Export` node can lead to an infinite recursion in the `MemMastForestStore`. 

The fix is that instead of registering all procedures from a `MastForest` with `MastForestStore`, we register only the procedures local to that `MastForest` (i.e., excluding procedures which consist of a single `Export` or `Dyn` node).
