### PR TITLE
Serialize decorator data at the end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - [BREAKING] `Process` no longer takes ownership of the `Host` (#1571)
 - [BREAKING] `ProcessState` was converted from a trait to a struct (#1571)
 - [BREAKING] `Host` and `AdviceProvider` traits simplified (#1572)
+- [BREAKING] `MastForest` serialization/deserialization will store/read decorator data at the end of the binary (#1531)
 
 #### Enhancements
 - Added `miden_core::mast::MastForest::advice_map` to load it into the advice provider before the `MastForest` execution (#1574).

--- a/core/src/mast/mod.rs
+++ b/core/src/mast/mod.rs
@@ -537,8 +537,9 @@ impl MastNodeId {
         Self::from_u32_with_node_count(value, mast_forest.nodes.len())
     }
 
-    /// Returns a new [`MastNodeId`] with the provided `node_id`, or an error if `node_id` is greater
-    /// than the number of nodes in the [`MastForest`] for which this ID is being constructed.
+    /// Returns a new [`MastNodeId`] with the provided `node_id`, or an error if `node_id` is
+    /// greater than the number of nodes in the [`MastForest`] for which this ID is being
+    /// constructed.
     pub fn from_usize_safe(
         node_id: usize,
         mast_forest: &MastForest,

--- a/core/src/mast/mod.rs
+++ b/core/src/mast/mod.rs
@@ -199,10 +199,6 @@ impl MastForest {
         Some(id_remappings)
     }
 
-    pub fn set_decorators(&mut self, node_id: MastNodeId, decorator_list: DecoratorList) {
-        self[node_id].set_decorators(decorator_list)
-    }
-
     pub fn set_before_enter(&mut self, node_id: MastNodeId, decorator_ids: Vec<DecoratorId>) {
         self[node_id].set_before_enter(decorator_ids)
     }
@@ -541,6 +537,18 @@ impl MastNodeId {
         Self::from_u32_with_node_count(value, mast_forest.nodes.len())
     }
 
+    pub fn from_usize_safe(
+        node_id: usize,
+        mast_forest: &MastForest,
+    ) -> Result<Self, DeserializationError> {
+        let node_id: u32 = node_id.try_into().map_err(|_| {
+            DeserializationError::InvalidValue(format!(
+                "Invalid node id '{node_id}' while deserializing"
+            ))
+        })?;
+        MastNodeId::from_u32_safe(node_id, mast_forest)
+    }
+
     /// Returns a new [`MastNodeId`] from the given `value` without checking its validity.
     pub(crate) fn new_unchecked(value: u32) -> Self {
         Self(value)
@@ -597,20 +605,6 @@ impl From<MastNodeId> for u32 {
 impl From<&MastNodeId> for u32 {
     fn from(value: &MastNodeId) -> Self {
         value.0
-    }
-}
-
-impl TryFrom<(usize, &MastForest)> for MastNodeId {
-    type Error = DeserializationError;
-
-    fn try_from(value: (usize, &MastForest)) -> Result<Self, Self::Error> {
-        let (node_id, mast_forest) = value;
-        let node_id: u32 = node_id.try_into().map_err(|_| {
-            DeserializationError::InvalidValue(format!(
-                "Invalid node id '{node_id}' while deserializing"
-            ))
-        })?;
-        MastNodeId::from_u32_safe(node_id, mast_forest)
     }
 }
 

--- a/core/src/mast/mod.rs
+++ b/core/src/mast/mod.rs
@@ -537,6 +537,8 @@ impl MastNodeId {
         Self::from_u32_with_node_count(value, mast_forest.nodes.len())
     }
 
+    /// Returns a new [`MastNodeId`] with the provided `node_id`, or an error if `node_id` is greater
+    /// than the number of nodes in the [`MastForest`] for which this ID is being constructed.
     pub fn from_usize_safe(
         node_id: usize,
         mast_forest: &MastForest,

--- a/core/src/mast/mod.rs
+++ b/core/src/mast/mod.rs
@@ -14,7 +14,7 @@ pub use node::{
     BasicBlockNode, CallNode, DynNode, ExternalNode, JoinNode, LoopNode, MastNode, OpBatch,
     OperationOrDecorator, SplitNode, OP_BATCH_SIZE, OP_GROUP_SIZE,
 };
-use winter_utils::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable};
+use winter_utils::{ByteWriter, DeserializationError, Serializable};
 
 use crate::{AdviceMap, Decorator, DecoratorList, Operation};
 
@@ -543,7 +543,7 @@ impl MastNodeId {
     ) -> Result<Self, DeserializationError> {
         let node_id: u32 = node_id.try_into().map_err(|_| {
             DeserializationError::InvalidValue(format!(
-                "Invalid node id '{node_id}' while deserializing"
+                "node id '{node_id}' does not fit into a u32"
             ))
         })?;
         MastNodeId::from_u32_safe(node_id, mast_forest)
@@ -683,12 +683,6 @@ impl fmt::Display for DecoratorId {
 impl Serializable for DecoratorId {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
         self.0.write_into(target)
-    }
-}
-
-impl Deserializable for DecoratorId {
-    fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
-        Ok(DecoratorId::new_unchecked(source.read()?))
     }
 }
 

--- a/core/src/mast/node/basic_block_node/mod.rs
+++ b/core/src/mast/node/basic_block_node/mod.rs
@@ -224,6 +224,12 @@ impl BasicBlockNode {
             decorator_ids.into_iter().map(|decorator_id| (after_last_op_idx, decorator_id)),
         );
     }
+
+    /// Used to initialize decorators for the [`BasicBlockNode`]. Replaces the existing decorators
+    /// with the given ['DecoratorList'].
+    pub fn init_decorators(&mut self, decorator_list: DecoratorList) {
+        self.decorators = decorator_list;
+    }
 }
 
 // PRETTY PRINTING

--- a/core/src/mast/node/basic_block_node/mod.rs
+++ b/core/src/mast/node/basic_block_node/mod.rs
@@ -227,7 +227,7 @@ impl BasicBlockNode {
 
     /// Used to initialize decorators for the [`BasicBlockNode`]. Replaces the existing decorators
     /// with the given ['DecoratorList'].
-    pub fn init_decorators(&mut self, decorator_list: DecoratorList) {
+    pub fn set_decorators(&mut self, decorator_list: DecoratorList) {
         self.decorators = decorator_list;
     }
 }

--- a/core/src/mast/node/mod.rs
+++ b/core/src/mast/node/mod.rs
@@ -236,20 +236,6 @@ impl MastNode {
 
 /// Mutators
 impl MastNode {
-    /// Sets the list of decorators for the [`MastNode`]. Currently, is only supported for the
-    /// [`Block`] variant.
-    pub fn set_decorators(&mut self, decorator_list: DecoratorList) {
-        match self {
-            MastNode::Block(node) => node.init_decorators(decorator_list),
-            MastNode::Join(_) => (),
-            MastNode::Split(_) => (),
-            MastNode::Loop(_) => (),
-            MastNode::Call(_) => (),
-            MastNode::Dyn(_) => (),
-            MastNode::External(_) => (),
-        }
-    }
-
     /// Sets the list of decorators to be executed before this node.
     pub fn set_before_enter(&mut self, decorator_ids: Vec<DecoratorId>) {
         match self {

--- a/core/src/mast/node/mod.rs
+++ b/core/src/mast/node/mod.rs
@@ -236,6 +236,20 @@ impl MastNode {
 
 /// Mutators
 impl MastNode {
+    /// Sets the list of decorators for the [`MastNode`]. Currently, is only supported for the
+    /// [`Block`] variant.
+    pub fn set_decorators(&mut self, decorator_list: DecoratorList) {
+        match self {
+            MastNode::Block(node) => node.init_decorators(decorator_list),
+            MastNode::Join(_) => (),
+            MastNode::Split(_) => (),
+            MastNode::Loop(_) => (),
+            MastNode::Call(_) => (),
+            MastNode::Dyn(_) => (),
+            MastNode::External(_) => (),
+        }
+    }
+
     /// Sets the list of decorators to be executed before this node.
     pub fn set_before_enter(&mut self, decorator_ids: Vec<DecoratorId>) {
         match self {

--- a/core/src/mast/serialization/basic_blocks.rs
+++ b/core/src/mast/serialization/basic_blocks.rs
@@ -2,11 +2,8 @@ use alloc::vec::Vec;
 
 use winter_utils::{ByteReader, DeserializationError, Serializable, SliceReader};
 
-use super::{DecoratorDataOffset, NodeDataOffset};
-use crate::{
-    mast::{BasicBlockNode, DecoratorId, MastForest},
-    DecoratorList, Operation,
-};
+use super::NodeDataOffset;
+use crate::{mast::BasicBlockNode, Operation};
 
 // BASIC BLOCK DATA BUILDER
 // ================================================================================================
@@ -26,24 +23,15 @@ impl BasicBlockDataBuilder {
 
 /// Mutators
 impl BasicBlockDataBuilder {
-    /// Encodes a [`BasicBlockNode`] into the serialized [`crate::mast::MastForest`] data field.
-    pub fn encode_basic_block(
-        &mut self,
-        basic_block: &BasicBlockNode,
-    ) -> (NodeDataOffset, Option<DecoratorDataOffset>) {
+    /// Encodes a [`BasicBlockNode`]'s operations into the serialized [`crate::mast::MastForest`]
+    /// data field. The decorators are not encoded because are stored separately
+    pub fn encode_basic_block(&mut self, basic_block: &BasicBlockNode) -> NodeDataOffset {
         let ops_offset = self.node_data.len() as NodeDataOffset;
 
         let operations: Vec<Operation> = basic_block.operations().copied().collect();
         operations.write_into(&mut self.node_data);
 
-        if basic_block.decorators().is_empty() {
-            (ops_offset, None)
-        } else {
-            let decorator_data_offset = self.node_data.len() as DecoratorDataOffset;
-            basic_block.decorators().write_into(&mut self.node_data);
-
-            (ops_offset, Some(decorator_data_offset))
-        }
+        ops_offset
     }
 
     /// Returns the serialized [`crate::mast::MastForest`] node data field.
@@ -68,35 +56,14 @@ impl<'a> BasicBlockDataDecoder<'a> {
 
 /// Decoding methods
 impl BasicBlockDataDecoder<'_> {
-    pub fn decode_operations_and_decorators(
+    pub fn decode_operations(
         &self,
         ops_offset: NodeDataOffset,
-        decorator_list_offset: NodeDataOffset,
-        mast_forest: &MastForest,
-    ) -> Result<(Vec<Operation>, DecoratorList), DeserializationError> {
+    ) -> Result<Vec<Operation>, DeserializationError> {
         // Read ops
         let mut ops_data_reader = SliceReader::new(&self.node_data[ops_offset as usize..]);
         let operations: Vec<Operation> = ops_data_reader.read()?;
 
-        // read decorators only if there are some
-        let decorators = if decorator_list_offset == MastForest::MAX_DECORATORS as u32 {
-            Vec::new()
-        } else {
-            let mut decorators_data_reader =
-                SliceReader::new(&self.node_data[decorator_list_offset as usize..]);
-
-            let num_decorators: usize = decorators_data_reader.read()?;
-            (0..num_decorators)
-                .map(|_| {
-                    let decorator_loc: usize = decorators_data_reader.read()?;
-                    let decorator_id =
-                        DecoratorId::from_u32_safe(decorators_data_reader.read()?, mast_forest)?;
-
-                    Ok((decorator_loc, decorator_id))
-                })
-                .collect::<Result<DecoratorList, _>>()?
-        };
-
-        Ok((operations, decorators))
+        Ok(operations)
     }
 }

--- a/core/src/mast/serialization/decorator.rs
+++ b/core/src/mast/serialization/decorator.rs
@@ -220,20 +220,14 @@ impl DecoratorDataBuilder {
 /// Mutators
 impl DecoratorDataBuilder {
     pub fn add_decorator(&mut self, decorator: &Decorator) {
-        let decorator_data_offset =
-            self.encode_decorator_data(decorator).unwrap_or(0);
-        self.decorator_infos.push(DecoratorInfo::from_decorator(
-            decorator,
-            decorator_data_offset,
-        ));
+        let decorator_data_offset = self.encode_decorator_data(decorator).unwrap_or(0);
+        self.decorator_infos
+            .push(DecoratorInfo::from_decorator(decorator, decorator_data_offset));
     }
 
     /// If a decorator has extra data to store, encode it in internal data buffer, and return the
     /// offset of the newly added data. If not, return `None`.
-    pub fn encode_decorator_data(
-        &mut self,
-        decorator: &Decorator,
-    ) -> Option<DecoratorDataOffset> {
+    pub fn encode_decorator_data(&mut self, decorator: &Decorator) -> Option<DecoratorDataOffset> {
         let data_offset = self.decorator_data.len() as DecoratorDataOffset;
 
         match decorator {
@@ -253,7 +247,8 @@ impl DecoratorDataBuilder {
 
                 // context name
                 {
-                    let str_offset = self.string_table_builder.add_string(assembly_op.context_name());
+                    let str_offset =
+                        self.string_table_builder.add_string(assembly_op.context_name());
                     self.decorator_data.write_usize(str_offset);
                 }
 
@@ -295,6 +290,10 @@ impl DecoratorDataBuilder {
 
     /// Returns the serialized [`crate::mast::MastForest`] decorator data field.
     pub fn finalize(self) -> (Vec<u8>, Vec<DecoratorInfo>, StringTable) {
-        (self.decorator_data, self.decorator_infos, self.string_table_builder.into_table())
+        (
+            self.decorator_data,
+            self.decorator_infos,
+            self.string_table_builder.into_table(),
+        )
     }
 }

--- a/core/src/mast/serialization/info.rs
+++ b/core/src/mast/serialization/info.rs
@@ -1,4 +1,4 @@
-use std::vec::Vec;
+use alloc::vec::Vec;
 
 use miden_crypto::hash::rpo::RpoDigest;
 use winter_utils::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable};

--- a/core/src/mast/serialization/mod.rs
+++ b/core/src/mast/serialization/mod.rs
@@ -195,15 +195,14 @@ impl Deserializable for MastForest {
         // Reading Decorators
         let decorator_data: Vec<u8> = Deserializable::read_from(source)?;
         let string_table: StringTable = Deserializable::read_from(source)?;
-        let decorator_infos: Vec<DecoratorInfo> =
-            decorator_infos_iter(source, decorator_count)
-                .collect::<Result<Vec<DecoratorInfo>, DeserializationError>>()?;
+        let decorator_infos = decorator_infos_iter(source, decorator_count);
 
         // Constructing MastForest
         let mut mast_forest = {
             let mut mast_forest = MastForest::new();
 
             for decorator_info in decorator_infos {
+                let decorator_info = decorator_info?;
                 let decorator =
                     decorator_info.try_into_decorator(&string_table, &decorator_data)?;
 
@@ -250,7 +249,7 @@ impl Deserializable for MastForest {
                 },
                 other => {
                     return Err(DeserializationError::InvalidValue(format!(
-                        "Expected mast node with id {node_id} to be a basic block, found {other:?}"
+                        "expected mast node with id {node_id} to be a basic block, found {other:?}"
                     )))
                 },
             }

--- a/core/src/mast/serialization/mod.rs
+++ b/core/src/mast/serialization/mod.rs
@@ -5,8 +5,9 @@
 //! - VERSION
 //!
 //! (sections metadata)
-//! - decorators length (`usize`)
 //! - nodes length (`usize`)
+//! - decorator data section offset (`usize`) (not implemented, see issue #1580)
+//! - decorators length (`usize`)
 //!
 //! (procedure roots section)
 //! - procedure roots (`Vec<MastNodeId>`)

--- a/core/src/mast/serialization/mod.rs
+++ b/core/src/mast/serialization/mod.rs
@@ -18,6 +18,9 @@
 //! (node info section)
 //! - MAST node infos (`Vec<MastNodeInfo>`)
 //!
+//! (advice map section)
+//! - Advice map (AdviceMap)
+//!
 //! (decorator data section)
 //! - Decorator data
 //! - String table
@@ -329,7 +332,7 @@ where
     R: ByteReader + 'a,
 {
     let mut remaining = decorator_count;
-    std::iter::from_fn(move || {
+    core::iter::from_fn(move || {
         if remaining == 0 {
             return None;
         }
@@ -346,7 +349,7 @@ where
     R: ByteReader + 'a,
 {
     let mut remaining = node_count;
-    std::iter::from_fn(move || {
+    core::iter::from_fn(move || {
         if remaining == 0 {
             return None;
         }

--- a/core/src/mast/serialization/mod.rs
+++ b/core/src/mast/serialization/mod.rs
@@ -142,8 +142,8 @@ impl Serializable for MastForest {
         // write all decorator data below
 
         let mut decorator_data_builder = DecoratorDataBuilder::new();
-        for decorator in self.decorators {
-            decorator_data_builder.add_decorator(&decorator)
+        for decorator in &self.decorators {
+            decorator_data_builder.add_decorator(decorator)
         }
 
         let (decorator_data, decorator_infos, string_table) = decorator_data_builder.finalize();

--- a/core/src/mast/serialization/mod.rs
+++ b/core/src/mast/serialization/mod.rs
@@ -4,21 +4,27 @@
 //! - MAGIC
 //! - VERSION
 //!
-//! (lengths)
-//! - decorators length (`usize`)
+//! (nodes metadata)
 //! - nodes length (`usize`)
 //!
 //! (procedure roots)
 //! - procedure roots (`Vec<MastNodeId>`)
 //!
 //! (raw data)
-//! - Decorator data
 //! - Node data
+//!
+//! (node info structs)
+//! - MAST node infos (`Vec<MastNodeInfo>`)
+//!
+//! (decorators metadata)
+//! - decorators length (`usize`)
+//!
+//! (raw decorator data)
+//! - Decorator data
 //! - String table
 //!
-//! (info structs)
+//! (decorator info structs)
 //! - decorator infos (`Vec<DecoratorInfo>`)
-//! - MAST node infos (`Vec<MastNodeInfo>`)
 //!
 //! (before enter and after exit decorators)
 //! - before enter decorators (`Vec<(MastNodeId, Vec<DecoratorId>)>`)
@@ -136,9 +142,9 @@ impl Serializable for MastForest {
         // write all decorator data below
 
         let mut decorator_data_builder = DecoratorDataBuilder::new();
-        self.decorators
-            .iter()
-            .for_each(|decorator| decorator_data_builder.add_decorator(decorator));
+        for decorator in self.decorators {
+            decorator_data_builder.add_decorator(&decorator)
+        }
 
         let (decorator_data, decorator_infos, string_table) = decorator_data_builder.finalize();
 


### PR DESCRIPTION
## Describe your changes
Moving all decorator data to the end in order to enable truncating it later. See issue #1489 

Contains a minor refactor to make writing decorator info more direct by reducing interconnected layers of indirection.
Also extracted some functions from the Serializer code to make it easer follow.

## Checklist before requesting a review
- [x] Repo forked and branch created from `next` according to naming convention.
- [x] Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- [x] Relevant issues are linked in the PR description.
- [x] Tests added for new functionality. (No new tests)
- [x] Documentation/comments updated according to changes. (No Doc changes)
