### PR TITLE
fix: detect circular external nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 #### Fixes
 
 - Fixed an issue with registering non-local procedures in `MemMastForestStore` (#1462).
+- Added a check for circular external node lookups in the processor (#1464).
 
 ## 0.10.4 (2024-08-15) - `miden-processor` crate only
 

--- a/processor/src/errors.rs
+++ b/processor/src/errors.rs
@@ -21,6 +21,7 @@ pub enum ExecutionError {
     AdviceMapKeyNotFound(Word),
     AdviceStackReadFailed(RowIndex),
     CallerNotInSyscall,
+    CircularExternalNode(Digest),
     CycleLimitExceeded(u32),
     DivideByZero(RowIndex),
     DynamicNodeNotFound(Digest),
@@ -90,6 +91,9 @@ impl Display for ExecutionError {
             AdviceStackReadFailed(step) => write!(f, "Advice stack read failed at step {step}"),
             CallerNotInSyscall => {
                 write!(f, "Instruction `caller` used outside of kernel context")
+            },
+            CircularExternalNode(mast_root) => {
+                write!(f, "External node with root {mast_root} resolved to an external node")
             },
             CycleLimitExceeded(max_cycles) => {
                 write!(f, "Exceeded the allowed number of cycles (max cycles = {max_cycles})")


### PR DESCRIPTION
This PR adds a small check to make sure looking up external nodes during execution does not result in a infinite loop.