### PR TITLE
Wrap MastForest in Program and Library in Arc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.11.0 (TBD)
+
+#### Changes
+
+- [BREAKING] Wrapped `MastForest`s in `Program` and `Library` structs in `Arc` (#1465).
+
+
 ## 0.10.5 (2024-08-21)
 
 #### Enhancements

--- a/assembly/src/assembler/instruction/procedures.rs
+++ b/assembly/src/assembler/instruction/procedures.rs
@@ -71,9 +71,9 @@ impl Assembler {
                             })
                         }
                     })?;
-                proc_ctx.register_external_call(&proc, false)?;
+                proc_ctx.register_external_call(proc, false)?;
             },
-            Some(proc) => proc_ctx.register_external_call(&proc, false)?,
+            Some(proc) => proc_ctx.register_external_call(proc, false)?,
             None => (),
         }
 
@@ -169,7 +169,7 @@ impl Assembler {
         // with the referenced procedure later
 
         if let Some(proc) = mast_forest_builder.find_procedure(&mast_root) {
-            proc_ctx.register_external_call(&proc, false)?;
+            proc_ctx.register_external_call(proc, false)?;
         }
 
         // Create an array with `Push` operations containing root elements

--- a/assembly/src/assembler/mod.rs
+++ b/assembly/src/assembler/mod.rs
@@ -379,18 +379,16 @@ impl Assembler {
         // Compile the module graph rooted at the entrypoint
         let mut mast_forest_builder = MastForestBuilder::default();
         self.compile_subgraph(entrypoint, &mut mast_forest_builder)?;
-        let entry_procedure = mast_forest_builder
+        let entry_node_id = mast_forest_builder
             .get_procedure(entrypoint)
-            .expect("compilation succeeded but root not found in cache");
+            .expect("compilation succeeded but root not found in cache")
+            .body_node_id();
 
+        // in case the node IDs changed, update the entrypoint ID to the new value
         let (mast_forest, id_remappings) = mast_forest_builder.build();
-        let entry_node_id = {
-            let old_entry_node_id = entry_procedure.body_node_id();
-
-            id_remappings
-                .map(|id_remappings| id_remappings[&old_entry_node_id])
-                .unwrap_or(old_entry_node_id)
-        };
+        let entry_node_id = id_remappings
+            .map(|id_remappings| id_remappings[&entry_node_id])
+            .unwrap_or(entry_node_id);
 
         Ok(Program::with_kernel(
             mast_forest.into(),

--- a/assembly/src/assembler/mod.rs
+++ b/assembly/src/assembler/mod.rs
@@ -301,7 +301,7 @@ impl Assembler {
 
         // TODO: show a warning if library exports are empty?
         let (mast_forest, _) = mast_forest_builder.build();
-        Ok(Library::new(mast_forest.into(), exports))
+        Ok(Library::new(mast_forest.into(), exports)?)
     }
 
     /// Assembles the provided module into a [KernelLibrary] intended to be used as a Kernel.
@@ -343,7 +343,7 @@ impl Assembler {
         // TODO: show a warning if library exports are empty?
 
         let (mast_forest, _) = mast_forest_builder.build();
-        let library = Library::new(mast_forest.into(), exports);
+        let library = Library::new(mast_forest.into(), exports)?;
         Ok(library.try_into()?)
     }
 

--- a/assembly/src/assembler/mod.rs
+++ b/assembly/src/assembler/mod.rs
@@ -301,7 +301,7 @@ impl Assembler {
 
         // TODO: show a warning if library exports are empty?
         let (mast_forest, _) = mast_forest_builder.build();
-        Ok(Library::new(mast_forest, exports))
+        Ok(Library::new(mast_forest.into(), exports))
     }
 
     /// Assembles the provided module into a [KernelLibrary] intended to be used as a Kernel.
@@ -343,7 +343,7 @@ impl Assembler {
         // TODO: show a warning if library exports are empty?
 
         let (mast_forest, _) = mast_forest_builder.build();
-        let library = Library::new(mast_forest, exports);
+        let library = Library::new(mast_forest.into(), exports);
         Ok(library.try_into()?)
     }
 
@@ -393,7 +393,7 @@ impl Assembler {
         };
 
         Ok(Program::with_kernel(
-            mast_forest,
+            mast_forest.into(),
             entry_node_id,
             self.module_graph.kernel().clone(),
         ))

--- a/assembly/src/assembler/procedure.rs
+++ b/assembly/src/assembler/procedure.rs
@@ -129,7 +129,9 @@ impl ProcedureContext {
     ///
     /// The passed-in `mast_root` defines the MAST root of the procedure's body while
     /// `mast_node_id` specifies the ID of the procedure's body node in the MAST forest in
-    /// which the procedure is defined.
+    /// which the procedure is defined. Note that if the procedure is re-exported (i.e., the body
+    /// of the procedure is defined in some other MAST forest) `mast_node_id` will point to a
+    /// single `External` node.
     ///
     /// <div class="warning">
     /// `mast_root` and `mast_node_id` must be consistent. That is, the node located in the MAST

--- a/assembly/src/assembler/tests.rs
+++ b/assembly/src/assembler/tests.rs
@@ -142,7 +142,8 @@ fn nested_blocks() -> Result<(), Report> {
         .join_nodes(vec![before, r#if1, nested, exec_foo_bar_baz_node_id, syscall_foo_node_id])
         .unwrap();
 
-    let expected_program = Program::new(expected_mast_forest_builder.build().0, combined_node_id);
+    let expected_program =
+        Program::new(expected_mast_forest_builder.build().0.into(), combined_node_id);
     assert_eq!(expected_program.hash(), program.hash());
 
     // also check that the program has the right number of procedures (which excludes the dummy
@@ -214,7 +215,7 @@ fn duplicate_nodes() {
 
     expected_mast_forest.make_root(root_id);
 
-    let expected_program = Program::new(expected_mast_forest, root_id);
+    let expected_program = Program::new(expected_mast_forest.into(), root_id);
 
     assert_eq!(program, expected_program);
 }

--- a/assembly/src/assembler/tests.rs
+++ b/assembly/src/assembler/tests.rs
@@ -142,8 +142,9 @@ fn nested_blocks() -> Result<(), Report> {
         .join_nodes(vec![before, r#if1, nested, exec_foo_bar_baz_node_id, syscall_foo_node_id])
         .unwrap();
 
-    let expected_program =
-        Program::new(expected_mast_forest_builder.build().0.into(), combined_node_id);
+    let mut expected_mast_forest = expected_mast_forest_builder.build().0;
+    expected_mast_forest.make_root(combined_node_id);
+    let expected_program = Program::new(expected_mast_forest.into(), combined_node_id);
     assert_eq!(expected_program.hash(), program.hash());
 
     // also check that the program has the right number of procedures (which excludes the dummy

--- a/assembly/src/library/error.rs
+++ b/assembly/src/library/error.rs
@@ -11,4 +11,6 @@ pub enum LibraryError {
     InvalidKernelExport { procedure_path: QualifiedProcedureName },
     #[error(transparent)]
     Kernel(#[from] KernelError),
+    #[error("invalid export: no procedure root for {procedure_path} procedure")]
+    NoProcedureRootForExport { procedure_path: QualifiedProcedureName },
 }

--- a/assembly/src/library/mod.rs
+++ b/assembly/src/library/mod.rs
@@ -126,9 +126,9 @@ impl Library {
             .unwrap_or(false)
     }
 
-    /// Returns the inner [`MastForest`].
-    pub fn mast_forest(&self) -> Arc<MastForest> {
-        self.mast_forest.clone()
+    /// Returns a reference to the inner [`MastForest`].
+    pub fn mast_forest(&self) -> &Arc<MastForest> {
+        &self.mast_forest
     }
 }
 
@@ -334,8 +334,8 @@ impl KernelLibrary {
         &self.kernel
     }
 
-    /// Returns the inner [`MastForest`].
-    pub fn mast_forest(&self) -> Arc<MastForest> {
+    /// Returns a reference to the inner [`MastForest`].
+    pub fn mast_forest(&self) -> &Arc<MastForest> {
         self.library.mast_forest()
     }
 

--- a/assembly/src/library/mod.rs
+++ b/assembly/src/library/mod.rs
@@ -105,6 +105,11 @@ impl Library {
         self.exports.keys()
     }
 
+    /// Returns the number of exports in this library.
+    pub fn num_exports(&self) -> usize {
+        self.exports.len()
+    }
+
     /// Returns a MAST node ID associated with the specified exported procedure.
     ///
     /// # Panics

--- a/assembly/src/library/module.rs
+++ b/assembly/src/library/module.rs
@@ -9,7 +9,7 @@ use crate::{
 // MODULE INFO
 // ================================================================================================
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ModuleInfo {
     path: LibraryPath,
     procedures: Vec<ProcedureInfo>,
@@ -68,7 +68,7 @@ impl ModuleInfo {
 }
 
 /// Stores the name and digest of a procedure.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ProcedureInfo {
     pub name: ProcedureName,
     pub digest: RpoDigest,

--- a/assembly/src/library/tests.rs
+++ b/assembly/src/library/tests.rs
@@ -1,6 +1,5 @@
-use alloc::{string::ToString, vec::Vec};
-
-use vm_core::utils::SliceReader;
+use alloc::string::ToString;
+use core::str::FromStr;
 
 use super::*;
 use crate::{
@@ -17,6 +16,101 @@ macro_rules! parse_module {
             $context.source_manager().load(concat!("test", line!()), $source.to_string());
         Module::parse(path, ModuleKind::Library, source_file)?
     }};
+}
+
+#[test]
+fn library_exports() -> Result<(), Report> {
+    let context = TestContext::new();
+
+    // build the first library
+    let baz = r#"
+        export.baz1
+            push.7 push.8 sub
+        end
+    "#;
+    let baz = parse_module!(&context, "lib1::baz", baz);
+
+    let lib1 = Assembler::new(context.source_manager()).assemble_library([baz])?;
+
+    // build the second library
+    let foo = r#"
+        proc.foo1
+            push.1 add
+        end
+
+        export.foo2
+            push.2 add
+            exec.foo1
+        end
+
+        export.foo3
+            push.3 mul
+            exec.foo1
+            exec.foo2
+        end
+    "#;
+    let foo = parse_module!(&context, "lib2::foo", foo);
+
+    // declare bar module
+    let bar = r#"
+        use.lib1::baz
+        use.lib2::foo
+
+        export.baz::baz1->bar1
+
+        export.foo::foo2->bar2
+
+        export.bar3
+            exec.foo::foo2
+        end
+
+        proc.bar4
+            push.1 push.2 mul
+        end
+
+        export.bar5
+            push.3 sub
+            exec.foo::foo2
+            exec.bar1
+            exec.bar2
+            exec.bar4
+        end
+    "#;
+    let bar = parse_module!(&context, "lib2::bar", bar);
+    let modules = [foo, bar];
+
+    let lib2 = Assembler::new(context.source_manager())
+        .with_library(lib1)?
+        .assemble_library(modules.iter().cloned())?;
+
+    let foo2 = QualifiedProcedureName::from_str("lib2::foo::foo2").unwrap();
+    let foo3 = QualifiedProcedureName::from_str("lib2::foo::foo3").unwrap();
+    let bar1 = QualifiedProcedureName::from_str("lib2::bar::bar1").unwrap();
+    let bar2 = QualifiedProcedureName::from_str("lib2::bar::bar2").unwrap();
+    let bar3 = QualifiedProcedureName::from_str("lib2::bar::bar3").unwrap();
+    let bar5 = QualifiedProcedureName::from_str("lib2::bar::bar5").unwrap();
+
+    // make sure the library exports all exported procedures
+    let expected_exports: BTreeSet<_> = [&foo2, &foo3, &bar1, &bar2, &bar3, &bar5].into();
+    let actual_exports: BTreeSet<_> = lib2.exports().collect();
+    assert_eq!(expected_exports, actual_exports);
+
+    // make sure foo2, bar2, and bar3 map to the same MastNode
+    assert_eq!(lib2.get_export_node_id(&foo2), lib2.get_export_node_id(&bar2));
+    assert_eq!(lib2.get_export_node_id(&foo2), lib2.get_export_node_id(&bar3));
+
+    // make sure there are 6 roots in the MAST (foo1, foo2, foo3, bar1, bar4, and bar5)
+    assert_eq!(lib2.mast_forest.num_procedures(), 6);
+
+    // bar1 should be the only re-export
+    assert!(!lib2.is_reexport(&foo2));
+    assert!(!lib2.is_reexport(&foo3));
+    assert!(lib2.is_reexport(&bar1));
+    assert!(!lib2.is_reexport(&bar2));
+    assert!(!lib2.is_reexport(&bar3));
+    assert!(!lib2.is_reexport(&bar5));
+
+    Ok(())
 }
 
 #[test]
@@ -46,13 +140,11 @@ fn library_serialization() -> Result<(), Report> {
     let modules = [foo, bar];
 
     // serialize/deserialize the bundle with locations
-    let bundle = Assembler::new(context.source_manager())
-        .assemble_library(modules.iter().cloned())
-        .unwrap();
+    let bundle =
+        Assembler::new(context.source_manager()).assemble_library(modules.iter().cloned())?;
 
-    let mut bytes = Vec::new();
-    bundle.write_into(&mut bytes);
-    let deserialized = Library::read_from(&mut SliceReader::new(&bytes)).unwrap();
+    let bytes = bundle.to_bytes();
+    let deserialized = Library::read_from_bytes(&bytes).unwrap();
     assert_eq!(bundle, deserialized);
 
     Ok(())

--- a/core/src/mast/mod.rs
+++ b/core/src/mast/mod.rs
@@ -125,6 +125,8 @@ impl MastForest {
 
     /// Marks the given [`MastNodeId`] as being the root of a procedure.
     ///
+    /// If the specified node is already marked as a root, this has no effect.
+    ///
     /// # Panics
     /// - if `new_root_id`'s internal index is larger than the number of nodes in this forest (i.e.
     ///   clearly doesn't belong to this MAST forest).

--- a/core/src/mast/mod.rs
+++ b/core/src/mast/mod.rs
@@ -125,7 +125,7 @@ impl MastForest {
 
     /// Marks the given [`MastNodeId`] as being the root of a procedure.
     ///
-    /// If the specified node is already marked as a root, this has no effect.
+    /// If the specified node is already marked as a root, this will have no effect.
     ///
     /// # Panics
     /// - if `new_root_id`'s internal index is larger than the number of nodes in this forest (i.e.

--- a/core/src/program.rs
+++ b/core/src/program.rs
@@ -70,9 +70,9 @@ impl Program {
         self.entrypoint
     }
 
-    /// Returns the underlying [`MastForest`].
-    pub fn mast_forest(&self) -> Arc<MastForest> {
-        self.mast_forest.clone()
+    /// Returns a reference to the underlying [`MastForest`].
+    pub fn mast_forest(&self) -> &Arc<MastForest> {
+        &self.mast_forest
     }
 
     /// Returns the kernel associated with this program.

--- a/core/src/program.rs
+++ b/core/src/program.rs
@@ -1,5 +1,5 @@
-use alloc::vec::Vec;
-use core::{fmt, ops::Index};
+use alloc::{sync::Arc, vec::Vec};
+use core::fmt;
 
 use miden_crypto::{hash::rpo::RpoDigest, Felt, WORD_SIZE};
 use winter_utils::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable};
@@ -13,9 +13,14 @@ use crate::{
 // PROGRAM
 // ===============================================================================================
 
+/// An executable program for Miden VM.
+///
+/// A program consists of a MAST forest, an entrypoint defining the MAST node at which the program
+/// execution begins, and a definition of the kernel against which the program must be executed
+/// (the kernel can be an empty kernel).
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Program {
-    mast_forest: MastForest,
+    mast_forest: Arc<MastForest>,
     /// The "entrypoint" is the node where execution of the program begins.
     entrypoint: MastNodeId,
     kernel: Kernel,
@@ -27,8 +32,8 @@ impl Program {
     /// to be empty.
     ///
     /// # Panics:
-    /// - if `mast_forest` doesn't have an entrypoint
-    pub fn new(mast_forest: MastForest, entrypoint: MastNodeId) -> Self {
+    /// - if `mast_forest` doesn't contain the specified entrypoint.
+    pub fn new(mast_forest: Arc<MastForest>, entrypoint: MastNodeId) -> Self {
         assert!(mast_forest.get_node_by_id(entrypoint).is_some());
 
         Self {
@@ -41,19 +46,24 @@ impl Program {
     /// Construct a new [`Program`] from the given MAST forest, entrypoint, and kernel.
     ///
     /// # Panics:
-    /// - if `mast_forest` doesn't have an entrypoint
-    pub fn with_kernel(mast_forest: MastForest, entrypoint: MastNodeId, kernel: Kernel) -> Self {
+    /// - if `mast_forest` doesn't contain the specified entrypoint.
+    pub fn with_kernel(
+        mast_forest: Arc<MastForest>,
+        entrypoint: MastNodeId,
+        kernel: Kernel,
+    ) -> Self {
         assert!(mast_forest.get_node_by_id(entrypoint).is_some());
 
         Self { mast_forest, entrypoint, kernel }
     }
 }
 
+// ------------------------------------------------------------------------------------------------
 /// Public accessors
 impl Program {
     /// Returns the underlying [`MastForest`].
-    pub fn mast_forest(&self) -> &MastForest {
-        &self.mast_forest
+    pub fn mast_forest(&self) -> Arc<MastForest> {
+        self.mast_forest.clone()
     }
 
     /// Returns the kernel associated with this program.
@@ -76,7 +86,7 @@ impl Program {
     /// Returns the [`MastNode`] associated with the provided [`MastNodeId`] if valid, or else
     /// `None`.
     ///
-    /// This is the faillible version of indexing (e.g. `program[node_id]`).
+    /// This is the fallible version of indexing (e.g. `program[node_id]`).
     #[inline(always)]
     pub fn get_node_by_id(&self, node_id: MastNodeId) -> Option<&MastNode> {
         self.mast_forest.get_node_by_id(node_id)
@@ -94,10 +104,11 @@ impl Program {
     }
 }
 
+// ------------------------------------------------------------------------------------------------
 /// Serialization
+#[cfg(feature = "std")]
 impl Program {
     /// Writes this [Program] to the provided file path.
-    #[cfg(feature = "std")]
     pub fn write_to_file<P>(&self, path: P) -> std::io::Result<()>
     where
         P: AsRef<std::path::Path>,
@@ -139,26 +150,21 @@ impl Serializable for Program {
 
 impl Deserializable for Program {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
-        let mast_forest = source.read()?;
+        let mast_forest = Arc::new(source.read()?);
         let kernel = source.read()?;
         let entrypoint = MastNodeId::from_u32_safe(source.read_u32()?, &mast_forest)?;
 
-        Ok(Self { mast_forest, kernel, entrypoint })
+        Ok(Self::with_kernel(mast_forest, entrypoint, kernel))
     }
 }
 
-impl Index<MastNodeId> for Program {
-    type Output = MastNode;
-
-    fn index(&self, node_id: MastNodeId) -> &Self::Output {
-        &self.mast_forest[node_id]
-    }
-}
+// ------------------------------------------------------------------------------------------------
+// Pretty-printing
 
 impl crate::prettier::PrettyPrint for Program {
     fn render(&self) -> crate::prettier::Document {
         use crate::prettier::*;
-        let entrypoint = self[self.entrypoint()].to_pretty_print(&self.mast_forest);
+        let entrypoint = self.mast_forest[self.entrypoint()].to_pretty_print(&self.mast_forest);
 
         indent(4, const_text("begin") + nl() + entrypoint.render()) + nl() + const_text("end")
     }
@@ -168,12 +174,6 @@ impl fmt::Display for Program {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use crate::prettier::PrettyPrint;
         self.pretty_print(f)
-    }
-}
-
-impl From<Program> for MastForest {
-    fn from(program: Program) -> Self {
-        program.mast_forest
     }
 }
 
@@ -195,16 +195,10 @@ pub struct ProgramInfo {
 }
 
 impl ProgramInfo {
-    // CONSTRUCTORS
-    // --------------------------------------------------------------------------------------------
-
     /// Creates a new instance of a program info.
     pub const fn new(program_hash: RpoDigest, kernel: Kernel) -> Self {
         Self { program_hash, kernel }
     }
-
-    // PUBLIC ACCESSORS
-    // --------------------------------------------------------------------------------------------
 
     /// Returns the program hash computed from its code block root.
     pub const fn program_hash(&self) -> &RpoDigest {
@@ -231,8 +225,8 @@ impl From<Program> for ProgramInfo {
     }
 }
 
-// SERIALIZATION
 // ------------------------------------------------------------------------------------------------
+// Serialization
 
 impl Serializable for ProgramInfo {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
@@ -249,8 +243,8 @@ impl Deserializable for ProgramInfo {
     }
 }
 
-// TO ELEMENTS
 // ------------------------------------------------------------------------------------------------
+// ToElements implementation
 
 impl ToElements for ProgramInfo {
     fn to_elements(&self) -> Vec<Felt> {

--- a/miden/src/examples/blake3.rs
+++ b/miden/src/examples/blake3.rs
@@ -22,7 +22,7 @@ pub fn get_example(n: usize) -> Example<DefaultHost<MemAdviceProvider>> {
     );
 
     let mut host = DefaultHost::default();
-    host.load_mast_forest(StdLibrary::default().into());
+    host.load_mast_forest(StdLibrary::default().mast_forest());
 
     let stack_inputs =
         StackInputs::try_from_ints(INITIAL_HASH_VALUE.iter().map(|&v| v as u64)).unwrap();

--- a/miden/src/examples/blake3.rs
+++ b/miden/src/examples/blake3.rs
@@ -22,7 +22,7 @@ pub fn get_example(n: usize) -> Example<DefaultHost<MemAdviceProvider>> {
     );
 
     let mut host = DefaultHost::default();
-    host.load_mast_forest(StdLibrary::default().mast_forest());
+    host.load_mast_forest(StdLibrary::default().mast_forest().clone());
 
     let stack_inputs =
         StackInputs::try_from_ints(INITIAL_HASH_VALUE.iter().map(|&v| v as u64)).unwrap();

--- a/miden/src/tools/mod.rs
+++ b/miden/src/tools/mod.rs
@@ -38,7 +38,7 @@ impl Analyze {
         // fetch the stack and program inputs from the arguments
         let stack_inputs = input_data.parse_stack_inputs().map_err(Report::msg)?;
         let mut host = DefaultHost::new(input_data.parse_advice_provider().map_err(Report::msg)?);
-        host.load_mast_forest(StdLibrary::default().mast_forest());
+        host.load_mast_forest(StdLibrary::default().mast_forest().clone());
 
         let execution_details: ExecutionDetails = analyze(program.as_str(), stack_inputs, host)
             .expect("Could not retrieve execution details");

--- a/miden/src/tools/mod.rs
+++ b/miden/src/tools/mod.rs
@@ -38,7 +38,7 @@ impl Analyze {
         // fetch the stack and program inputs from the arguments
         let stack_inputs = input_data.parse_stack_inputs().map_err(Report::msg)?;
         let mut host = DefaultHost::new(input_data.parse_advice_provider().map_err(Report::msg)?);
-        host.load_mast_forest(StdLibrary::default().into());
+        host.load_mast_forest(StdLibrary::default().mast_forest());
 
         let execution_details: ExecutionDetails = analyze(program.as_str(), stack_inputs, host)
             .expect("Could not retrieve execution details");

--- a/processor/src/chiplets/tests.rs
+++ b/processor/src/chiplets/tests.rs
@@ -120,7 +120,7 @@ fn build_trace(
 
         let basic_block_id = mast_forest.add_block(operations, None).unwrap();
 
-        Program::new(mast_forest, basic_block_id)
+        Program::new(mast_forest.into(), basic_block_id)
     };
     process.execute(&program).unwrap();
 

--- a/processor/src/chiplets/tests.rs
+++ b/processor/src/chiplets/tests.rs
@@ -119,6 +119,7 @@ fn build_trace(
         let mut mast_forest = MastForest::new();
 
         let basic_block_id = mast_forest.add_block(operations, None).unwrap();
+        mast_forest.make_root(basic_block_id);
 
         Program::new(mast_forest.into(), basic_block_id)
     };

--- a/processor/src/decoder/tests.rs
+++ b/processor/src/decoder/tests.rs
@@ -54,7 +54,7 @@ fn basic_block_one_group() {
         let basic_block_node = MastNode::Block(basic_block.clone());
         let basic_block_id = mast_forest.add_node(basic_block_node).unwrap();
 
-        Program::new(mast_forest, basic_block_id)
+        Program::new(mast_forest.into(), basic_block_id)
     };
 
     let (trace, trace_len) = build_trace(&[], &program);
@@ -100,7 +100,7 @@ fn basic_block_small() {
         let basic_block_node = MastNode::Block(basic_block.clone());
         let basic_block_id = mast_forest.add_node(basic_block_node).unwrap();
 
-        Program::new(mast_forest, basic_block_id)
+        Program::new(mast_forest.into(), basic_block_id)
     };
 
     let (trace, trace_len) = build_trace(&[], &program);
@@ -163,7 +163,7 @@ fn basic_block() {
         let basic_block_node = MastNode::Block(basic_block.clone());
         let basic_block_id = mast_forest.add_node(basic_block_node).unwrap();
 
-        Program::new(mast_forest, basic_block_id)
+        Program::new(mast_forest.into(), basic_block_id)
     };
     let (trace, trace_len) = build_trace(&[], &program);
 
@@ -255,7 +255,7 @@ fn span_block_with_respan() {
         let basic_block_node = MastNode::Block(basic_block.clone());
         let basic_block_id = mast_forest.add_node(basic_block_node).unwrap();
 
-        Program::new(mast_forest, basic_block_id)
+        Program::new(mast_forest.into(), basic_block_id)
     };
     let (trace, trace_len) = build_trace(&[], &program);
 
@@ -331,7 +331,7 @@ fn join_node() {
 
         let join_node_id = mast_forest.add_join(basic_block1_id, basic_block2_id).unwrap();
 
-        Program::new(mast_forest, join_node_id)
+        Program::new(mast_forest.into(), join_node_id)
     };
 
     let (trace, trace_len) = build_trace(&[], &program);
@@ -396,7 +396,7 @@ fn split_node_true() {
 
         let split_node_id = mast_forest.add_split(basic_block1_id, basic_block2_id).unwrap();
 
-        Program::new(mast_forest, split_node_id)
+        Program::new(mast_forest.into(), split_node_id)
     };
 
     let (trace, trace_len) = build_trace(&[1], &program);
@@ -448,7 +448,7 @@ fn split_node_false() {
 
         let split_node_id = mast_forest.add_split(basic_block1_id, basic_block2_id).unwrap();
 
-        Program::new(mast_forest, split_node_id)
+        Program::new(mast_forest.into(), split_node_id)
     };
 
     let (trace, trace_len) = build_trace(&[0], &program);
@@ -501,7 +501,7 @@ fn loop_node() {
 
         let loop_node_id = mast_forest.add_loop(loop_body_id).unwrap();
 
-        Program::new(mast_forest, loop_node_id)
+        Program::new(mast_forest.into(), loop_node_id)
     };
 
     let (trace, trace_len) = build_trace(&[0, 1], &program);
@@ -553,7 +553,7 @@ fn loop_node_skip() {
 
         let loop_node_id = mast_forest.add_loop(loop_body_id).unwrap();
 
-        Program::new(mast_forest, loop_node_id)
+        Program::new(mast_forest.into(), loop_node_id)
     };
 
     let (trace, trace_len) = build_trace(&[0], &program);
@@ -595,7 +595,7 @@ fn loop_node_repeat() {
 
         let loop_node_id = mast_forest.add_loop(loop_body_id).unwrap();
 
-        Program::new(mast_forest, loop_node_id)
+        Program::new(mast_forest.into(), loop_node_id)
     };
 
     let (trace, trace_len) = build_trace(&[0, 1, 1], &program);
@@ -697,7 +697,7 @@ fn call_block() {
 
     let program_root_id = mast_forest.add_join(join1_node_id, last_basic_block_id).unwrap();
 
-    let program = Program::new(mast_forest, program_root_id);
+    let program = Program::new(mast_forest.into(), program_root_id);
 
     let (sys_trace, dec_trace,   trace_len) =
         build_call_trace(&program, Kernel::default());
@@ -923,7 +923,7 @@ fn syscall_block() {
     let program_root_node = MastNode::new_join(inner_join_node_id, last_basic_block_id, &mast_forest).unwrap();
     let program_root_node_id = mast_forest.add_node(program_root_node.clone()).unwrap();
 
-    let program = Program::with_kernel(mast_forest, program_root_node_id, kernel.clone());
+    let program = Program::with_kernel(mast_forest.into(), program_root_node_id, kernel.clone());
 
     let (sys_trace, dec_trace,   trace_len) =
         build_call_trace(&program, kernel);
@@ -1196,7 +1196,7 @@ fn dyn_block() {
     let program_root_node = MastNode::new_join(join_node_id, dyn_node_id, &mast_forest).unwrap();
     let program_root_node_id = mast_forest.add_node(program_root_node.clone()).unwrap();
 
-    let program = Program::new(mast_forest, program_root_node_id);
+    let program = Program::new(mast_forest.into(), program_root_node_id);
 
     let (trace, trace_len) = build_dyn_trace(
         &[
@@ -1303,7 +1303,7 @@ fn set_user_op_helpers_many() {
 
         let basic_block_id = mast_forest.add_block(vec![Operation::U32div], None).unwrap();
 
-        Program::new(mast_forest, basic_block_id)
+        Program::new(mast_forest.into(), basic_block_id)
     };
     let a = rand_value::<u32>();
     let b = rand_value::<u32>();

--- a/processor/src/decoder/tests.rs
+++ b/processor/src/decoder/tests.rs
@@ -53,6 +53,7 @@ fn basic_block_one_group() {
 
         let basic_block_node = MastNode::Block(basic_block.clone());
         let basic_block_id = mast_forest.add_node(basic_block_node).unwrap();
+        mast_forest.make_root(basic_block_id);
 
         Program::new(mast_forest.into(), basic_block_id)
     };
@@ -99,6 +100,7 @@ fn basic_block_small() {
 
         let basic_block_node = MastNode::Block(basic_block.clone());
         let basic_block_id = mast_forest.add_node(basic_block_node).unwrap();
+        mast_forest.make_root(basic_block_id);
 
         Program::new(mast_forest.into(), basic_block_id)
     };
@@ -162,6 +164,7 @@ fn basic_block() {
 
         let basic_block_node = MastNode::Block(basic_block.clone());
         let basic_block_id = mast_forest.add_node(basic_block_node).unwrap();
+        mast_forest.make_root(basic_block_id);
 
         Program::new(mast_forest.into(), basic_block_id)
     };
@@ -254,6 +257,7 @@ fn span_block_with_respan() {
 
         let basic_block_node = MastNode::Block(basic_block.clone());
         let basic_block_id = mast_forest.add_node(basic_block_node).unwrap();
+        mast_forest.make_root(basic_block_id);
 
         Program::new(mast_forest.into(), basic_block_id)
     };
@@ -330,6 +334,7 @@ fn join_node() {
         let basic_block2_id = mast_forest.add_node(basic_block2.clone()).unwrap();
 
         let join_node_id = mast_forest.add_join(basic_block1_id, basic_block2_id).unwrap();
+        mast_forest.make_root(join_node_id);
 
         Program::new(mast_forest.into(), join_node_id)
     };
@@ -395,6 +400,7 @@ fn split_node_true() {
         let basic_block2_id = mast_forest.add_node(basic_block2.clone()).unwrap();
 
         let split_node_id = mast_forest.add_split(basic_block1_id, basic_block2_id).unwrap();
+        mast_forest.make_root(split_node_id);
 
         Program::new(mast_forest.into(), split_node_id)
     };
@@ -447,6 +453,7 @@ fn split_node_false() {
         let basic_block2_id = mast_forest.add_node(basic_block2.clone()).unwrap();
 
         let split_node_id = mast_forest.add_split(basic_block1_id, basic_block2_id).unwrap();
+        mast_forest.make_root(split_node_id);
 
         Program::new(mast_forest.into(), split_node_id)
     };
@@ -498,8 +505,8 @@ fn loop_node() {
         let mut mast_forest = MastForest::new();
 
         let loop_body_id = mast_forest.add_node(loop_body.clone()).unwrap();
-
         let loop_node_id = mast_forest.add_loop(loop_body_id).unwrap();
+        mast_forest.make_root(loop_node_id);
 
         Program::new(mast_forest.into(), loop_node_id)
     };
@@ -550,8 +557,8 @@ fn loop_node_skip() {
         let mut mast_forest = MastForest::new();
 
         let loop_body_id = mast_forest.add_node(loop_body.clone()).unwrap();
-
         let loop_node_id = mast_forest.add_loop(loop_body_id).unwrap();
+        mast_forest.make_root(loop_node_id);
 
         Program::new(mast_forest.into(), loop_node_id)
     };
@@ -592,8 +599,8 @@ fn loop_node_repeat() {
         let mut mast_forest = MastForest::new();
 
         let loop_body_id = mast_forest.add_node(loop_body.clone()).unwrap();
-
         let loop_node_id = mast_forest.add_loop(loop_body_id).unwrap();
+        mast_forest.make_root(loop_node_id);
 
         Program::new(mast_forest.into(), loop_node_id)
     };
@@ -696,6 +703,7 @@ fn call_block() {
     let join1_node_id = mast_forest.add_node(join1_node.clone()).unwrap();
 
     let program_root_id = mast_forest.add_join(join1_node_id, last_basic_block_id).unwrap();
+    mast_forest.make_root(program_root_id);
 
     let program = Program::new(mast_forest.into(), program_root_id);
 
@@ -922,6 +930,7 @@ fn syscall_block() {
 
     let program_root_node = MastNode::new_join(inner_join_node_id, last_basic_block_id, &mast_forest).unwrap();
     let program_root_node_id = mast_forest.add_node(program_root_node.clone()).unwrap();
+    mast_forest.make_root(program_root_node_id);
 
     let program = Program::with_kernel(mast_forest.into(), program_root_node_id, kernel.clone());
 
@@ -1195,6 +1204,7 @@ fn dyn_block() {
 
     let program_root_node = MastNode::new_join(join_node_id, dyn_node_id, &mast_forest).unwrap();
     let program_root_node_id = mast_forest.add_node(program_root_node.clone()).unwrap();
+    mast_forest.make_root(program_root_node_id);
 
     let program = Program::new(mast_forest.into(), program_root_node_id);
 
@@ -1302,6 +1312,7 @@ fn set_user_op_helpers_many() {
         let mut mast_forest = MastForest::new();
 
         let basic_block_id = mast_forest.add_block(vec![Operation::U32div], None).unwrap();
+        mast_forest.make_root(basic_block_id);
 
         Program::new(mast_forest.into(), basic_block_id)
     };

--- a/processor/src/host/mast_forest_store.rs
+++ b/processor/src/host/mast_forest_store.rs
@@ -23,9 +23,7 @@ pub struct MemMastForestStore {
 
 impl MemMastForestStore {
     /// Inserts all the procedures of the provided MAST forest in the store.
-    pub fn insert(&mut self, mast_forest: MastForest) {
-        let mast_forest = Arc::new(mast_forest);
-
+    pub fn insert(&mut self, mast_forest: Arc<MastForest>) {
         // only register the procedures which are local to this forest
         for proc_digest in mast_forest.local_procedure_digests() {
             self.mast_forests.insert(proc_digest, mast_forest.clone());

--- a/processor/src/host/mod.rs
+++ b/processor/src/host/mod.rs
@@ -316,7 +316,7 @@ where
         }
     }
 
-    pub fn load_mast_forest(&mut self, mast_forest: MastForest) {
+    pub fn load_mast_forest(&mut self, mast_forest: Arc<MastForest>) {
         self.store.insert(mast_forest)
     }
 

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -252,7 +252,7 @@ where
             return Err(ExecutionError::ProgramAlreadyExecuted);
         }
 
-        self.execute_mast_node(program.entrypoint(), program.mast_forest())?;
+        self.execute_mast_node(program.entrypoint(), &program.mast_forest())?;
 
         Ok(self.stack.build_stack_outputs())
     }

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -252,7 +252,7 @@ where
             return Err(ExecutionError::ProgramAlreadyExecuted);
         }
 
-        self.execute_mast_node(program.entrypoint(), &program.mast_forest())?;
+        self.execute_mast_node(program.entrypoint(), &program.mast_forest().clone())?;
 
         Ok(self.stack.build_stack_outputs())
     }

--- a/processor/src/trace/tests/chiplets/hasher.rs
+++ b/processor/src/trace/tests/chiplets/hasher.rs
@@ -57,6 +57,7 @@ pub fn b_chip_span() {
 
         let basic_block_id =
             mast_forest.add_block(vec![Operation::Add, Operation::Mul], None).unwrap();
+        mast_forest.make_root(basic_block_id);
 
         Program::new(mast_forest.into(), basic_block_id)
     };
@@ -129,6 +130,7 @@ pub fn b_chip_span_with_respan() {
 
         let (ops, _) = build_span_with_respan_ops();
         let basic_block_id = mast_forest.add_block(ops, None).unwrap();
+        mast_forest.make_root(basic_block_id);
 
         Program::new(mast_forest.into(), basic_block_id)
     };
@@ -220,10 +222,9 @@ pub fn b_chip_merge() {
         let mut mast_forest = MastForest::new();
 
         let t_branch_id = mast_forest.add_block(vec![Operation::Add], None).unwrap();
-
         let f_branch_id = mast_forest.add_block(vec![Operation::Mul], None).unwrap();
-
         let split_id = mast_forest.add_split(t_branch_id, f_branch_id).unwrap();
+        mast_forest.make_root(split_id);
 
         Program::new(mast_forest.into(), split_id)
     };
@@ -336,6 +337,7 @@ pub fn b_chip_permutation() {
         let mut mast_forest = MastForest::new();
 
         let basic_block_id = mast_forest.add_block(vec![Operation::HPerm], None).unwrap();
+        mast_forest.make_root(basic_block_id);
 
         Program::new(mast_forest.into(), basic_block_id)
     };

--- a/processor/src/trace/tests/chiplets/hasher.rs
+++ b/processor/src/trace/tests/chiplets/hasher.rs
@@ -58,7 +58,7 @@ pub fn b_chip_span() {
         let basic_block_id =
             mast_forest.add_block(vec![Operation::Add, Operation::Mul], None).unwrap();
 
-        Program::new(mast_forest, basic_block_id)
+        Program::new(mast_forest.into(), basic_block_id)
     };
 
     let trace = build_trace_from_program(&program, &[]);
@@ -130,7 +130,7 @@ pub fn b_chip_span_with_respan() {
         let (ops, _) = build_span_with_respan_ops();
         let basic_block_id = mast_forest.add_block(ops, None).unwrap();
 
-        Program::new(mast_forest, basic_block_id)
+        Program::new(mast_forest.into(), basic_block_id)
     };
     let trace = build_trace_from_program(&program, &[]);
 
@@ -225,7 +225,7 @@ pub fn b_chip_merge() {
 
         let split_id = mast_forest.add_split(t_branch_id, f_branch_id).unwrap();
 
-        Program::new(mast_forest, split_id)
+        Program::new(mast_forest.into(), split_id)
     };
 
     let trace = build_trace_from_program(&program, &[]);
@@ -337,7 +337,7 @@ pub fn b_chip_permutation() {
 
         let basic_block_id = mast_forest.add_block(vec![Operation::HPerm], None).unwrap();
 
-        Program::new(mast_forest, basic_block_id)
+        Program::new(mast_forest.into(), basic_block_id)
     };
     let stack = vec![8, 0, 0, 0, 1, 2, 3, 4, 5, 6, 7, 8];
     let trace = build_trace_from_program(&program, &stack);

--- a/processor/src/trace/tests/decoder.rs
+++ b/processor/src/trace/tests/decoder.rs
@@ -74,10 +74,9 @@ fn decoder_p1_join() {
         let mut mast_forest = MastForest::new();
 
         let basic_block_1_id = mast_forest.add_block(vec![Operation::Mul], None).unwrap();
-
         let basic_block_2_id = mast_forest.add_block(vec![Operation::Add], None).unwrap();
-
         let join_id = mast_forest.add_join(basic_block_1_id, basic_block_2_id).unwrap();
+        mast_forest.make_root(join_id);
 
         Program::new(mast_forest.into(), join_id)
     };
@@ -142,10 +141,9 @@ fn decoder_p1_split() {
         let mut mast_forest = MastForest::new();
 
         let basic_block_1_id = mast_forest.add_block(vec![Operation::Mul], None).unwrap();
-
         let basic_block_2_id = mast_forest.add_block(vec![Operation::Add], None).unwrap();
-
         let split_id = mast_forest.add_split(basic_block_1_id, basic_block_2_id).unwrap();
+        mast_forest.make_root(split_id);
 
         Program::new(mast_forest.into(), split_id)
     };
@@ -197,12 +195,10 @@ fn decoder_p1_loop_with_repeat() {
         let mut mast_forest = MastForest::new();
 
         let basic_block_1_id = mast_forest.add_block(vec![Operation::Pad], None).unwrap();
-
         let basic_block_2_id = mast_forest.add_block(vec![Operation::Drop], None).unwrap();
-
         let join_id = mast_forest.add_join(basic_block_1_id, basic_block_2_id).unwrap();
-
         let loop_node_id = mast_forest.add_loop(join_id).unwrap();
+        mast_forest.make_root(loop_node_id);
 
         Program::new(mast_forest.into(), loop_node_id)
     };
@@ -324,6 +320,7 @@ fn decoder_p2_span_with_respan() {
 
         let (ops, _) = build_span_with_respan_ops();
         let basic_block_id = mast_forest.add_block(ops, None).unwrap();
+        mast_forest.make_root(basic_block_id);
 
         Program::new(mast_forest.into(), basic_block_id)
     };
@@ -366,6 +363,7 @@ fn decoder_p2_join() {
 
     let join = MastNode::new_join(basic_block_1_id, basic_block_2_id, &mast_forest).unwrap();
     let join_id = mast_forest.add_node(join.clone()).unwrap();
+    mast_forest.make_root(join_id);
 
     let program = Program::new(mast_forest.into(), join_id);
 
@@ -425,10 +423,9 @@ fn decoder_p2_split_true() {
 
     let basic_block_1 = MastNode::new_basic_block(vec![Operation::Mul], None).unwrap();
     let basic_block_1_id = mast_forest.add_node(basic_block_1.clone()).unwrap();
-
     let basic_block_2_id = mast_forest.add_block(vec![Operation::Add], None).unwrap();
-
     let split_id = mast_forest.add_split(basic_block_1_id, basic_block_2_id).unwrap();
+    mast_forest.make_root(split_id);
 
     let program = Program::new(mast_forest.into(), split_id);
 
@@ -484,6 +481,7 @@ fn decoder_p2_split_false() {
     let basic_block_2_id = mast_forest.add_node(basic_block_2.clone()).unwrap();
 
     let split_id = mast_forest.add_split(basic_block_1_id, basic_block_2_id).unwrap();
+    mast_forest.make_root(split_id);
 
     let program = Program::new(mast_forest.into(), split_id);
 
@@ -542,6 +540,7 @@ fn decoder_p2_loop_with_repeat() {
     let join_id = mast_forest.add_node(join.clone()).unwrap();
 
     let loop_node_id = mast_forest.add_loop(join_id).unwrap();
+    mast_forest.make_root(loop_node_id);
 
     let program = Program::new(mast_forest.into(), loop_node_id);
 

--- a/processor/src/trace/tests/decoder.rs
+++ b/processor/src/trace/tests/decoder.rs
@@ -79,7 +79,7 @@ fn decoder_p1_join() {
 
         let join_id = mast_forest.add_join(basic_block_1_id, basic_block_2_id).unwrap();
 
-        Program::new(mast_forest, join_id)
+        Program::new(mast_forest.into(), join_id)
     };
 
     let trace = build_trace_from_program(&program, &[]);
@@ -147,7 +147,7 @@ fn decoder_p1_split() {
 
         let split_id = mast_forest.add_split(basic_block_1_id, basic_block_2_id).unwrap();
 
-        Program::new(mast_forest, split_id)
+        Program::new(mast_forest.into(), split_id)
     };
 
     let trace = build_trace_from_program(&program, &[1]);
@@ -204,7 +204,7 @@ fn decoder_p1_loop_with_repeat() {
 
         let loop_node_id = mast_forest.add_loop(join_id).unwrap();
 
-        Program::new(mast_forest, loop_node_id)
+        Program::new(mast_forest.into(), loop_node_id)
     };
 
     let trace = build_trace_from_program(&program, &[0, 1, 1]);
@@ -325,7 +325,7 @@ fn decoder_p2_span_with_respan() {
         let (ops, _) = build_span_with_respan_ops();
         let basic_block_id = mast_forest.add_block(ops, None).unwrap();
 
-        Program::new(mast_forest, basic_block_id)
+        Program::new(mast_forest.into(), basic_block_id)
     };
     let trace = build_trace_from_program(&program, &[]);
     let alphas = rand_array::<Felt, AUX_TRACE_RAND_ELEMENTS>();
@@ -367,7 +367,7 @@ fn decoder_p2_join() {
     let join = MastNode::new_join(basic_block_1_id, basic_block_2_id, &mast_forest).unwrap();
     let join_id = mast_forest.add_node(join.clone()).unwrap();
 
-    let program = Program::new(mast_forest, join_id);
+    let program = Program::new(mast_forest.into(), join_id);
 
     let trace = build_trace_from_program(&program, &[]);
     let alphas = rand_array::<Felt, AUX_TRACE_RAND_ELEMENTS>();
@@ -430,7 +430,7 @@ fn decoder_p2_split_true() {
 
     let split_id = mast_forest.add_split(basic_block_1_id, basic_block_2_id).unwrap();
 
-    let program = Program::new(mast_forest, split_id);
+    let program = Program::new(mast_forest.into(), split_id);
 
     // build trace from program
     let trace = build_trace_from_program(&program, &[1]);
@@ -485,7 +485,7 @@ fn decoder_p2_split_false() {
 
     let split_id = mast_forest.add_split(basic_block_1_id, basic_block_2_id).unwrap();
 
-    let program = Program::new(mast_forest, split_id);
+    let program = Program::new(mast_forest.into(), split_id);
 
     // build trace from program
     let trace = build_trace_from_program(&program, &[0]);
@@ -543,7 +543,7 @@ fn decoder_p2_loop_with_repeat() {
 
     let loop_node_id = mast_forest.add_loop(join_id).unwrap();
 
-    let program = Program::new(mast_forest, loop_node_id);
+    let program = Program::new(mast_forest.into(), loop_node_id);
 
     // build trace from program
     let trace = build_trace_from_program(&program, &[0, 1, 1]);

--- a/processor/src/trace/tests/mod.rs
+++ b/processor/src/trace/tests/mod.rs
@@ -35,7 +35,7 @@ pub fn build_trace_from_ops(operations: Vec<Operation>, stack: &[u64]) -> Execut
 
     let basic_block_id = mast_forest.add_block(operations, None).unwrap();
 
-    let program = Program::new(mast_forest, basic_block_id);
+    let program = Program::new(mast_forest.into(), basic_block_id);
 
     build_trace_from_program(&program, stack)
 }
@@ -56,7 +56,7 @@ pub fn build_trace_from_ops_with_inputs(
     let mut mast_forest = MastForest::new();
     let basic_block_id = mast_forest.add_block(operations, None).unwrap();
 
-    let program = Program::new(mast_forest, basic_block_id);
+    let program = Program::new(mast_forest.into(), basic_block_id);
 
     process.execute(&program).unwrap();
     ExecutionTrace::new(process, StackOutputs::default())

--- a/processor/src/trace/tests/mod.rs
+++ b/processor/src/trace/tests/mod.rs
@@ -34,6 +34,7 @@ pub fn build_trace_from_ops(operations: Vec<Operation>, stack: &[u64]) -> Execut
     let mut mast_forest = MastForest::new();
 
     let basic_block_id = mast_forest.add_block(operations, None).unwrap();
+    mast_forest.make_root(basic_block_id);
 
     let program = Program::new(mast_forest.into(), basic_block_id);
 
@@ -55,6 +56,7 @@ pub fn build_trace_from_ops_with_inputs(
 
     let mut mast_forest = MastForest::new();
     let basic_block_id = mast_forest.add_block(operations, None).unwrap();
+    mast_forest.make_root(basic_block_id);
 
     let program = Program::new(mast_forest.into(), basic_block_id);
 

--- a/stdlib/src/lib.rs
+++ b/stdlib/src/lib.rs
@@ -2,6 +2,8 @@
 
 extern crate alloc;
 
+use alloc::sync::Arc;
+
 use assembly::{mast::MastForest, utils::Deserializable, Library};
 
 // STANDARD LIBRARY
@@ -22,22 +24,20 @@ impl From<StdLibrary> for Library {
     }
 }
 
-impl From<StdLibrary> for MastForest {
-    fn from(value: StdLibrary) -> Self {
-        value.0.into()
-    }
-}
-
 impl StdLibrary {
+    /// Serialized representation of the Miden standard library.
     pub const SERIALIZED: &'static [u8] =
         include_bytes!(concat!(env!("OUT_DIR"), "/assets/std.masl"));
+
+    /// Returns a reference to the [MastForest] underlying the Miden standard library.
+    pub fn mast_forest(&self) -> Arc<MastForest> {
+        self.0.mast_forest()
+    }
 }
 
 impl Default for StdLibrary {
     fn default() -> Self {
-        let contents =
-            Library::read_from_bytes(Self::SERIALIZED).expect("failed to read std masl!");
-        Self(contents)
+        Self(Library::read_from_bytes(Self::SERIALIZED).expect("failed to deserialize stdlib"))
     }
 }
 

--- a/stdlib/src/lib.rs
+++ b/stdlib/src/lib.rs
@@ -30,7 +30,7 @@ impl StdLibrary {
         include_bytes!(concat!(env!("OUT_DIR"), "/assets/std.masl"));
 
     /// Returns a reference to the [MastForest] underlying the Miden standard library.
-    pub fn mast_forest(&self) -> Arc<MastForest> {
+    pub fn mast_forest(&self) -> &Arc<MastForest> {
         self.0.mast_forest()
     }
 }

--- a/stdlib/tests/mem/mod.rs
+++ b/stdlib/tests/mem/mod.rs
@@ -31,7 +31,7 @@ fn test_memcopy() {
         assembler.assemble_program(source).expect("Failed to compile test source.");
 
     let mut host = DefaultHost::default();
-    host.load_mast_forest(stdlib.into());
+    host.load_mast_forest(stdlib.mast_forest());
 
     let mut process = Process::new(
         program.kernel().clone(),

--- a/stdlib/tests/mem/mod.rs
+++ b/stdlib/tests/mem/mod.rs
@@ -31,7 +31,7 @@ fn test_memcopy() {
         assembler.assemble_program(source).expect("Failed to compile test source.");
 
     let mut host = DefaultHost::default();
-    host.load_mast_forest(stdlib.mast_forest());
+    host.load_mast_forest(stdlib.mast_forest().clone());
 
     let mut process = Process::new(
         program.kernel().clone(),

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -225,10 +225,10 @@ impl Test {
         let (program, kernel) = self.compile().expect("Failed to compile test source.");
         let mut host = DefaultHost::new(MemAdviceProvider::from(self.advice_inputs.clone()));
         if let Some(kernel) = kernel {
-            host.load_mast_forest(kernel.mast_forest());
+            host.load_mast_forest(kernel.mast_forest().clone());
         }
         for library in &self.libraries {
-            host.load_mast_forest(library.mast_forest());
+            host.load_mast_forest(library.mast_forest().clone());
         }
 
         // execute the test
@@ -323,10 +323,10 @@ impl Test {
         let (program, kernel) = self.compile().expect("Failed to compile test source.");
         let mut host = DefaultHost::new(MemAdviceProvider::from(self.advice_inputs.clone()));
         if let Some(kernel) = kernel {
-            host.load_mast_forest(kernel.mast_forest());
+            host.load_mast_forest(kernel.mast_forest().clone());
         }
         for library in &self.libraries {
-            host.load_mast_forest(library.mast_forest());
+            host.load_mast_forest(library.mast_forest().clone());
         }
         processor::execute(&program, self.stack_inputs.clone(), host, ExecutionOptions::default())
     }
@@ -339,10 +339,10 @@ impl Test {
         let (program, kernel) = self.compile().expect("Failed to compile test source.");
         let mut host = DefaultHost::new(MemAdviceProvider::from(self.advice_inputs.clone()));
         if let Some(kernel) = kernel {
-            host.load_mast_forest(kernel.mast_forest());
+            host.load_mast_forest(kernel.mast_forest().clone());
         }
         for library in &self.libraries {
-            host.load_mast_forest(library.mast_forest());
+            host.load_mast_forest(library.mast_forest().clone());
         }
 
         let mut process = Process::new(
@@ -363,10 +363,10 @@ impl Test {
         let (program, kernel) = self.compile().expect("Failed to compile test source.");
         let mut host = DefaultHost::new(MemAdviceProvider::from(self.advice_inputs.clone()));
         if let Some(kernel) = kernel {
-            host.load_mast_forest(kernel.mast_forest());
+            host.load_mast_forest(kernel.mast_forest().clone());
         }
         for library in &self.libraries {
-            host.load_mast_forest(library.mast_forest());
+            host.load_mast_forest(library.mast_forest().clone());
         }
         let (mut stack_outputs, proof) =
             prover::prove(&program, stack_inputs.clone(), host, ProvingOptions::default()).unwrap();
@@ -388,10 +388,10 @@ impl Test {
         let (program, kernel) = self.compile().expect("Failed to compile test source.");
         let mut host = DefaultHost::new(MemAdviceProvider::from(self.advice_inputs.clone()));
         if let Some(kernel) = kernel {
-            host.load_mast_forest(kernel.mast_forest());
+            host.load_mast_forest(kernel.mast_forest().clone());
         }
         for library in &self.libraries {
-            host.load_mast_forest(library.mast_forest());
+            host.load_mast_forest(library.mast_forest().clone());
         }
         processor::execute_iter(&program, self.stack_inputs.clone(), host)
     }


### PR DESCRIPTION
This PR wraps `MastForest` fields in `Program` and `Library` structs in `Arc`. This way, cloning these objects becomes a relatively cheap operation.

Additionally, this PR contains the following changes/refactorings:

1. A check was added to make sure that an entrypoint of a `Program` is registered as a root in the `MastForest`. This was already happening - but now we have an explicit check for this.
2. For every re-exported procedure, we now add an `External` node to the `MastForest`. This makes `Library` and `Program` structs a bit more consistent and also removes a somewhat un-intuitive situations where if a library had only re-exported procedures, its `MastForest` would be completely empty. Since now there is an easy way to track re-exported procedures in the `MastForest` itself, the distinction between local and re-exported procedures was removed from the `Library` struct (but I added a method that allows checking if a given export is a re-export).
3. In the `MastForestBuilder`, we now insert `Procedure` structs for re-exported procedures too. This allowed removing `procedure_hashes` map and unify the way we treat local and re-exported procedures.

There is one thing we can improve in the future: if we re-export a procedure from the library and a procedure with the same digest is locally defined, we may end up with some unreachable nodes in the MAST forest. This is technically not a bug - but it does create bloat in the MAST forest. In general, I think if a library has a locally-defined procedure and also re-exports a procedure with the same root, the re-exported procedure should take precedence.

This PR closes #1430. As suggested by @bitwalker, I did not to add `Version` to the `Library`. We should probably either remove `Version` entirely or move it to `miden-core`. But I left this for future PRs.