### PR TITLE
fix(assembly): properly indent first op in nested blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - [BREAKING] Wrapped `MastForest`s in `Program` and `Library` structs in `Arc` (#1465).
 - `MastForestBuilder`: use `MastNodeId` instead of MAST root to uniquely identify procedures (#1473)
 
+#### Fixes
+
+- Fixed an issue with formatting of blocks in Miden Assembly syntax
+
 ## 0.10.5 (2024-08-21)
 
 #### Enhancements

--- a/assembly/src/ast/block.rs
+++ b/assembly/src/ast/block.rs
@@ -70,7 +70,7 @@ impl crate::prettier::PrettyPrint for Block {
         .map(PrettyPrint::render)
         .reduce(|acc, doc| acc + nl() + doc);
 
-        body.map(|body| indent(4, body)).unwrap_or(Document::Empty)
+        body.map(|body| indent(4, nl() + body)).unwrap_or(Document::Empty)
     }
 }
 


### PR DESCRIPTION
This is just a small patch that fixes an issue in the formatting of Miden Assembly syntax - namely, blocks nested in operations, such as `if.true`, were being formatted with the first instruction in the block improperly indented. This PR ensures they are indented to the same level as the rest of the block.

@bobbinth Feel free to ignore this one and leave it to @plafer / @Fumuran - accidentally added you as a reviewer, and it's not possible to remove reviewers, so you're in for the long haul now 😆 