### PR TITLE
Rename `EqHash` to `MastNodeFingerprint`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Migrated to new padding rule for RPO (#1343).
 - Migrated to `miden-crypto` v0.11.0 (#1343).
 - Implemented `MastForest` merging (#1534)
+- Rename `EqHash` to `MastNodeFingerprint` and make it `pub` (#1539)
 
 #### Fixes
 

--- a/assembly/src/assembler/mast_forest_builder.rs
+++ b/assembly/src/assembler/mast_forest_builder.rs
@@ -450,6 +450,7 @@ impl MastForestBuilder {
 impl MastForestBuilder {
     fn fingerprint_for_node(&self, node: &MastNode) -> MastNodeFingerprint {
         MastNodeFingerprint::from_mast_node(&self.mast_forest, &self.hash_by_node_id, node)
+            .expect("hash_by_node_id should contain the fingerprints of all children of `node`")
     }
 }
 

--- a/assembly/src/assembler/mast_forest_builder.rs
+++ b/assembly/src/assembler/mast_forest_builder.rs
@@ -5,8 +5,10 @@ use alloc::{
 use core::ops::{Index, IndexMut};
 
 use vm_core::{
-    crypto::hash::{Blake3Digest, RpoDigest},
-    mast::{DecoratorId, EqHash, MastForest, MastNode, MastNodeId},
+    crypto::hash::RpoDigest,
+    mast::{
+        DecoratorFingerprint, DecoratorId, MastForest, MastNode, MastNodeFingerprint, MastNodeId,
+    },
     Decorator, DecoratorList, Operation,
 };
 
@@ -46,13 +48,13 @@ pub struct MastForestBuilder {
     /// map, this map contains only the first inserted procedure for procedures with the same MAST
     /// root.
     proc_gid_by_mast_root: BTreeMap<RpoDigest, GlobalProcedureIndex>,
-    /// A map of MAST node eq hashes to their corresponding positions in the MAST forest.
-    node_id_by_hash: BTreeMap<EqHash, MastNodeId>,
-    /// The reverse mapping of `node_id_by_hash`. This map caches the eq hashes of all nodes (for
-    /// performance reasons).
-    hash_by_node_id: BTreeMap<MastNodeId, EqHash>,
-    /// A map of decorator hashes to their corresponding positions in the MAST forest.
-    decorator_id_by_hash: BTreeMap<Blake3Digest<32>, DecoratorId>,
+    /// A map of MAST node fingerprints to their corresponding positions in the MAST forest.
+    node_id_by_fingerprint: BTreeMap<MastNodeFingerprint, MastNodeId>,
+    /// The reverse mapping of `node_id_by_fingerprint`. This map caches the fingerprints of all
+    /// nodes (for performance reasons).
+    hash_by_node_id: BTreeMap<MastNodeId, MastNodeFingerprint>,
+    /// A map of decorator fingerprints to their corresponding positions in the MAST forest.
+    decorator_id_by_fingerprint: BTreeMap<DecoratorFingerprint, DecoratorId>,
     /// A set of IDs for basic blocks which have been merged into a bigger basic blocks. This is
     /// used as a candidate set of nodes that may be eliminated if the are not referenced by any
     /// other node in the forest and are not a root of any procedure.
@@ -339,14 +341,14 @@ impl MastForestBuilder {
 impl MastForestBuilder {
     /// Adds a decorator to the forest, and returns the [`Decorator`] associated with it.
     pub fn ensure_decorator(&mut self, decorator: Decorator) -> Result<DecoratorId, AssemblyError> {
-        let decorator_hash = decorator.eq_hash();
+        let decorator_hash = decorator.fingerprint();
 
-        if let Some(decorator_id) = self.decorator_id_by_hash.get(&decorator_hash) {
+        if let Some(decorator_id) = self.decorator_id_by_fingerprint.get(&decorator_hash) {
             // decorator already exists in the forest; return previously assigned id
             Ok(*decorator_id)
         } else {
             let new_decorator_id = self.mast_forest.add_decorator(decorator)?;
-            self.decorator_id_by_hash.insert(decorator_hash, new_decorator_id);
+            self.decorator_id_by_fingerprint.insert(decorator_hash, new_decorator_id);
 
             Ok(new_decorator_id)
         }
@@ -358,15 +360,15 @@ impl MastForestBuilder {
     /// MAST forest; two nodes that have the same MAST root and decorators will have the same
     /// [`MastNodeId`].
     pub fn ensure_node(&mut self, node: MastNode) -> Result<MastNodeId, AssemblyError> {
-        let node_hash = self.eq_hash_for_node(&node);
+        let node_fingerprint = self.fingerprint_for_node(&node);
 
-        if let Some(node_id) = self.node_id_by_hash.get(&node_hash) {
+        if let Some(node_id) = self.node_id_by_fingerprint.get(&node_fingerprint) {
             // node already exists in the forest; return previously assigned id
             Ok(*node_id)
         } else {
             let new_node_id = self.mast_forest.add_node(node)?;
-            self.node_id_by_hash.insert(node_hash, new_node_id);
-            self.hash_by_node_id.insert(new_node_id, node_hash);
+            self.node_id_by_fingerprint.insert(node_fingerprint, new_node_id);
+            self.hash_by_node_id.insert(new_node_id, node_fingerprint);
 
             Ok(new_node_id)
         }
@@ -433,21 +435,21 @@ impl MastForestBuilder {
     pub fn set_before_enter(&mut self, node_id: MastNodeId, decorator_ids: Vec<DecoratorId>) {
         self.mast_forest[node_id].set_before_enter(decorator_ids);
 
-        let new_node_hash = self.eq_hash_for_node(&self[node_id]);
-        self.hash_by_node_id.insert(node_id, new_node_hash);
+        let new_node_fingerprint = self.fingerprint_for_node(&self[node_id]);
+        self.hash_by_node_id.insert(node_id, new_node_fingerprint);
     }
 
     pub fn set_after_exit(&mut self, node_id: MastNodeId, decorator_ids: Vec<DecoratorId>) {
         self.mast_forest[node_id].set_after_exit(decorator_ids);
 
-        let new_node_hash = self.eq_hash_for_node(&self[node_id]);
-        self.hash_by_node_id.insert(node_id, new_node_hash);
+        let new_node_fingerprint = self.fingerprint_for_node(&self[node_id]);
+        self.hash_by_node_id.insert(node_id, new_node_fingerprint);
     }
 }
 
 impl MastForestBuilder {
-    fn eq_hash_for_node(&self, node: &MastNode) -> EqHash {
-        EqHash::from_mast_node(&self.mast_forest, &self.hash_by_node_id, node)
+    fn fingerprint_for_node(&self, node: &MastNode) -> MastNodeFingerprint {
+        MastNodeFingerprint::from_mast_node(&self.mast_forest, &self.hash_by_node_id, node)
     }
 }
 

--- a/core/src/mast/merger/mod.rs
+++ b/core/src/mast/merger/mod.rs
@@ -186,6 +186,9 @@ impl MastForestMerger {
             &self.mast_forest,
             &self.hash_by_node_id,
             &remapped_node,
+        )
+        .expect(
+            "hash_by_node_id should contain the fingerprints of all children of `remapped_node`",
         );
 
         match self.lookup_node_by_fingerprint(&node_fingerprint) {

--- a/core/src/mast/merger/tests.rs
+++ b/core/src/mast/merger/tests.rs
@@ -484,12 +484,12 @@ fn mast_forest_merge_external_node_reference_with_decorator() {
     .enumerate()
     {
         let id_foo_a_fingerprint =
-            EqHash::from_mast_node(&forest_a, &BTreeMap::new(), &forest_a[id_foo_a]);
+            MastNodeFingerprint::from_mast_node(&forest_a, &BTreeMap::new(), &forest_a[id_foo_a]);
 
         let fingerprints: Vec<_> = merged
             .nodes()
             .iter()
-            .map(|node| EqHash::from_mast_node(&merged, &BTreeMap::new(), node))
+            .map(|node| MastNodeFingerprint::from_mast_node(&merged, &BTreeMap::new(), node))
             .collect();
 
         assert_eq!(merged.nodes.len(), 1);
@@ -552,12 +552,12 @@ fn mast_forest_merge_external_node_with_decorator() {
         assert_eq!(merged.nodes.len(), 1);
 
         let id_foo_b_fingerprint =
-            EqHash::from_mast_node(&forest_a, &BTreeMap::new(), &forest_b[id_foo_b]);
+            MastNodeFingerprint::from_mast_node(&forest_a, &BTreeMap::new(), &forest_b[id_foo_b]);
 
         let fingerprints: Vec<_> = merged
             .nodes()
             .iter()
-            .map(|node| EqHash::from_mast_node(&merged, &BTreeMap::new(), node))
+            .map(|node| MastNodeFingerprint::from_mast_node(&merged, &BTreeMap::new(), node))
             .collect();
 
         // Block foo should be unmodified.
@@ -622,12 +622,12 @@ fn mast_forest_merge_external_node_and_referenced_node_have_decorators() {
         assert_eq!(merged.nodes.len(), 1);
 
         let id_foo_b_fingerprint =
-            EqHash::from_mast_node(&forest_b, &BTreeMap::new(), &forest_b[id_foo_b]);
+            MastNodeFingerprint::from_mast_node(&forest_b, &BTreeMap::new(), &forest_b[id_foo_b]);
 
         let fingerprints: Vec<_> = merged
             .nodes()
             .iter()
-            .map(|node| EqHash::from_mast_node(&merged, &BTreeMap::new(), node))
+            .map(|node| MastNodeFingerprint::from_mast_node(&merged, &BTreeMap::new(), node))
             .collect();
 
         // Block foo should be unmodified.
@@ -700,12 +700,12 @@ fn mast_forest_merge_multiple_external_nodes_with_decorator() {
         assert_eq!(merged.nodes.len(), 1);
 
         let id_foo_b_fingerprint =
-            EqHash::from_mast_node(&forest_a, &BTreeMap::new(), &forest_b[id_foo_b]);
+            MastNodeFingerprint::from_mast_node(&forest_a, &BTreeMap::new(), &forest_b[id_foo_b]);
 
         let fingerprints: Vec<_> = merged
             .nodes()
             .iter()
-            .map(|node| EqHash::from_mast_node(&merged, &BTreeMap::new(), node))
+            .map(|node| MastNodeFingerprint::from_mast_node(&merged, &BTreeMap::new(), node))
             .collect();
 
         // Block foo should be unmodified.

--- a/core/src/mast/mod.rs
+++ b/core/src/mast/mod.rs
@@ -663,4 +663,6 @@ pub enum MastForestError {
     DecoratorIdOverflow(DecoratorId, usize),
     #[error("basic block cannot be created from an empty list of operations")]
     EmptyBasicBlock,
+    #[error("decorator root of child with node id {0} is missing but required for fingerprint computation")]
+    ChildFingerprintMissing(MastNodeId),
 }

--- a/core/src/mast/mod.rs
+++ b/core/src/mast/mod.rs
@@ -7,11 +7,7 @@ use core::{
     ops::{Index, IndexMut},
 };
 
-use miden_crypto::hash::{
-    blake::{Blake3Digest, Blake3_256},
-    rpo::RpoDigest,
-    Digest,
-};
+use miden_crypto::hash::rpo::RpoDigest;
 
 mod node;
 pub use node::{
@@ -30,6 +26,9 @@ pub use merger::MastForestRootMap;
 
 mod multi_forest_node_iterator;
 pub(crate) use multi_forest_node_iterator::*;
+
+mod node_fingerprint;
+pub use node_fingerprint::{DecoratorFingerprint, MastNodeFingerprint};
 
 #[cfg(test)]
 mod tests;
@@ -639,166 +638,6 @@ impl fmt::Display for DecoratorId {
 impl Serializable for DecoratorId {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
         self.0.write_into(target)
-    }
-}
-
-// MAST NODE EQUALITY
-// ================================================================================================
-
-/// Represents the hash used to test for equality between [`MastNode`]s.
-///
-/// The decorator root will be `None` if and only if there are no decorators attached to the node,
-/// and all children have no decorator roots (meaning that there are no decorators in all the
-/// descendants).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub struct EqHash {
-    mast_root: RpoDigest,
-    decorator_root: Option<Blake3Digest<32>>,
-}
-
-// TODO: Document public functions and assumptions about forest and the index map.
-impl EqHash {
-    pub fn new(mast_root: RpoDigest) -> Self {
-        Self { mast_root, decorator_root: None }
-    }
-
-    pub fn with_decorator_root(mast_root: RpoDigest, decorator_root: Blake3Digest<32>) -> Self {
-        Self {
-            mast_root,
-            decorator_root: Some(decorator_root),
-        }
-    }
-
-    pub fn from_mast_node(
-        forest: &MastForest,
-        hash_by_node_id: &BTreeMap<MastNodeId, EqHash>,
-        node: &MastNode,
-    ) -> EqHash {
-        match node {
-            MastNode::Block(node) => {
-                let mut bytes_to_hash = Vec::new();
-
-                for &(idx, decorator_id) in node.decorators() {
-                    bytes_to_hash.extend(idx.to_le_bytes());
-                    bytes_to_hash.extend(forest[decorator_id].eq_hash().as_bytes());
-                }
-
-                // Add any `Assert` or `U32assert2` opcodes present, since these are not included in
-                // the MAST root.
-                for (op_idx, op) in node.operations().enumerate() {
-                    if let Operation::U32assert2(inner_value)
-                    | Operation::Assert(inner_value)
-                    | Operation::MpVerify(inner_value) = op
-                    {
-                        let op_idx: u32 = op_idx
-                            .try_into()
-                            .expect("there are more than 2^{32}-1 operations in basic block");
-
-                        // we include the opcode to differentiate between `Assert` and `U32assert2`
-                        bytes_to_hash.push(op.op_code());
-                        // we include the operation index to distinguish between basic blocks that
-                        // would have the same assert instructions, but in a different order
-                        bytes_to_hash.extend(op_idx.to_le_bytes());
-                        bytes_to_hash.extend(inner_value.to_le_bytes());
-                    }
-                }
-
-                if bytes_to_hash.is_empty() {
-                    EqHash::new(node.digest())
-                } else {
-                    let decorator_root = Blake3_256::hash(&bytes_to_hash);
-                    EqHash::with_decorator_root(node.digest(), decorator_root)
-                }
-            },
-            MastNode::Join(node) => eq_hash_from_parts(
-                forest,
-                hash_by_node_id,
-                node.before_enter(),
-                node.after_exit(),
-                &[node.first(), node.second()],
-                node.digest(),
-            ),
-            MastNode::Split(node) => eq_hash_from_parts(
-                forest,
-                hash_by_node_id,
-                node.before_enter(),
-                node.after_exit(),
-                &[node.on_true(), node.on_false()],
-                node.digest(),
-            ),
-            MastNode::Loop(node) => eq_hash_from_parts(
-                forest,
-                hash_by_node_id,
-                node.before_enter(),
-                node.after_exit(),
-                &[node.body()],
-                node.digest(),
-            ),
-            MastNode::Call(node) => eq_hash_from_parts(
-                forest,
-                hash_by_node_id,
-                node.before_enter(),
-                node.after_exit(),
-                &[node.callee()],
-                node.digest(),
-            ),
-            MastNode::Dyn(node) => eq_hash_from_parts(
-                forest,
-                hash_by_node_id,
-                node.before_enter(),
-                node.after_exit(),
-                &[],
-                node.digest(),
-            ),
-            MastNode::External(node) => eq_hash_from_parts(
-                forest,
-                hash_by_node_id,
-                node.before_enter(),
-                node.after_exit(),
-                &[],
-                node.digest(),
-            ),
-        }
-    }
-}
-
-fn eq_hash_from_parts(
-    forest: &MastForest,
-    hash_by_node_id: &BTreeMap<MastNodeId, EqHash>,
-    before_enter_ids: &[DecoratorId],
-    after_exit_ids: &[DecoratorId],
-    children_ids: &[MastNodeId],
-    node_digest: RpoDigest,
-) -> EqHash {
-    let pre_decorator_hash_bytes =
-        before_enter_ids.iter().flat_map(|&id| forest[id].eq_hash().as_bytes());
-    let post_decorator_hash_bytes =
-        after_exit_ids.iter().flat_map(|&id| forest[id].eq_hash().as_bytes());
-
-    // Reminder: the `EqHash`'s decorator root will be `None` if and only if there are no
-    // decorators attached to the node, and all children have no decorator roots (meaning that
-    // there are no decorators in all the descendants).
-    if pre_decorator_hash_bytes.clone().next().is_none()
-        && post_decorator_hash_bytes.clone().next().is_none()
-        && children_ids
-            .iter()
-            .filter_map(|child_id| hash_by_node_id[child_id].decorator_root)
-            .next()
-            .is_none()
-    {
-        EqHash::new(node_digest)
-    } else {
-        let children_decorator_roots = children_ids
-            .iter()
-            .filter_map(|child_id| hash_by_node_id[child_id].decorator_root)
-            .flat_map(|decorator_root| decorator_root.as_bytes());
-        let decorator_bytes_to_hash: Vec<u8> = pre_decorator_hash_bytes
-            .chain(post_decorator_hash_bytes)
-            .chain(children_decorator_roots)
-            .collect();
-
-        let decorator_root = Blake3_256::hash(&decorator_bytes_to_hash);
-        EqHash::with_decorator_root(node_digest, decorator_root)
     }
 }
 

--- a/core/src/mast/node_fingerprint.rs
+++ b/core/src/mast/node_fingerprint.rs
@@ -46,8 +46,10 @@ impl MastNodeFingerprint {
 
     /// Creates a [`MastNodeFingerprint`] from a [`MastNode`].
     ///
+    /// # Panics
+    ///
     /// The `hash_by_node_id` map must contain all children of the node for efficient lookup of
-    /// their fingerprints.
+    /// their fingerprints. This function panics if a child of the given `node` is not in this map.
     pub fn from_mast_node(
         forest: &MastForest,
         hash_by_node_id: &BTreeMap<MastNodeId, MastNodeFingerprint>,

--- a/core/src/mast/node_fingerprint.rs
+++ b/core/src/mast/node_fingerprint.rs
@@ -64,8 +64,8 @@ impl MastNodeFingerprint {
                     bytes_to_hash.extend(forest[decorator_id].fingerprint().as_bytes());
                 }
 
-                // Add any `Assert` or `U32assert2` opcodes present, since these are not included in
-                // the MAST root.
+                // Add any `Assert`, `U32assert2` and `MpVerify` opcodes present, since these are
+                // not included in the MAST root.
                 for (op_idx, op) in node.operations().enumerate() {
                     if let Operation::U32assert2(inner_value)
                     | Operation::Assert(inner_value)

--- a/core/src/mast/node_fingerprint.rs
+++ b/core/src/mast/node_fingerprint.rs
@@ -1,0 +1,190 @@
+use alloc::{collections::BTreeMap, vec::Vec};
+
+use miden_crypto::hash::{
+    blake::{Blake3Digest, Blake3_256},
+    rpo::RpoDigest,
+    Digest,
+};
+
+use crate::{
+    mast::{DecoratorId, MastForest, MastNode, MastNodeId},
+    Operation,
+};
+
+// MAST NODE EQUALITY
+// ================================================================================================
+
+pub type DecoratorFingerprint = Blake3Digest<32>;
+
+/// Represents the hash used to test for equality between [`MastNode`]s.
+///
+/// The decorator root will be `None` if and only if there are no decorators attached to the node,
+/// and all children have no decorator roots (meaning that there are no decorators in all the
+/// descendants).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct MastNodeFingerprint {
+    mast_root: RpoDigest,
+    decorator_root: Option<DecoratorFingerprint>,
+}
+
+// ------------------------------------------------------------------------------------------------
+/// Constructors
+impl MastNodeFingerprint {
+    /// Creates a new [`MastNodeFingerprint`] from the given MAST root with an empty decorator root.
+    pub fn new(mast_root: RpoDigest) -> Self {
+        Self { mast_root, decorator_root: None }
+    }
+
+    /// Creates a new [`MastNodeFingerprint`] from the given MAST root and the given
+    /// [`DecoratorFingerprint`].
+    pub fn with_decorator_root(mast_root: RpoDigest, decorator_root: DecoratorFingerprint) -> Self {
+        Self {
+            mast_root,
+            decorator_root: Some(decorator_root),
+        }
+    }
+
+    /// Creates a [`MastNodeFingerprint`] from a [`MastNode`].
+    ///
+    /// The `hash_by_node_id` map must contain all children of the node for efficient lookup of
+    /// their fingerprints.
+    pub fn from_mast_node(
+        forest: &MastForest,
+        hash_by_node_id: &BTreeMap<MastNodeId, MastNodeFingerprint>,
+        node: &MastNode,
+    ) -> MastNodeFingerprint {
+        match node {
+            MastNode::Block(node) => {
+                let mut bytes_to_hash = Vec::new();
+
+                for &(idx, decorator_id) in node.decorators() {
+                    bytes_to_hash.extend(idx.to_le_bytes());
+                    bytes_to_hash.extend(forest[decorator_id].fingerprint().as_bytes());
+                }
+
+                // Add any `Assert` or `U32assert2` opcodes present, since these are not included in
+                // the MAST root.
+                for (op_idx, op) in node.operations().enumerate() {
+                    if let Operation::U32assert2(inner_value)
+                    | Operation::Assert(inner_value)
+                    | Operation::MpVerify(inner_value) = op
+                    {
+                        let op_idx: u32 = op_idx
+                            .try_into()
+                            .expect("there are more than 2^{32}-1 operations in basic block");
+
+                        // we include the opcode to differentiate between `Assert` and `U32assert2`
+                        bytes_to_hash.push(op.op_code());
+                        // we include the operation index to distinguish between basic blocks that
+                        // would have the same assert instructions, but in a different order
+                        bytes_to_hash.extend(op_idx.to_le_bytes());
+                        bytes_to_hash.extend(inner_value.to_le_bytes());
+                    }
+                }
+
+                if bytes_to_hash.is_empty() {
+                    MastNodeFingerprint::new(node.digest())
+                } else {
+                    let decorator_root = Blake3_256::hash(&bytes_to_hash);
+                    MastNodeFingerprint::with_decorator_root(node.digest(), decorator_root)
+                }
+            },
+            MastNode::Join(node) => fingerprint_from_parts(
+                forest,
+                hash_by_node_id,
+                node.before_enter(),
+                node.after_exit(),
+                &[node.first(), node.second()],
+                node.digest(),
+            ),
+            MastNode::Split(node) => fingerprint_from_parts(
+                forest,
+                hash_by_node_id,
+                node.before_enter(),
+                node.after_exit(),
+                &[node.on_true(), node.on_false()],
+                node.digest(),
+            ),
+            MastNode::Loop(node) => fingerprint_from_parts(
+                forest,
+                hash_by_node_id,
+                node.before_enter(),
+                node.after_exit(),
+                &[node.body()],
+                node.digest(),
+            ),
+            MastNode::Call(node) => fingerprint_from_parts(
+                forest,
+                hash_by_node_id,
+                node.before_enter(),
+                node.after_exit(),
+                &[node.callee()],
+                node.digest(),
+            ),
+            MastNode::Dyn(node) => fingerprint_from_parts(
+                forest,
+                hash_by_node_id,
+                node.before_enter(),
+                node.after_exit(),
+                &[],
+                node.digest(),
+            ),
+            MastNode::External(node) => fingerprint_from_parts(
+                forest,
+                hash_by_node_id,
+                node.before_enter(),
+                node.after_exit(),
+                &[],
+                node.digest(),
+            ),
+        }
+    }
+}
+
+// ------------------------------------------------------------------------------------------------
+/// Accessors
+impl MastNodeFingerprint {
+    pub fn mast_root(&self) -> &RpoDigest {
+        &self.mast_root
+    }
+}
+
+fn fingerprint_from_parts(
+    forest: &MastForest,
+    hash_by_node_id: &BTreeMap<MastNodeId, MastNodeFingerprint>,
+    before_enter_ids: &[DecoratorId],
+    after_exit_ids: &[DecoratorId],
+    children_ids: &[MastNodeId],
+    node_digest: RpoDigest,
+) -> MastNodeFingerprint {
+    let pre_decorator_hash_bytes =
+        before_enter_ids.iter().flat_map(|&id| forest[id].fingerprint().as_bytes());
+    let post_decorator_hash_bytes =
+        after_exit_ids.iter().flat_map(|&id| forest[id].fingerprint().as_bytes());
+
+    // Reminder: the `MastNodeFingerprint`'s decorator root will be `None` if and only if there are
+    // no decorators attached to the node, and all children have no decorator roots (meaning
+    // that there are no decorators in all the descendants).
+    if pre_decorator_hash_bytes.clone().next().is_none()
+        && post_decorator_hash_bytes.clone().next().is_none()
+        && children_ids
+            .iter()
+            .filter_map(|child_id| hash_by_node_id[child_id].decorator_root)
+            .next()
+            .is_none()
+    {
+        MastNodeFingerprint::new(node_digest)
+    } else {
+        let children_decorator_roots = children_ids
+            .iter()
+            .filter_map(|child_id| hash_by_node_id[child_id].decorator_root)
+            .flat_map(|decorator_root| decorator_root.as_bytes());
+        let decorator_bytes_to_hash: Vec<u8> = pre_decorator_hash_bytes
+            .chain(post_decorator_hash_bytes)
+            .chain(children_decorator_roots)
+            .collect();
+
+        let decorator_root = Blake3_256::hash(&decorator_bytes_to_hash);
+        MastNodeFingerprint::with_decorator_root(node_digest, decorator_root)
+    }
+}

--- a/core/src/operations/decorators/mod.rs
+++ b/core/src/operations/decorators/mod.rs
@@ -1,7 +1,7 @@
 use alloc::{string::ToString, vec::Vec};
 use core::fmt;
 
-use miden_crypto::hash::blake::{Blake3Digest, Blake3_256};
+use miden_crypto::hash::blake::Blake3_256;
 use num_traits::ToBytes;
 
 mod advice;
@@ -13,7 +13,7 @@ pub use assembly_op::AssemblyOp;
 mod debug;
 pub use debug::DebugOptions;
 
-use crate::mast::DecoratorId;
+use crate::mast::{DecoratorFingerprint, DecoratorId};
 
 // DECORATORS
 // ================================================================================================
@@ -40,7 +40,7 @@ pub enum Decorator {
 }
 
 impl Decorator {
-    pub fn eq_hash(&self) -> Blake3Digest<32> {
+    pub fn fingerprint(&self) -> DecoratorFingerprint {
         match self {
             Self::Advice(advice) => Blake3_256::hash(advice.to_string().as_bytes()),
             Self::AsmOp(asm_op) => {


### PR DESCRIPTION
## Describe your changes

Renames `EqHash` to `MastNodeFingerprint` as a follow-up to #1534 and moves the fingerprint to its own module.

## Checklist before requesting a review

- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
