### PR TITLE
feat: improve handling of u32 operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - `MastForestBuilder`: use `MastNodeId` instead of MAST root to uniquely identify procedures (#1473)
 - Added `miden_core::utils::sync::racy_lock` module (#1463).
 - Updated `miden_core::utils` to re-export `std::sync::LazyLock` and `racy_lock::RacyLock as LazyLock` for std and no_std environments, respectively (#1463).
+- Made the undocumented behavior of the VM with regard to undefined behavior of u32 operations, stricter (#1480)
 
 #### Fixes
 

--- a/assembly/src/assembler/instruction/u32_ops.rs
+++ b/assembly/src/assembler/instruction/u32_ops.rs
@@ -302,7 +302,7 @@ pub fn u32clz(span: &mut BasicBlockBuilder) {
     span.push_advice_injector(AdviceInjector::U32Clz);
     span.push_op(AdvPop); // [clz, n, ...]
 
-    calculate_clz(span);
+    verify_clz(span);
 }
 
 /// Translates `u32ctz` assembly instruction to VM operations. `u32ctz` counts the number of
@@ -326,7 +326,7 @@ pub fn u32clo(span: &mut BasicBlockBuilder) {
     span.push_advice_injector(AdviceInjector::U32Clo);
     span.push_op(AdvPop); // [clo, n, ...]
 
-    calculate_clo(span);
+    verify_clo(span);
 }
 
 /// Translates `u32cto` assembly instruction to VM operations. `u32cto` counts the number of
@@ -338,7 +338,7 @@ pub fn u32cto(span: &mut BasicBlockBuilder) {
     span.push_advice_injector(AdviceInjector::U32Cto);
     span.push_op(AdvPop); // [cto, n, ...]
 
-    calculate_cto(span);
+    verify_cto(span);
 }
 
 /// Specifically handles these specific inputs per the spec.
@@ -450,7 +450,7 @@ fn prepare_bitwise<const MAX_VALUE: u8>(
 /// `[clz, n, ... ] -> [clz, ... ]`
 ///
 /// VM cycles: 42
-fn calculate_clz(span: &mut BasicBlockBuilder) {
+fn verify_clz(span: &mut BasicBlockBuilder) {
     // [clz, n, ...]
     #[rustfmt::skip]
     let ops_group_1 = [
@@ -531,7 +531,7 @@ fn calculate_clz(span: &mut BasicBlockBuilder) {
 /// `[clo, n, ... ] -> [clo, ... ]`
 ///
 /// VM cycle: 40
-fn calculate_clo(span: &mut BasicBlockBuilder) {
+fn verify_clo(span: &mut BasicBlockBuilder) {
     // [clo, n, ...]
     #[rustfmt::skip]
     let ops_group_1 = [
@@ -606,7 +606,7 @@ fn calculate_clo(span: &mut BasicBlockBuilder) {
 /// `[ctz, n, ... ] -> [ctz, ... ]`
 ///
 /// VM cycles: 33
-fn calculate_ctz(span: &mut BasicBlockBuilder) {
+fn verify_ctz(span: &mut BasicBlockBuilder) {
     // [ctz, n, ...]
     #[rustfmt::skip]
     let ops_group_1 = [
@@ -680,7 +680,7 @@ fn calculate_ctz(span: &mut BasicBlockBuilder) {
 /// `[cto, n, ... ] -> [cto, ... ]`
 ///
 /// VM cycles: 32
-fn calculate_cto(span: &mut BasicBlockBuilder) {
+fn verify_cto(span: &mut BasicBlockBuilder) {
     // [cto, n, ...]
     #[rustfmt::skip]
     let ops_group_1 = [

--- a/assembly/src/assembler/instruction/u32_ops.rs
+++ b/assembly/src/assembler/instruction/u32_ops.rs
@@ -236,25 +236,25 @@ pub fn u32rotl(span_builder: &mut BasicBlockBuilder, imm: Option<u8>) -> Result<
 /// b is the shift amount, then adding the overflow limb to the shifted limb.
 ///
 /// VM cycles per mode:
-/// - u32rotr: 22 cycles
+/// - u32rotr: 23 cycles
 /// - u32rotr.b: 3 cycles
 pub fn u32rotr(span_builder: &mut BasicBlockBuilder, imm: Option<u8>) -> Result<(), AssemblyError> {
     match imm {
         Some(0) => {
             // if rotation is performed by 0, do nothing (Noop)
             span_builder.push_op(Noop);
-            return Ok(());
         },
         Some(imm) => {
             validate_param(imm, 1..=MAX_U32_ROTATE_VALUE)?;
             span_builder.push_op(Push(Felt::new(1 << (32 - imm))));
+            span_builder.push_ops([U32mul, Add]);
         },
         None => {
             span_builder.push_ops([Push(Felt::new(32)), Swap, U32sub, Drop]);
             append_pow2_op(span_builder);
+            span_builder.push_ops([Mul, U32split, Add]);
         },
     }
-    span_builder.push_ops([U32mul, Add]);
     Ok(())
 }
 

--- a/docs/src/user_docs/assembly/u32_operations.md
+++ b/docs/src/user_docs/assembly/u32_operations.md
@@ -5,6 +5,56 @@ For instructions where one or more operands can be provided as immediate paramet
 
 In all the table below, the number of cycles it takes for the VM to execute each instruction is listed beneath the instruction.
 
+### Notes on Undefined Behavior
+
+Most of the instructions documented below expect to receive operands whose values are valid `u32`
+values, i.e. values in the range $0..=(2^{32} - 1)$. Currently, the semantics of the instructions
+when given values outside of that range are undefined (as noted in the documented semantics for
+each instruction). The rule with undefined behavior generally speaking is that you can make no
+assumptions about what will happen if your program exhibits it.
+
+For purposes of describing the effects of undefined behavior below, we will refer to values which
+are not valid for the input type of the affected operation, e.g. `u32`, as _poison_. Any use of a
+poison value propagates the poison state. For example, performing `u32div` with a poison operand,
+can be considered as producing a poison value as its result, for the purposes of discussing
+undefined behavior semantics.
+
+With that in mind, there are two ways in which the effects of undefined behavior manifest:
+
+#### Executor Semantics
+
+From an executor perspective, currently, the semantics are completely undefined. An executor can
+do everything from terminate the program, panic, always produce 42 as a result, produce a random
+result, or something more principled.
+
+In practice, the Miden VM, when executing an operation, will almost always trap on _poison_ values.
+This is not guaranteed, but is currently the case for most operations which have niches of undefined
+behavior. To the extent that some other behavior may occur, it will generally be to truncate/wrap the
+poison value, but this is subject to change at any time, and is undocumented. You should assume that
+all operations will trap on poison.
+
+The reason the Miden VM makes the choice to trap on poison, is to ensure that undefined behavior is
+caught close to the source, rather than propagated silently throughout the program. It also has the
+effect of ensuring you do not execute a program with undefined behavior, and produce a proof that
+is not actually valid, as we will describe in a moment.
+
+#### Verifier Semantics
+
+From the perspective of the verifier, the implementation details of the executor are completely
+unknown. For example, the fact that the Miden VM traps on poison values is not actually verified
+by constraints. An alternative executor implementation could choose _not_ to trap, and thus appear
+to execute successfully. The resulting proof, however, as a result of the program exhibiting
+undefined behavior, is not a valid proof. In effect the use of poison values "poisons" the proof
+as well.
+
+As a result, a program that exhibits undefined behavior, and executes successfully, will produce
+a proof that could pass verification, even though it should not. In other words, the proof does
+not prove what it says it does.
+
+In the future, we may attempt to remove niches of undefined behavior in such a way that producing
+such invalid proofs is not possible, but for the time being, you must ensure that your program does
+not exhibit (or rely on) undefined behavior.
+
 ### Conversions and tests
 
 | Instruction                                    | Stack_input | Stack_output  | Notes                                                                                                                          |

--- a/docs/src/user_docs/assembly/u32_operations.md
+++ b/docs/src/user_docs/assembly/u32_operations.md
@@ -103,11 +103,11 @@ If the error code is omitted, the default value of $0$ is assumed.
 | u32shl <br> - *(18 cycles)* <br> u32shl.*b* <br> - *(3 cycles)*   | [b, a, ...]    | [c, ...]      | $c \leftarrow (a \cdot 2^b) \mod 2^{32}$ <br> Undefined if $a \ge 2^{32}$ or $b > 31$                                          |
 | u32shr <br> - *(18 cycles)* <br> u32shr.*b* <br> - *(3 cycles)*   | [b, a, ...]    | [c, ...]      | $c \leftarrow \lfloor a/2^b \rfloor$ <br> Undefined if $a \ge 2^{32}$ or $b > 31$                                              |
 | u32rotl <br> - *(18 cycles)* <br> u32rotl.*b* <br> - *(3 cycles)* | [b, a, ...]    | [c, ...]      | Computes $c$ by rotating a 32-bit representation of $a$ to the left by $b$ bits. <br> Undefined if $a \ge 2^{32}$ or $b > 31$  |
-| u32rotr <br> - *(22 cycles)* <br> u32rotr.*b* <br> - *(3 cycles)* | [b, a, ...]    | [c, ...]      | Computes $c$ by rotating a 32-bit representation of $a$ to the right by $b$ bits. <br> Undefined if $a \ge 2^{32}$ or $b > 31$ |
+| u32rotr <br> - *(23 cycles)* <br> u32rotr.*b* <br> - *(3 cycles)* | [b, a, ...]    | [c, ...]      | Computes $c$ by rotating a 32-bit representation of $a$ to the right by $b$ bits. <br> Undefined if $a \ge 2^{32}$ or $b > 31$ |
 | u32popcnt <br> - *(33 cycles)*                                              | [a, ...]       | [b, ...]      | Computes $b$ by counting the number of set bits in $a$ (hamming weight of $a$). <br> Undefined if $a \ge 2^{32}$               |
-| u32clz <br> - *(37 cycles)*                                                     | [a, ...]    | [b, ...]      | Computes $b$ as a number of leading zeros of $a$. <br> Undefined if $a \ge 2^{32}$               |
+| u32clz <br> - *(42 cycles)*                                                     | [a, ...]    | [b, ...]      | Computes $b$ as a number of leading zeros of $a$. <br> Undefined if $a \ge 2^{32}$               |
 | u32ctz <br> - *(34 cycles)*                                                     | [a, ...]    | [b, ...]      | Computes $b$ as a number of trailing zeros of $a$. <br> Undefined if $a \ge 2^{32}$               |
-| u32clo <br> - *(36 cycles)*                                                     | [a, ...]    | [b, ...]      | Computes $b$ as a number of leading ones of $a$. <br> Undefined if $a \ge 2^{32}$               |
+| u32clo <br> - *(41 cycles)*                                                     | [a, ...]    | [b, ...]      | Computes $b$ as a number of leading ones of $a$. <br> Undefined if $a \ge 2^{32}$               |
 | u32cto <br> - *(33 cycles)*                                                     | [a, ...]    | [b, ...]      | Computes $b$ as a number of trailing ones of $a$. <br> Undefined if $a \ge 2^{32}$               |
 
 

--- a/miden/tests/integration/operations/u32_ops/arithmetic_ops.rs
+++ b/miden/tests/integration/operations/u32_ops/arithmetic_ops.rs
@@ -3,8 +3,6 @@ use test_utils::{
     build_op_test, expect_exec_error, proptest::prelude::*, rand::rand_value, U32_BOUND,
 };
 
-use super::test_unchecked_execution;
-
 // U32 OPERATIONS TESTS - MANUAL - ARITHMETIC OPERATIONS
 // ================================================================================================
 
@@ -112,9 +110,6 @@ fn u32overflowing_add() {
     let e = rand_value::<u64>();
     let test = build_op_test!(asm_op, &[e, a as u64, b as u64]);
     test.expect_stack(&[d, c as u64, e]);
-
-    // should not fail when inputs are out of bounds.
-    test_unchecked_execution(asm_op, 2);
 }
 
 #[test]
@@ -169,20 +164,6 @@ fn u32overflowing_add3() {
     let f = rand_value::<u64>();
     let test = build_op_test!(asm_op, &[f, c as u64, a as u64, b as u64]);
     test.expect_stack(&[e, d as u64, f]);
-
-    // --- test that out of bounds inputs do not cause a failure ----------------------------------
-
-    // should not fail if a >= 2^32.
-    let test = build_op_test!(asm_op, &[0, 0, U32_BOUND]);
-    assert!(test.execute().is_ok());
-
-    // should not fail if b >= 2^32.
-    let test = build_op_test!(asm_op, &[0, U32_BOUND, 0]);
-    assert!(test.execute().is_ok());
-
-    // should not fail if c >= 2^32.
-    let test = build_op_test!(asm_op, &[U32_BOUND, 0, 0]);
-    assert!(test.execute().is_ok());
 }
 
 #[test]
@@ -283,9 +264,6 @@ fn u32overflowing_sub() {
     let e = rand_value::<u64>();
     let test = build_op_test!(asm_op, &[e, a as u64, b as u64]);
     test.expect_stack(&[d, c as u64, e]);
-
-    // should not fail when inputs are out of bounds.
-    test_unchecked_execution(asm_op, 2);
 }
 
 #[test]
@@ -384,9 +362,6 @@ fn u32overflowing_mul() {
     let e = rand_value::<u64>();
     let test = build_op_test!(asm_op, &[e, a as u64, b as u64]);
     test.expect_stack(&[d, c as u64, e]);
-
-    // should not fail when inputs are out of bounds.
-    test_unchecked_execution(asm_op, 2);
 }
 
 #[test]
@@ -425,9 +400,6 @@ fn u32overflowing_madd() {
     let f = rand_value::<u64>();
     let test = build_op_test!(asm_op, &[f, c as u64, a as u64, b as u64]);
     test.expect_stack(&[e, d, f]);
-
-    // should not fail when inputs are out of bounds.
-    test_unchecked_execution(asm_op, 3);
 }
 
 #[test]
@@ -460,9 +432,6 @@ fn u32div() {
     let e = rand_value::<u64>();
     let test = build_op_test!("u32div", &[e, a as u64, b as u64]);
     test.expect_stack(&[quot, e]);
-
-    // should not fail when inputs are out of bounds.
-    test_unchecked_execution("u32div", 2);
 }
 
 #[test]
@@ -501,9 +470,6 @@ fn u32mod() {
     let c = rand_value::<u64>();
     let test = build_op_test!("u32mod", &[c, a as u64, b as u64]);
     test.expect_stack(&[expected as u64, c]);
-
-    // should not fail when inputs are out of bounds.
-    test_unchecked_execution("u32mod", 2);
 }
 
 #[test]
@@ -547,9 +513,6 @@ fn u32divmod() {
     let e = rand_value::<u64>();
     let test = build_op_test!("u32divmod", &[e, a as u64, b as u64]);
     test.expect_stack(&[rem, quot, e]);
-
-    // should not fail when inputs are out of bounds.
-    test_unchecked_execution("u32divmod", 2);
 }
 
 #[test]

--- a/miden/tests/integration/operations/u32_ops/bitwise_ops.rs
+++ b/miden/tests/integration/operations/u32_ops/bitwise_ops.rs
@@ -317,10 +317,6 @@ fn u32shl() {
 
     let test = build_op_test!(asm_op, &[a as u64, b as u64]);
     test.expect_stack(&[a.wrapping_shl(b) as u64]);
-
-    // --- test out of bounds input (should not fail) --------------------------------------------
-    let test = build_op_test!(asm_op, &[U32_BOUND, 1]);
-    assert!(test.execute().is_ok());
 }
 
 #[test]
@@ -355,11 +351,6 @@ fn u32shl_b() {
 
     // let test = build_op_test!(get_asm_op(b).as_str(), &[a as u64]);
     // test.expect_stack(&[a.wrapping_shl(b) as u64]);
-
-    // --- test out of bounds input (should not fail) ---------------------------------------------
-    // let b = 1;
-    // let test = build_op_test!(get_asm_op(b).as_str(), &[U32_BOUND]);
-    // assert!(test.execute().is_ok());
 }
 
 #[test]
@@ -393,10 +384,6 @@ fn u32shr() {
 
     let test = build_op_test!(asm_op, &[a as u64, b as u64]);
     test.expect_stack(&[a.wrapping_shr(b) as u64]);
-
-    // --- test out of bounds inputs (should not fail) --------------------------------------------
-    let test = build_op_test!(asm_op, &[U32_BOUND, 1]);
-    assert!(test.execute().is_ok());
 }
 
 #[test]
@@ -431,11 +418,6 @@ fn u32shr_b() {
 
     let test = build_op_test!(get_asm_op(b).as_str(), &[a as u64]);
     test.expect_stack(&[a.wrapping_shr(b) as u64]);
-
-    // --- test out of bounds inputs (should not fail) --------------------------------------------
-    let b = 1;
-    let test = build_op_test!(get_asm_op(b).as_str(), &[U32_BOUND]);
-    assert!(test.execute().is_ok());
 }
 
 #[test]

--- a/miden/tests/integration/operations/u32_ops/bitwise_ops.rs
+++ b/miden/tests/integration/operations/u32_ops/bitwise_ops.rs
@@ -462,10 +462,6 @@ fn u32rotl() {
 
     let test = build_op_test!(asm_op, &[a as u64, b as u64]);
     test.expect_stack(&[a.rotate_left(b) as u64]);
-
-    // --- test out of bounds inputs (should not fail) --------------------------------------------
-    let test = build_op_test!(asm_op, &[U32_BOUND, 1]);
-    assert!(test.execute().is_ok());
 }
 
 #[test]
@@ -510,10 +506,6 @@ fn u32rotr() {
 
     let test = build_op_test!(asm_op, &[a as u64, b as u64]);
     test.expect_stack(&[a.rotate_right(b) as u64]);
-
-    // --- test out of bounds inputs (should not fail) --------------------------------------------
-    let test = build_op_test!(asm_op, &[U32_BOUND, 1]);
-    assert!(test.execute().is_ok());
 }
 
 #[test]

--- a/miden/tests/integration/operations/u32_ops/comparison_ops.rs
+++ b/miden/tests/integration/operations/u32_ops/comparison_ops.rs
@@ -2,8 +2,6 @@ use core::cmp::Ordering;
 
 use test_utils::{build_op_test, proptest::prelude::*, rand::rand_value};
 
-use super::test_unchecked_execution;
-
 // U32 OPERATIONS TESTS - MANUAL - COMPARISON OPERATIONS
 // ================================================================================================
 
@@ -13,9 +11,6 @@ fn u32lt() {
 
     // should push 1 to the stack when a < b and 0 otherwise
     test_comparison_op(asm_op, 1, 0, 0);
-
-    // should not fail when inputs are out of bounds
-    test_unchecked_execution(asm_op, 2);
 }
 
 #[test]
@@ -24,9 +19,6 @@ fn u32lte() {
 
     // should push 1 to the stack when a <= b and 0 otherwise
     test_comparison_op(asm_op, 1, 1, 0);
-
-    // should not fail when inputs are out of bounds
-    test_unchecked_execution(asm_op, 2);
 }
 
 #[test]
@@ -35,9 +27,6 @@ fn u32gt() {
 
     // should push 1 to the stack when a > b and 0 otherwise
     test_comparison_op(asm_op, 0, 0, 1);
-
-    // should not fail when inputs are out of bounds
-    test_unchecked_execution(asm_op, 2);
 }
 
 #[test]
@@ -46,9 +35,6 @@ fn u32gte() {
 
     // should push 1 to the stack when a >= b and 0 otherwise
     test_comparison_op(asm_op, 0, 1, 1);
-
-    // should not fail when inputs are out of bounds
-    test_unchecked_execution(asm_op, 2);
 }
 
 #[test]
@@ -57,9 +43,6 @@ fn u32min() {
 
     // should put the minimum of the 2 inputs on the stack
     test_min(asm_op);
-
-    // should not fail when inputs are out of bounds
-    test_unchecked_execution(asm_op, 2);
 }
 
 #[test]
@@ -68,9 +51,6 @@ fn u32max() {
 
     // should put the maximum of the 2 inputs on the stack
     test_max(asm_op);
-
-    // should not fail when inputs are out of bounds
-    test_unchecked_execution(asm_op, 2);
 }
 
 // U32 OPERATIONS TESTS - RANDOMIZED - COMPARISON OPERATIONS

--- a/miden/tests/integration/operations/u32_ops/mod.rs
+++ b/miden/tests/integration/operations/u32_ops/mod.rs
@@ -30,18 +30,3 @@ pub fn test_inputs_out_of_bounds(asm_op: &str, input_count: usize) {
         expect_exec_error!(test, ExecutionError::NotU32Value(Felt::new(U32_BOUND), ZERO));
     }
 }
-
-/// This helper function tests that when the given u32 assembly instruction is executed on
-/// out-of-bounds inputs it does not fail. Each input is tested independently.
-pub fn test_unchecked_execution(asm_op: &str, input_count: usize) {
-    let values = vec![1_u64; input_count];
-
-    for i in 0..input_count {
-        let mut i_values = values.clone();
-        // should execute successfully when the value of the input at index i is out of bounds
-        i_values[i] = U32_BOUND;
-
-        let test = build_op_test!(asm_op, &i_values);
-        assert!(test.execute().is_ok());
-    }
-}

--- a/processor/src/operations/u32_ops.rs
+++ b/processor/src/operations/u32_ops.rs
@@ -4,6 +4,22 @@ use super::{
 };
 use crate::ZERO;
 
+const U32_MAX: u64 = u32::MAX as u64;
+
+macro_rules! require_u32_operand {
+    ($stack:expr, $idx:literal) => {
+        require_u32_operand!($stack, $idx, ZERO)
+    };
+
+    ($stack:expr, $idx:literal, $errno:expr) => {{
+        let operand = $stack.get($idx);
+        if operand.as_int() > U32_MAX {
+            return Err(ExecutionError::NotU32Value(operand, $errno));
+        }
+        operand
+    }};
+}
+
 impl<H> Process<H>
 where
     H: Host,
@@ -29,15 +45,8 @@ where
     /// the high values are equal to 0; if they are, puts the original elements back onto the
     /// stack; if they are not, returns an error.
     pub(super) fn op_u32assert2(&mut self, err_code: u32) -> Result<(), ExecutionError> {
-        let a = self.stack.get(0);
-        let b = self.stack.get(1);
-
-        if a.as_int() >> 32 != 0 {
-            return Err(ExecutionError::NotU32Value(a, Felt::from(err_code)));
-        }
-        if b.as_int() >> 32 != 0 {
-            return Err(ExecutionError::NotU32Value(b, Felt::from(err_code)));
-        }
+        let b = require_u32_operand!(self.stack, 0, Felt::from(err_code));
+        let a = require_u32_operand!(self.stack, 1, Felt::from(err_code));
 
         self.add_range_checks(Operation::U32assert2(err_code), a, b, false);
 
@@ -51,11 +60,11 @@ where
     /// Pops two elements off the stack, adds them, splits the result into low and high 32-bit
     /// values, and pushes these values back onto the stack.
     pub(super) fn op_u32add(&mut self) -> Result<(), ExecutionError> {
-        let b = self.stack.get(0);
-        let a = self.stack.get(1);
-        let result = a + b;
-        let (hi, lo) = split_element(result);
+        let b = require_u32_operand!(self.stack, 0).as_int();
+        let a = require_u32_operand!(self.stack, 1).as_int();
 
+        let result = Felt::new(a + b);
+        let (hi, lo) = split_element(result);
         self.add_range_checks(Operation::U32add, lo, hi, false);
 
         self.stack.set(0, hi);
@@ -67,9 +76,9 @@ where
     /// Pops three elements off the stack, adds them, splits the result into low and high 32-bit
     /// values, and pushes these values back onto the stack.
     pub(super) fn op_u32add3(&mut self) -> Result<(), ExecutionError> {
-        let c = self.stack.get(0).as_int();
-        let b = self.stack.get(1).as_int();
-        let a = self.stack.get(2).as_int();
+        let c = require_u32_operand!(self.stack, 0).as_int();
+        let b = require_u32_operand!(self.stack, 1).as_int();
+        let a = require_u32_operand!(self.stack, 2).as_int();
         let result = Felt::new(a + b + c);
         let (hi, lo) = split_element(result);
 
@@ -85,11 +94,11 @@ where
     /// pushes the result as well as a flag indicating whether there was underflow back onto the
     /// stack.
     pub(super) fn op_u32sub(&mut self) -> Result<(), ExecutionError> {
-        let b = self.stack.get(0).as_int();
-        let a = self.stack.get(1).as_int();
+        let b = require_u32_operand!(self.stack, 0).as_int();
+        let a = require_u32_operand!(self.stack, 1).as_int();
         let result = a.wrapping_sub(b);
         let d = Felt::new(result >> 63);
-        let c = Felt::new((result as u32) as u64);
+        let c = Felt::new(result & U32_MAX);
 
         // Force this operation to consume 4 range checks, even though only `lo` is needed.
         // This is required for making the constraints more uniform and grouping the opcodes of
@@ -105,8 +114,8 @@ where
     /// Pops two elements off the stack, multiplies them, splits the result into low and high
     /// 32-bit values, and pushes these values back onto the stack.
     pub(super) fn op_u32mul(&mut self) -> Result<(), ExecutionError> {
-        let b = self.stack.get(0).as_int();
-        let a = self.stack.get(1).as_int();
+        let b = require_u32_operand!(self.stack, 0).as_int();
+        let a = require_u32_operand!(self.stack, 1).as_int();
         let result = Felt::new(a * b);
         let (hi, lo) = split_element(result);
 
@@ -122,9 +131,9 @@ where
     /// the result, splits the result into low and high 32-bit values, and pushes these values
     /// back onto the stack.
     pub(super) fn op_u32madd(&mut self) -> Result<(), ExecutionError> {
-        let b = self.stack.get(0).as_int();
-        let a = self.stack.get(1).as_int();
-        let c = self.stack.get(2).as_int();
+        let b = require_u32_operand!(self.stack, 0).as_int();
+        let a = require_u32_operand!(self.stack, 1).as_int();
+        let c = require_u32_operand!(self.stack, 2).as_int();
         let result = Felt::new(a * b + c);
         let (hi, lo) = split_element(result);
 
@@ -142,8 +151,8 @@ where
     /// # Errors
     /// Returns an error if the divisor is ZERO.
     pub(super) fn op_u32div(&mut self) -> Result<(), ExecutionError> {
-        let b = self.stack.get(0).as_int();
-        let a = self.stack.get(1).as_int();
+        let b = require_u32_operand!(self.stack, 0).as_int();
+        let a = require_u32_operand!(self.stack, 1).as_int();
 
         if b == 0 {
             return Err(ExecutionError::DivideByZero(self.system.clk()));
@@ -170,8 +179,8 @@ where
     /// Pops two elements off the stack, computes their bitwise AND, and pushes the result back
     /// onto the stack.
     pub(super) fn op_u32and(&mut self) -> Result<(), ExecutionError> {
-        let b = self.stack.get(0);
-        let a = self.stack.get(1);
+        let b = require_u32_operand!(self.stack, 0);
+        let a = require_u32_operand!(self.stack, 1);
         let result = self.chiplets.u32and(a, b)?;
 
         self.stack.set(0, result);
@@ -183,8 +192,8 @@ where
     /// Pops two elements off the stack, computes their bitwise XOR, and pushes the result back onto
     /// the stack.
     pub(super) fn op_u32xor(&mut self) -> Result<(), ExecutionError> {
-        let b = self.stack.get(0);
-        let a = self.stack.get(1);
+        let b = require_u32_operand!(self.stack, 0);
+        let a = require_u32_operand!(self.stack, 1);
         let result = self.chiplets.u32xor(a, b)?;
 
         self.stack.set(0, result);

--- a/stdlib/asm/math/u64.masm
+++ b/stdlib/asm/math/u64.masm
@@ -568,7 +568,7 @@ end
 #! error.
 #! Stack transition looks as follows:
 #! [b, a_hi, a_lo, ...] -> [c_hi, c_lo, ...], where c = a << b mod 2^64.
-#! This takes 40 cycles.
+#! This takes 44 cycles.
 export.rotr
     push.31
     dup.1
@@ -609,7 +609,7 @@ end
 #! The input value is assumed to be represented using 32 bit limbs, but this is not checked.
 #! Stack transition looks as follows:
 #! [n_hi, n_lo, ...] -> [clz, ...], where clz is a number of leading zeros of value n.
-#! This takes 43 cycles.
+#! This takes 48 cycles.
 export.clz
     dup.0
     eq.0
@@ -650,7 +650,7 @@ end
 #! The input value is assumed to be represented using 32 bit limbs, but this is not checked.
 #! Stack transition looks as follows:
 #! [n_hi, n_lo, ...] -> [clo, ...], where clo is a number of leading ones of value n.
-#! This takes 42 cycles.
+#! This takes 47 cycles.
 export.clo
     dup.0
     eq.4294967295

--- a/stdlib/asm/math/u64.masm
+++ b/stdlib/asm/math/u64.masm
@@ -618,7 +618,7 @@ export.clz
         drop
         u32clz
         add.32 # clz(n_lo) + 32
-    else 
+    else
         swap
         drop
         u32clz # clz(n_hi)
@@ -639,7 +639,7 @@ export.ctz
         drop
         u32ctz
         add.32 # ctz(n_hi) + 32
-    else 
+    else
         swap
         drop
         u32ctz # ctz(n_lo)
@@ -659,7 +659,7 @@ export.clo
         drop
         u32clo
         add.32 # clo(n_lo) + 32
-    else 
+    else
         swap
         drop
         u32clo # clo(n_hi)
@@ -680,7 +680,7 @@ export.cto
         drop
         u32cto
         add.32 # cto(n_hi) + 32
-    else 
+    else
         swap
         drop
         u32cto # ctz(n_lo)

--- a/stdlib/asm/math/u64.masm
+++ b/stdlib/asm/math/u64.masm
@@ -572,9 +572,7 @@ end
 export.rotr
     push.31
     dup.1
-    u32overflowing_sub
-    swap
-    drop
+    u32lt
     movdn.3
 
     # Shift the low limb left by 32-b.
@@ -582,17 +580,19 @@ export.rotr
     u32and
     push.32
     swap
-    u32overflowing_sub
-    drop
+    u32wrapping_sub
     pow2
     dup
     movup.3
-    u32overflowing_mul
+    mul
+    u32split
 
     # Shift the high limb left by 32-b.
     movup.3
     movup.3
-    u32overflowing_madd
+    mul
+    add
+    u32split
 
     # Carry the overflow shift to the low bits.
     movup.2

--- a/stdlib/tests/math/u64_mod.rs
+++ b/stdlib/tests/math/u64_mod.rs
@@ -520,7 +520,7 @@ fn checked_and_fail() {
         end";
 
     let test = build_test!(source, &[a0, a1, b0, b1]);
-    expect_exec_error!(test, ExecutionError::NotU32Value(Felt::new(b0), ZERO));
+    expect_exec_error!(test, ExecutionError::NotU32Value(Felt::new(a0), ZERO));
 }
 
 #[test]
@@ -558,7 +558,7 @@ fn checked_or_fail() {
         end";
 
     let test = build_test!(source, &[a0, a1, b0, b1]);
-    expect_exec_error!(test, ExecutionError::NotU32Value(Felt::new(b0), ZERO));
+    expect_exec_error!(test, ExecutionError::NotU32Value(Felt::new(a0), ZERO));
 }
 
 #[test]
@@ -596,7 +596,7 @@ fn checked_xor_fail() {
         end";
 
     let test = build_test!(source, &[a0, a1, b0, b1]);
-    expect_exec_error!(test, ExecutionError::NotU32Value(Felt::new(b0), ZERO));
+    expect_exec_error!(test, ExecutionError::NotU32Value(Felt::new(a0), ZERO));
 }
 
 #[test]


### PR DESCRIPTION
This PR solves two problems:

1. It ensures that we raise an `ExecutionError` when inputs to a `u32` operation are invalid, rather than attempting the operation with those inputs and potentially panicking, crashing the VM in the process. This has the effect of making the `u32` operations stricter in practice, but this has two primary benefits:
    * These errors are handled gracefully, which means you get a useful error (and source locations in the debugger), rather than a crash with no useful information at all.
    * It makes relying on undefined behavior impractical, forcing you to instead ensure that your program is semantically correct. It is one thing to avoid checked operations because you know that your program will never produce invalid values, and quite another to rely on the fact that the current behavior of the VM will allow you to use _some_ invalid values without punishing you. This is no longer the case, and the VM now punishes you for violating the semantics of the instruction set.
2. It fixes the places where we ourselves were relying on undefined/undocumented behavior of the VM, which was identified as a result of the stricter handling of invalid u32 operands.

See the first commit in the changeset for a more in-depth description of the changes/rationale, but the above is a pretty good summary.

## Rationale

Aside from needing to fix the initial issue of certain u32 operations triggering a panic in the VM, it is not apparent to me why we would want to allow invalid operands to these instructions. The fact that we happened to allow it at all is basically arbitrary, and has the effect of allowing bugs to creep into programs very subtly. The only valid reason to make room for undefined behavior _at all_, is to allow for optimizations to be made based on the invariants of the instruction - optimizations which tend to be wildly unsafe if the invariants are _not_ upheld. We have no such optimizations implemented, nor planned, so I believe we should ensure that any reliance on the currently documented undefined behavior, results in an execution error, to better aid in debugging and validating the correctness of programs.

## Alternatives

An alternative approach is to try and promote the behavior we were relying on to "defined behavior". For example, if we think it is imperative to allow $$2^{32}$$ as a valid value for `u32` operations, we could explicitly document the behavior of the various operations for that specific value. I should note, as it can be easy to forget, that $$2^{32}$$ is _not_ a valid `u32` value, as it requires 33 bits to represent, but it seems to be the dominant reason why we were relying on undefined behavior in our own ops. As you can see from the commits in this PR though, it is not actually necessary for us to do so, though there may be some small overhead of a couple cycles to avoid it.

We could also attempt to make the degree of "strictness" configurable, so that we only produce an `ExecutionError` if the operation would cause the VM to panic otherwise. I'm not fond of this idea, as it adds additional complexity, for the sole benefit of allowing one to rely on undefined behavior - that doesn't seem wise.

---

**NOTE:** I removed test assertions from the `u32` operation tests that specifically asserted that those ops did not fail on out-of-bounds operands. Not only does it not make sense for us to be testing undefined behavior in the first place, it suggests that the undocumented behavior under test is relied upon, which we definitely do not want to encourage.

**TODO**

- [ ] Update documented cycle counts for operations affected by changes (is there a way we can automate this somehow? Sure would be nice if we didn't have to compile that information by hand). I'd use the playground or the VM, but the cycle counts obtained from those include a bunch of irrelevant stuff, so obtaining a precise count is a bit challenging.
- [ ] Update documentation to clarify the behavior of the VM with regard to undefined behavior, namely that the VM will now trap on invalid operands, but that this can change at any time, without any warning.