### PR TITLE
fix: use unchecked constructor for `ProcedureName` on `Library` deserialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - [BREAKING] `DYNCALL` operation fixed, and now expects a memory address pointing to the procedure hash (#1535).
 - Permit child `MastNodeId`s to exceed the `MastNodeId`s of their parents (#1542).
 - Make `miden-prover::prove()` method conditionally asynchronous (#1563).
+- Don't validate export names on `Library` deserialization (#1554)
 
 #### Fixes
 

--- a/assembly/src/library/mod.rs
+++ b/assembly/src/library/mod.rs
@@ -1,18 +1,19 @@
 use alloc::{
     collections::{BTreeMap, BTreeSet},
-    string::{String, ToString},
+    string::String,
     sync::Arc,
     vec::Vec,
 };
 
 use vm_core::{
     crypto::hash::RpoDigest,
+    debuginfo::Span,
     mast::{MastForest, MastNodeId},
     utils::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable},
     Kernel,
 };
 
-use crate::ast::{ProcedureName, QualifiedProcedureName};
+use crate::ast::{Ident, ProcedureName, QualifiedProcedureName};
 
 mod error;
 mod module;
@@ -180,8 +181,9 @@ impl Deserializable for Library {
         for _ in 0..num_exports {
             let proc_module = source.read()?;
             let proc_name: String = source.read()?;
-            let proc_name = ProcedureName::new(proc_name)
-                .map_err(|err| DeserializationError::InvalidValue(err.to_string()))?;
+            let proc_name = ProcedureName::new_unchecked(Ident::new_unchecked(Span::unknown(
+                Arc::from(proc_name),
+            )));
             let proc_name = QualifiedProcedureName::new(proc_module, proc_name);
             let proc_node_id = MastNodeId::from_u32_safe(source.read_u32()?, &mast_forest)?;
 


### PR DESCRIPTION
## Describe your changes

Following the conversation with @bitwalker the checked constructor fits only when parsing MASM code. The Miden package contains the export names crafted according to the Wasm CM naming scheme, i.e. `namespace:package/interface@version#function`. 
Discovered in https://github.com/0xPolygonMiden/compiler/issues/347 when parsing the Miden package file of the basic wallet account code.
The test for the failing case added in #1544 in the `Package` deserialization test suite at https://github.com/0xPolygonMiden/miden-vm/blob/9ff342eacb24315c784e95cea3eeb1f87058fc06/package/src/tests.rs#L136-L147.


## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
