### PR TITLE
feat: add `PartialEq`,`Eq` and `De/Serialize` for `AdviceInputs` and `AdviceMap`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.10.6 (TBD)
+
+#### Enhancements
+
+- Added `PartialEq`, `Eq`, `Serialize` and `Deserialize` to `AdviceMap` and `AdviceInputs` structs (#1494).
+
 ## 0.10.5 (2024-08-21)
 
 #### Enhancements

--- a/processor/Cargo.toml
+++ b/processor/Cargo.toml
@@ -21,7 +21,7 @@ doctest = false
 concurrent = ["std", "winter-prover/concurrent"]
 default = ["std"]
 testing = ["miden-air/testing"]
-std = ["vm-core/std", "winter-prover/std"]
+std = ["vm-core/std", "winter-prover/std", "winter-utils/std"]
 
 [dependencies]
 miden-air = { package = "miden-air", path = "../air", version = "0.10", default-features = false }
@@ -34,4 +34,4 @@ assembly = { package = "miden-assembly", path = "../assembly", version = "0.10",
 logtest = { version = "2.0", default-features = false }
 test-utils = { package = "miden-test-utils", path = "../test-utils" }
 winter-fri = { package = "winter-fri", version = "0.9" }
-winter-utils = { package = "winter-utils", version = "0.9" }
+winter-utils = { package = "winter-utils", version = "0.9", default-features = false }

--- a/processor/Cargo.toml
+++ b/processor/Cargo.toml
@@ -21,7 +21,7 @@ doctest = false
 concurrent = ["std", "winter-prover/concurrent"]
 default = ["std"]
 testing = ["miden-air/testing"]
-std = ["vm-core/std", "winter-prover/std", "winter-utils/std"]
+std = ["vm-core/std", "winter-prover/std"]
 
 [dependencies]
 miden-air = { package = "miden-air", path = "../air", version = "0.10", default-features = false }
@@ -34,4 +34,4 @@ assembly = { package = "miden-assembly", path = "../assembly", version = "0.10",
 logtest = { version = "2.0", default-features = false }
 test-utils = { package = "miden-test-utils", path = "../test-utils" }
 winter-fri = { package = "winter-fri", version = "0.9" }
-winter-utils = { package = "winter-utils", version = "0.9", default-features = false }
+winter-utils = { package = "winter-utils", version = "0.9" }

--- a/processor/src/host/advice/inputs.rs
+++ b/processor/src/host/advice/inputs.rs
@@ -1,6 +1,8 @@
 use alloc::vec::Vec;
 
+use miden_air::DeserializationError;
 use vm_core::crypto::hash::RpoDigest;
+use winter_utils::{ByteReader, ByteWriter, Deserializable, Serializable};
 
 use super::{AdviceMap, Felt, InnerNodeInfo, InputError, MerkleStore};
 
@@ -19,7 +21,7 @@ use super::{AdviceMap, Felt, InnerNodeInfo, InputError, MerkleStore};
 /// 3. Merkle store, which is used to provide nondeterministic inputs for instructions that operates
 ///    with Merkle trees.
 #[cfg(not(feature = "testing"))]
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct AdviceInputs {
     stack: Vec<Felt>,
     map: AdviceMap,
@@ -132,11 +134,29 @@ impl AdviceInputs {
     }
 }
 
+impl Serializable for AdviceInputs {
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        let Self { stack, map, store } = self;
+        stack.write_into(target);
+        map.write_into(target);
+        store.write_into(target);
+    }
+}
+
+impl Deserializable for AdviceInputs {
+    fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
+        let stack = Vec::<Felt>::read_from(source)?;
+        let map = AdviceMap::read_from(source)?;
+        let store = MerkleStore::read_from(source)?;
+        Ok(Self { stack, map, store })
+    }
+}
+
 // TESTING
 // ================================================================================================
 
 #[cfg(feature = "testing")]
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct AdviceInputs {
     pub stack: Vec<Felt>,
     pub map: AdviceMap,

--- a/processor/src/host/advice/inputs.rs
+++ b/processor/src/host/advice/inputs.rs
@@ -1,8 +1,7 @@
 use alloc::vec::Vec;
 
-use miden_air::DeserializationError;
 use vm_core::crypto::hash::RpoDigest;
-use winter_utils::{ByteReader, ByteWriter, Deserializable, Serializable};
+use vm_core::utils::{ByteReader, ByteWriter, Deserializable, Serializable, DeserializationError};
 
 use super::{AdviceMap, Felt, InnerNodeInfo, InputError, MerkleStore};
 

--- a/processor/src/host/advice/inputs.rs
+++ b/processor/src/host/advice/inputs.rs
@@ -171,7 +171,7 @@ pub struct AdviceInputs {
 mod tests {
     use winter_utils::{Deserializable, Serializable};
 
-    use crate::{host::advice, AdviceInputs};
+    use crate::AdviceInputs;
 
     #[test]
     fn test_advice_inputs_eq() {

--- a/processor/src/host/advice/inputs.rs
+++ b/processor/src/host/advice/inputs.rs
@@ -1,7 +1,9 @@
 use alloc::vec::Vec;
 
-use vm_core::crypto::hash::RpoDigest;
-use vm_core::utils::{ByteReader, ByteWriter, Deserializable, Serializable, DeserializationError};
+use vm_core::{
+    crypto::hash::RpoDigest,
+    utils::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable},
+};
 
 use super::{AdviceMap, Felt, InnerNodeInfo, InputError, MerkleStore};
 
@@ -160,4 +162,36 @@ pub struct AdviceInputs {
     pub stack: Vec<Felt>,
     pub map: AdviceMap,
     pub store: MerkleStore,
+}
+
+// TESTS
+// ================================================================================================
+
+#[cfg(test)]
+mod tests {
+    use winter_utils::{Deserializable, Serializable};
+
+    use crate::{host::advice, AdviceInputs};
+
+    #[test]
+    fn test_advice_inputs_eq() {
+        let advice1 = AdviceInputs::default();
+        let advice2 = AdviceInputs::default();
+
+        assert_eq!(advice1, advice2);
+
+        let advice1 = AdviceInputs::default().with_stack_values([1, 2, 3].iter().copied()).unwrap();
+        let advice2 = AdviceInputs::default().with_stack_values([1, 2, 3].iter().copied()).unwrap();
+
+        assert_eq!(advice1, advice2);
+    }
+
+    #[test]
+    fn test_advice_inputs_serialization() {
+        let advice1 = AdviceInputs::default().with_stack_values([1, 2, 3].iter().copied()).unwrap();
+        let bytes = advice1.to_bytes();
+        let advice2 = AdviceInputs::read_from_bytes(&bytes).unwrap();
+
+        assert_eq!(advice1, advice2);
+    }
 }

--- a/processor/src/host/advice/map.rs
+++ b/processor/src/host/advice/map.rs
@@ -66,10 +66,9 @@ impl Extend<(RpoDigest, Vec<Felt>)> for AdviceMap {
 
 impl Serializable for AdviceMap {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
-        target.write_u32(self.0.len() as u32);
+        target.write_usize(self.0.len());
         for (key, values) in self.0.iter() {
-            key.write_into(target);
-            values.write_into(target);
+            target.write((key, values));
         }
     }
 }
@@ -77,10 +76,9 @@ impl Serializable for AdviceMap {
 impl Deserializable for AdviceMap {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
         let mut map = BTreeMap::new();
-        let count = source.read_u32()?;
+        let count = source.read_usize()?;
         for _ in 0..count {
-            let key = RpoDigest::read_from(source)?;
-            let values = Vec::<Felt>::read_from(source)?;
+            let (key, values) = source.read()?;
             map.insert(key, values);
         }
         Ok(Self(map))

--- a/processor/src/host/advice/map.rs
+++ b/processor/src/host/advice/map.rs
@@ -3,8 +3,10 @@ use alloc::{
     vec::Vec,
 };
 
-use vm_core::crypto::hash::RpoDigest;
-use vm_core::utils::{Serializable, Deserializable, ByteReader, ByteWriter, DeserializationError};
+use vm_core::{
+    crypto::hash::RpoDigest,
+    utils::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable},
+};
 
 use super::Felt;
 
@@ -82,5 +84,22 @@ impl Deserializable for AdviceMap {
             map.insert(key, values);
         }
         Ok(Self(map))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_advice_map_serialization() {
+        let mut map1 = AdviceMap::new();
+        map1.insert(RpoDigest::default(), vec![Felt::from(1u32), Felt::from(2u32)]);
+
+        let bytes = map1.to_bytes();
+
+        let map2 = AdviceMap::read_from_bytes(&bytes).unwrap();
+
+        assert_eq!(map1, map2);
     }
 }

--- a/processor/src/host/advice/map.rs
+++ b/processor/src/host/advice/map.rs
@@ -3,9 +3,8 @@ use alloc::{
     vec::Vec,
 };
 
-use miden_air::DeserializationError;
 use vm_core::crypto::hash::RpoDigest;
-use winter_utils::{ByteReader, ByteWriter, Deserializable, Serializable};
+use vm_core::utils::{Serializable, Deserializable, ByteReader, ByteWriter, DeserializationError};
 
 use super::Felt;
 
@@ -17,7 +16,7 @@ use super::Felt;
 /// Each key maps to one or more field element. To access the elements, the VM can move the values
 /// associated with a given key onto the advice stack using `adv.push_mapval` instruction. The VM
 /// can also insert new values into the advice map during execution.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct AdviceMap(BTreeMap<RpoDigest, Vec<Felt>>);
 
 impl AdviceMap {


### PR DESCRIPTION
closes #1448 

As @bobbinth said at https://github.com/0xPolygonMiden/miden-base/issues/860#issuecomment-2344897083 , the PR is opened against `main` since it is not a breaking change.