### PR TITLE
Fix chiplets bus

### DIFF
--- a/processor/src/chiplets/aux_trace/mod.rs
+++ b/processor/src/chiplets/aux_trace/mod.rs
@@ -63,8 +63,7 @@ impl AuxTraceBuilder {
         let b_chip = bus_col_builder.build_aux_column(main_trace, rand_elements);
 
         debug_assert_eq!(*t_chip.last().unwrap(), E::ONE);
-        // TODO: Fix and re-enable after testing with miden-base
-        // debug_assert_eq!(*b_chip.last().unwrap(), E::ONE);
+        debug_assert_eq!(*b_chip.last().unwrap(), E::ONE);
         vec![t_chip, b_chip]
     }
 }


### PR DESCRIPTION
It turns out that all "execution-only" tests (e.g. using `Test::get_last_stack_state()`) did not test the construction of the auxiliary columns, since we were not building the aux trace. Adding this uncovered a few bugs.