### PR TITLE
Fix block stack table respan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 
 - Fixed an issue with formatting of blocks in Miden Assembly syntax
 - Fixed the construction of the block hash table (#1506)
-- Fixed a bug in the block stack table (#1511)
+- Fixed a bug in the block stack table (#1511) (#1512)
 - Fixed the construction of the chiplets virtual table (#1514)
 - Fixed the construction of the chiplets bus (#1516)
 

--- a/miden/tests/integration/main.rs
+++ b/miden/tests/integration/main.rs
@@ -1,6 +1,6 @@
 extern crate alloc;
 
-use test_utils::build_test;
+use test_utils::{build_op_test, build_test};
 
 mod air;
 mod cli;
@@ -20,4 +20,15 @@ fn simple_program() {
 fn multi_output_program() {
     let test = build_test!("begin mul movup.2 drop end", &[1, 2, 3]);
     test.prove_and_verify(vec![1, 2, 3], false);
+}
+
+#[test]
+fn program_with_respan() {
+    let source = "
+        repeat.49
+            swap dup.1 add
+        end";
+    let pub_inputs = vec![];
+
+    build_op_test!(source, &pub_inputs).prove_and_verify(pub_inputs, false);
 }

--- a/processor/src/decoder/aux_trace/block_stack_table.rs
+++ b/processor/src/decoder/aux_trace/block_stack_table.rs
@@ -55,12 +55,11 @@ fn get_block_stack_table_removal_multiplicand<E: FieldElement<BaseField = Felt>>
     alphas: &[E],
 ) -> E {
     let block_id = main_trace.addr(i);
-    let parent_id = if is_respan {
-        main_trace.decoder_hasher_state_element(1, i + 1)
+    let (parent_id, is_loop) = if is_respan {
+        (main_trace.decoder_hasher_state_element(1, i + 1), ZERO)
     } else {
-        main_trace.addr(i + 1)
+        (main_trace.addr(i + 1), main_trace.is_loop_flag(i))
     };
-    let is_loop = main_trace.is_loop_flag(i);
 
     let elements = if main_trace.is_call_flag(i) == ONE || main_trace.is_syscall_flag(i) == ONE {
         let parent_ctx = main_trace.ctx(i + 1);

--- a/processor/src/decoder/aux_trace/mod.rs
+++ b/processor/src/decoder/aux_trace/mod.rs
@@ -41,8 +41,21 @@ impl AuxTraceBuilder {
         let p2 = block_hash_column_builder.build_aux_column(main_trace, rand_elements);
         let p3 = op_group_table_column_builder.build_aux_column(main_trace, rand_elements);
 
-        debug_assert_eq!(*p2.last().unwrap(), E::ONE);
-        debug_assert_eq!(*p3.last().unwrap(), E::ONE);
+        debug_assert_eq!(
+            *p1.last().unwrap(),
+            E::ONE,
+            "block stack table is not empty at the end of program execution"
+        );
+        debug_assert_eq!(
+            *p2.last().unwrap(),
+            E::ONE,
+            "block hash table is not empty at the end of program execution"
+        );
+        debug_assert_eq!(
+            *p3.last().unwrap(),
+            E::ONE,
+            "op group table is not empty at the end of program execution"
+        );
 
         vec![p1, p2, p3]
     }


### PR DESCRIPTION
There was still a bug after #1511 with how the a `RESPAN` operation fetches the `is_loop` virtual column of the block stack table.

The fix is to set `is_loop` to `ZERO` when removing a row from a `RESPAN`, since the `is_loop` flag (read in `hasher_state[5]`) only applies to the `END` operation. For requests, it will only be set for the `LOOP` opcode.