### PR TITLE
chore: remove callset from `Procedure`

### DIFF
--- a/assembly/src/assembler/instruction/procedures.rs
+++ b/assembly/src/assembler/instruction/procedures.rs
@@ -19,7 +19,7 @@ impl Assembler {
     ) -> Result<Option<MastNodeId>, AssemblyError> {
         let span = callee.span();
         let digest = self.resolve_target(kind, callee, proc_ctx, mast_forest_builder)?;
-        self.invoke_mast_root(kind, span, digest, proc_ctx, mast_forest_builder)
+        self.invoke_mast_root(kind, span, digest, mast_forest_builder)
     }
 
     fn invoke_mast_root(
@@ -27,14 +27,12 @@ impl Assembler {
         kind: InvokeKind,
         span: SourceSpan,
         mast_root: RpoDigest,
-        proc_ctx: &mut ProcedureContext,
         mast_forest_builder: &mut MastForestBuilder,
     ) -> Result<Option<MastNodeId>, AssemblyError> {
         // Get the procedure from the assembler
         let current_source_file = self.source_manager.get(span.source_id()).ok();
 
-        // If the procedure is cached, register the call to ensure the callset
-        // is updated correctly.
+        // If the procedure is cached and is a system call, ensure that the call is valid.
         match mast_forest_builder.find_procedure(&mast_root) {
             Some(proc) if matches!(kind, InvokeKind::SysCall) => {
                 // Verify if this is a syscall, that the callee is a kernel procedure
@@ -71,10 +69,8 @@ impl Assembler {
                             })
                         }
                     })?;
-                proc_ctx.register_external_call(&proc, false)?;
             },
-            Some(proc) => proc_ctx.register_external_call(&proc, false)?,
-            None => (),
+            Some(_) | None => (),
         }
 
         let mast_root_node_id = {
@@ -150,34 +146,25 @@ impl Assembler {
         &self,
         callee: &InvocationTarget,
         proc_ctx: &mut ProcedureContext,
-        span_builder: &mut BasicBlockBuilder,
+        basic_block_builder: &mut BasicBlockBuilder,
         mast_forest_builder: &MastForestBuilder,
     ) -> Result<(), AssemblyError> {
         let digest =
             self.resolve_target(InvokeKind::ProcRef, callee, proc_ctx, mast_forest_builder)?;
-        self.procref_mast_root(digest, proc_ctx, span_builder, mast_forest_builder)
+        self.procref_mast_root(digest, basic_block_builder)
     }
 
     fn procref_mast_root(
         &self,
         mast_root: RpoDigest,
-        proc_ctx: &mut ProcedureContext,
-        span_builder: &mut BasicBlockBuilder,
-        mast_forest_builder: &MastForestBuilder,
+        basic_block_builder: &mut BasicBlockBuilder,
     ) -> Result<(), AssemblyError> {
-        // Add the root to the callset to be able to use dynamic instructions
-        // with the referenced procedure later
-
-        if let Some(proc) = mast_forest_builder.find_procedure(&mast_root) {
-            proc_ctx.register_external_call(&proc, false)?;
-        }
-
         // Create an array with `Push` operations containing root elements
         let ops = mast_root
             .iter()
             .map(|elem| Operation::Push(*elem))
             .collect::<SmallVec<[_; 4]>>();
-        span_builder.push_ops(ops);
+        basic_block_builder.push_ops(ops);
         Ok(())
     }
 }

--- a/assembly/src/assembler/procedure.rs
+++ b/assembly/src/assembler/procedure.rs
@@ -1,4 +1,4 @@
-use alloc::{collections::BTreeSet, sync::Arc};
+use alloc::sync::Arc;
 
 use vm_core::mast::MastNodeId;
 
@@ -6,10 +6,8 @@ use super::GlobalProcedureIndex;
 use crate::{
     ast::{ProcedureName, QualifiedProcedureName, Visibility},
     diagnostics::{SourceManager, SourceSpan, Spanned},
-    AssemblyError, LibraryPath, RpoDigest,
+    LibraryPath, RpoDigest,
 };
-
-pub type CallSet = BTreeSet<RpoDigest>;
 
 // PROCEDURE CONTEXT
 // ================================================================================================
@@ -23,7 +21,6 @@ pub struct ProcedureContext {
     visibility: Visibility,
     is_kernel: bool,
     num_locals: u16,
-    callset: CallSet,
 }
 
 // ------------------------------------------------------------------------------------------------
@@ -44,7 +41,6 @@ impl ProcedureContext {
             visibility,
             is_kernel,
             num_locals: 0,
-            callset: Default::default(),
         }
     }
 
@@ -93,38 +89,6 @@ impl ProcedureContext {
 // ------------------------------------------------------------------------------------------------
 /// State mutators
 impl ProcedureContext {
-    pub fn insert_callee(&mut self, callee: RpoDigest) {
-        self.callset.insert(callee);
-    }
-
-    pub fn extend_callset<I>(&mut self, callees: I)
-    where
-        I: IntoIterator<Item = RpoDigest>,
-    {
-        self.callset.extend(callees);
-    }
-
-    /// Registers a call to an externally-defined procedure which we have previously compiled.
-    ///
-    /// The call set of the callee is added to the call set of the procedure we are currently
-    /// compiling, to reflect that all of the code reachable from the callee is by extension
-    /// reachable by the caller.
-    pub fn register_external_call(
-        &mut self,
-        callee: &Procedure,
-        inlined: bool,
-    ) -> Result<(), AssemblyError> {
-        // If we call the callee, it's callset is by extension part of our callset
-        self.extend_callset(callee.callset().iter().cloned());
-
-        // If the callee is not being inlined, add it to our callset
-        if !inlined {
-            self.insert_callee(callee.mast_root());
-        }
-
-        Ok(())
-    }
-
     /// Transforms this procedure context into a [Procedure].
     ///
     /// The passed-in `mast_root` defines the MAST root of the procedure's body while
@@ -138,7 +102,6 @@ impl ProcedureContext {
     pub fn into_procedure(self, mast_root: RpoDigest, mast_node_id: MastNodeId) -> Procedure {
         Procedure::new(self.name, self.visibility, self.num_locals as u32, mast_root, mast_node_id)
             .with_span(self.span)
-            .with_callset(self.callset)
     }
 }
 
@@ -170,8 +133,6 @@ pub struct Procedure {
     mast_root: RpoDigest,
     /// The MAST node id which resolves to the above MAST root.
     body_node_id: MastNodeId,
-    /// The set of MAST roots called by this procedure
-    callset: CallSet,
 }
 
 // ------------------------------------------------------------------------------------------------
@@ -191,17 +152,11 @@ impl Procedure {
             num_locals,
             mast_root,
             body_node_id,
-            callset: Default::default(),
         }
     }
 
     pub(crate) fn with_span(mut self, span: SourceSpan) -> Self {
         self.span = span;
-        self
-    }
-
-    pub(crate) fn with_callset(mut self, callset: CallSet) -> Self {
-        self.callset = callset;
         self
     }
 }
@@ -243,12 +198,6 @@ impl Procedure {
     /// Returns a reference to the MAST node ID of this procedure.
     pub fn body_node_id(&self) -> MastNodeId {
         self.body_node_id
-    }
-
-    /// Returns a reference to a set of all procedures (identified by their MAST roots) which may
-    /// be called during the execution of this procedure.
-    pub fn callset(&self) -> &CallSet {
-        &self.callset
     }
 }
 


### PR DESCRIPTION
I was able to remove the call set from `Procedure` and `ProcedureContext` without breaking anything. It suggests that we no longer need to track that information.

Am I missing something?