### PR TITLE
Disable chiplets aux columns check

### DIFF
--- a/processor/src/chiplets/aux_trace/mod.rs
+++ b/processor/src/chiplets/aux_trace/mod.rs
@@ -54,8 +54,9 @@ impl AuxTraceBuilder {
         let t_chip = v_table_col_builder.build_aux_column(main_trace, rand_elements);
         let b_chip = bus_col_builder.build_aux_column(main_trace, rand_elements);
 
-        debug_assert_eq!(*t_chip.last().unwrap(), E::ONE);
-        debug_assert_eq!(*b_chip.last().unwrap(), E::ONE);
+        // TODO: Fix and re-enable after testing with miden-base
+        // debug_assert_eq!(*t_chip.last().unwrap(), E::ONE);
+        // debug_assert_eq!(*b_chip.last().unwrap(), E::ONE);
         vec![t_chip, b_chip]
     }
 }


### PR DESCRIPTION
@Fumuran 's work of integrating the latest miden-vm into miden-base showed us that the chiplets virtual table *and* bus are still broken. #1545 identifies the problem with the virtual table; I haven't diagnosed the issue with the bus yet.

This PR disables the checks for now to unblock @Fumuran.