### PR TITLE
Simplify `batch_ops()`

### DIFF
--- a/core/src/mast/node/basic_block_node/mod.rs
+++ b/core/src/mast/node/basic_block_node/mod.rs
@@ -323,9 +323,8 @@ fn batch_and_hash_ops(ops: Vec<Operation>) -> (Vec<OpBatch>, RpoDigest) {
     (batches, hash)
 }
 
-/// Groups the provided operations into batches as described in the docs for this module (i.e.,
-/// up to 9 operations per group, and 8 groups per batch).
-/// Returns a list of operation batches and a list of operation groups.
+/// Groups the provided operations into batches as described in the docs for this module (i.e., up
+/// to 9 operations per group, and 8 groups per batch).
 fn batch_ops(ops: Vec<Operation>) -> Vec<OpBatch> {
     let mut batches = Vec::<OpBatch>::new();
     let mut batch_acc = OpBatchAccumulator::new();

--- a/core/src/mast/node/basic_block_node/mod.rs
+++ b/core/src/mast/node/basic_block_node/mod.rs
@@ -3,7 +3,6 @@ use core::fmt;
 
 use miden_crypto::{hash::rpo::RpoDigest, Felt, ZERO};
 use miden_formatting::prettier::PrettyPrint;
-use winter_utils::flatten_slice_elements;
 
 use crate::{
     chiplets::hasher, mast::MastForestError, Decorator, DecoratorIterator, DecoratorList, Operation,
@@ -110,7 +109,7 @@ impl BasicBlockNode {
         digest: RpoDigest,
     ) -> Self {
         assert!(!operations.is_empty());
-        let (op_batches, _) = batch_ops(operations);
+        let op_batches = batch_ops(operations);
         Self { op_batches, digest, decorators }
     }
 }
@@ -315,11 +314,11 @@ impl<'a> Iterator for OperationOrDecoratorIterator<'a> {
 /// Groups the provided operations into batches and computes the hash of the block.
 fn batch_and_hash_ops(ops: Vec<Operation>) -> (Vec<OpBatch>, RpoDigest) {
     // Group the operations into batches.
-    let (batches, batch_groups) = batch_ops(ops);
+    let batches = batch_ops(ops);
 
     // Compute the hash of all operation groups.
-    let op_groups = &flatten_slice_elements(&batch_groups);
-    let hash = hasher::hash_elements(op_groups);
+    let op_groups: Vec<Felt> = batches.iter().flat_map(|batch| batch.groups).collect();
+    let hash = hasher::hash_elements(&op_groups);
 
     (batches, hash)
 }
@@ -327,10 +326,9 @@ fn batch_and_hash_ops(ops: Vec<Operation>) -> (Vec<OpBatch>, RpoDigest) {
 /// Groups the provided operations into batches as described in the docs for this module (i.e.,
 /// up to 9 operations per group, and 8 groups per batch).
 /// Returns a list of operation batches and a list of operation groups.
-fn batch_ops(ops: Vec<Operation>) -> (Vec<OpBatch>, Vec<[Felt; BATCH_SIZE]>) {
+fn batch_ops(ops: Vec<Operation>) -> Vec<OpBatch> {
     let mut batches = Vec::<OpBatch>::new();
     let mut batch_acc = OpBatchAccumulator::new();
-    let mut batch_groups = Vec::<[Felt; BATCH_SIZE]>::new();
 
     for op in ops {
         // If the operation cannot be accepted into the current accumulator, add the contents of
@@ -339,7 +337,6 @@ fn batch_ops(ops: Vec<Operation>) -> (Vec<OpBatch>, Vec<[Felt; BATCH_SIZE]>) {
             let batch = batch_acc.into_batch();
             batch_acc = OpBatchAccumulator::new();
 
-            batch_groups.push(*batch.groups());
             batches.push(batch);
         }
 
@@ -350,10 +347,10 @@ fn batch_ops(ops: Vec<Operation>) -> (Vec<OpBatch>, Vec<[Felt; BATCH_SIZE]>) {
     // Make sure we finished processing the last batch.
     if !batch_acc.is_empty() {
         let batch = batch_acc.into_batch();
-        batch_groups.push(*batch.groups());
         batches.push(batch);
     }
-    (batches, batch_groups)
+
+    batches
 }
 
 /// Checks if a given decorators list is valid (only checked in debug mode)


### PR DESCRIPTION
Small PR that simplifies `batch_ops()` by not returning redundant information (i.e. batch groups).

I also used `Iterator::flat_map` instead of `winter_utils::flatten_slice_elements` since it's more canonical, and doesn't affect performance (blake3 benchmark). I also wouldn't be surprised if it compiled down to the same code after compiler optimizations.
