### PR TITLE
Fix block hash table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 #### Fixes
 
 - Fixed an issue with formatting of blocks in Miden Assembly syntax
+- Fixed the construction of the block hash table (#1506)
 
 #### Fixes
 

--- a/processor/src/decoder/aux_trace/mod.rs
+++ b/processor/src/decoder/aux_trace/mod.rs
@@ -41,6 +41,9 @@ impl AuxTraceBuilder {
         let p2 = block_hash_column_builder.build_aux_column(main_trace, rand_elements);
         let p3 = op_group_table_column_builder.build_aux_column(main_trace, rand_elements);
 
+        debug_assert_eq!(*p2.last().unwrap(), E::ONE);
+        debug_assert_eq!(*p3.last().unwrap(), E::ONE);
+
         vec![p1, p2, p3]
     }
 }


### PR DESCRIPTION
Fixes the block hash table.

Note that the block stack table also seems broken (which is why I didn't add a `debug_assert_eq!` statement for `p1`). I will fix it in a subsequent PR.