### PR TITLE
Fix block stack table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 
 - Fixed an issue with formatting of blocks in Miden Assembly syntax
 - Fixed the construction of the block hash table (#1506)
-- Fixed a bug in the block stack table (#1511) (#1512)
+- Fixed a bug in the block stack table (#1511) (#1512) (#1557)
 - Fixed the construction of the chiplets virtual table (#1514) (#1556)
 - Fixed the construction of the chiplets bus (#1516) (#1525)
 - Decorators are now allowed in empty basic blocks (#1466)

--- a/processor/src/decoder/aux_trace/mod.rs
+++ b/processor/src/decoder/aux_trace/mod.rs
@@ -42,6 +42,11 @@ impl AuxTraceBuilder {
         let p3 = op_group_table_column_builder.build_aux_column(main_trace, rand_elements);
 
         debug_assert_eq!(
+            *p1.last().unwrap(),
+            E::ONE,
+            "block stack table is not empty at the end of program execution"
+        );
+        debug_assert_eq!(
             *p2.last().unwrap(),
             E::ONE,
             "block hash table is not empty at the end of program execution"


### PR DESCRIPTION
Fixes block stack table (once again). 

The problem this time was that the code that removed a row (on `RESPAN` or `END`) would always read the `IS_CALL` and `IS_SYSCALL` flags, which are only valid on an `END` operation. The blake3 benchmark happened to have a `RESPAN` operation with a few `RESPAN`s that had a `1` in one of these rows. The fix is then to completely separate these 2 code paths.

I confirmed that all `miden-base` tests pass.