### PR TITLE
chore: Add warning about `no_std` environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ A STARK-based virtual machine.
 
 **WARNING:** This project is in an alpha stage. It has not been audited and may contain bugs and security flaws. This implementation is NOT ready for production use.
 
+**WARNING:** For `no_std`, only the WASM environment is officially supported.
+
 ## Overview
 
 Miden VM is a zero-knowledge virtual machine written in Rust. For any program executed on Miden VM, a STARK-based proof of execution is automatically generated. This proof can then be used by anyone to verify that the program was executed correctly without the need for re-executing the program or even knowing the contents of the program.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A STARK-based virtual machine.
 
 **WARNING:** This project is in an alpha stage. It has not been audited and may contain bugs and security flaws. This implementation is NOT ready for production use.
 
-**WARNING:** For `no_std`, only the WASM environment is officially supported.
+**WARNING:** For `no_std`, only the `wasm32-unknown-unknown` and `wasm32-wasip1` targets are officially supported.
 
 ## Overview
 

--- a/miden/README.md
+++ b/miden/README.md
@@ -308,6 +308,7 @@ Miden VM can be compiled with the following features:
 - `executable` - required for building Miden VM binary as described above. Implies `std`.
 - `metal` - enables [Metal](<https://en.wikipedia.org/wiki/Metal_(API)>)-based acceleration of proof generation (for recursive proofs) on supported platforms (e.g., Apple silicon).
 - `no_std` does not rely on the Rust standard library and enables compilation to WebAssembly.
+    - Only the `wasm32-unknown-unknown` and `wasm32-wasip1` targets are officially supported.
 
 To compile with `no_std`, disable default features via `--no-default-features` flag.
 

--- a/processor/README.md
+++ b/processor/README.md
@@ -63,6 +63,7 @@ Miden processor can be compiled with the following features:
 
 * `std` - enabled by default and relies on the Rust standard library.
 * `no_std` does not rely on the Rust standard library and enables compilation to WebAssembly.
+    * Only the `wasm32-unknown-unknown` and `wasm32-wasip1` targets are officially supported.
 
 To compile with `no_std`, disable default features via `--no-default-features` flag.
 

--- a/prover/README.md
+++ b/prover/README.md
@@ -46,6 +46,7 @@ Miden prover can be compiled with the following features:
 * `concurrent` - implies `std` and also enables multi-threaded proof generation.
 * `metal` - enables [Metal](https://en.wikipedia.org/wiki/Metal_(API))-based acceleration of proof generation (for recursive proofs) on supported platforms (e.g., Apple silicon).
 * `no_std` does not rely on the Rust standard library and enables compilation to WebAssembly.
+    * Only the `wasm32-unknown-unknown` and `wasm32-wasip1` targets are officially supported.
 
 To compile with `no_std`, disable default features via `--no-default-features` flag.
 

--- a/verifier/README.md
+++ b/verifier/README.md
@@ -28,6 +28,7 @@ Miden verifier can be compiled with the following features:
 
 * `std` - enabled by default and relies on the Rust standard library.
 * `no_std` does not rely on the Rust standard library and enables compilation to WebAssembly.
+    * Only the `wasm32-unknown-unknown` and `wasm32-wasip1` targets are officially supported.
 
 To compile with `no_std`, disable default features via `--no-default-features` flag.
 


### PR DESCRIPTION
Adds a warning in the main README that the only officially supported `no_std` environment is WASM