### PR TITLE
Fix block stack table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 - Fixed an issue with formatting of blocks in Miden Assembly syntax
 - Fixed the construction of the block hash table (#1506)
+- Fixed a bug in the block stack table (#1511)
 
 #### Fixes
 

--- a/processor/src/decoder/aux_trace/block_stack_table.rs
+++ b/processor/src/decoder/aux_trace/block_stack_table.rs
@@ -67,7 +67,7 @@ fn get_block_stack_table_removal_multiplicand<E: FieldElement<BaseField = Felt>>
         let parent_fmp = main_trace.fmp(i + 1);
         let parent_stack_depth = main_trace.stack_depth(i + 1);
         let parent_next_overflow_addr = main_trace.parent_overflow_address(i + 1);
-        let parent_fn_hash = main_trace.fn_hash(i);
+        let parent_fn_hash = main_trace.fn_hash(i + 1);
 
         [
             ONE,
@@ -81,7 +81,7 @@ fn get_block_stack_table_removal_multiplicand<E: FieldElement<BaseField = Felt>>
             parent_fn_hash[0],
             parent_fn_hash[1],
             parent_fn_hash[2],
-            parent_fn_hash[0],
+            parent_fn_hash[3],
         ]
     } else {
         let mut result = [ZERO; 12];
@@ -123,7 +123,7 @@ fn get_block_stack_table_inclusion_multiplicand<E: FieldElement<BaseField = Felt
         let parent_fmp = main_trace.fmp(i);
         let parent_stack_depth = main_trace.stack_depth(i);
         let parent_next_overflow_addr = main_trace.parent_overflow_address(i);
-        let parent_fn_hash = main_trace.decoder_hasher_state_first_half(i);
+        let parent_fn_hash = main_trace.fn_hash(i);
         [
             ONE,
             block_id,

--- a/processor/src/decoder/aux_trace/mod.rs
+++ b/processor/src/decoder/aux_trace/mod.rs
@@ -41,6 +41,7 @@ impl AuxTraceBuilder {
         let p2 = block_hash_column_builder.build_aux_column(main_trace, rand_elements);
         let p3 = op_group_table_column_builder.build_aux_column(main_trace, rand_elements);
 
+        debug_assert_eq!(*p1.last().unwrap(), E::ONE);
         debug_assert_eq!(*p2.last().unwrap(), E::ONE);
         debug_assert_eq!(*p3.last().unwrap(), E::ONE);
 


### PR DESCRIPTION
Fixes the block stack table with the following logic:

- on `CALL`: `fn_hash` contains the parent function hash; it is only set to `callee_hash` in the next row
- on `SYSCALL`: `fn_hash` also contains the parent function hash; it remains unchanged by a syscall
- on `END` for call/syscall: block stack logic resets the `fn_hash` columns to the parent fn hash [only in the next row](https://github.com/0xPolygonMiden/miden-vm/blob/c6e2bc88923780aa15e0680482ac27886cb8351b/processor/src/decoder/mod.rs#L277-L281)