### PR TITLE
Make prover conditionally asynchronous

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,22 +9,23 @@
 #### Changes
 
 - [BREAKING] Wrapped `MastForest`s in `Program` and `Library` structs in `Arc` (#1465).
-- `MastForestBuilder`: use `MastNodeId` instead of MAST root to uniquely identify procedures (#1473)
+- `MastForestBuilder`: use `MastNodeId` instead of MAST root to uniquely identify procedures (#1473).
 - Added `miden_core::utils::sync::racy_lock` module (#1463).
 - Updated `miden_core::utils` to re-export `std::sync::LazyLock` and `racy_lock::RacyLock as LazyLock` for std and no_std environments, respectively (#1463).
-- Made the undocumented behavior of the VM with regard to undefined behavior of u32 operations, stricter (#1480)
-- Introduced the `Emit` instruction (#1496)
-- Debug instructions can be enabled in the cli `run` command using `--debug` flag (#1502)
-- [BREAKING] ExecutionOptions::new constructor requires a boolean to explicitly set debug mode (#1502)
-- [BREAKING] The `run` and the `prove` commands in the cli will accept `--trace` flag instead of `--tracing` (#1502)
+- Made the undocumented behavior of the VM with regard to undefined behavior of u32 operations, stricter (#1480).
+- Introduced the `Emit` instruction (#1496).
+- Debug instructions can be enabled in the cli `run` command using `--debug` flag (#1502).
+- [BREAKING] ExecutionOptions::new constructor requires a boolean to explicitly set debug mode (#1502).
+- [BREAKING] The `run` and the `prove` commands in the cli will accept `--trace` flag instead of `--tracing` (#1502).
 - Migrated to new padding rule for RPO (#1343).
 - Migrated to `miden-crypto` v0.11.0 (#1343).
-- Implemented `MastForest` merging (#1534)
-- Rename `EqHash` to `MastNodeFingerprint` and make it `pub` (#1539)
+- Implemented `MastForest` merging (#1534).
+- Rename `EqHash` to `MastNodeFingerprint` and make it `pub` (#1539).
 - Updated Winterfell dependency to v0.10 (#1533).
-- [BREAKING] `DYN` operation now expects a memory address pointing to the procedure hash (#1535)
-- [BREAKING] `DYNCALL` operation fixed, and now expects a memory address pointing to the procedure hash (#1535)
-- Permit child `MastNodeId`s to exceed the `MastNodeId`s of their parents (#1542)
+- [BREAKING] `DYN` operation now expects a memory address pointing to the procedure hash (#1535).
+- [BREAKING] `DYNCALL` operation fixed, and now expects a memory address pointing to the procedure hash (#1535).
+- Permit child `MastNodeId`s to exceed the `MastNodeId`s of their parents (#1542).
+- Make `miden-prover::prove()` method conditionally asynchronous (#1563).
 
 #### Fixes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1156,6 +1156,7 @@ dependencies = [
  "miden-processor",
  "pollster",
  "tracing",
+ "winter-maybe-async",
  "winter-prover",
 ]
 

--- a/Makefile
+++ b/Makefile
@@ -11,17 +11,18 @@ DEBUG_ASSERTIONS=RUSTFLAGS="-C debug-assertions"
 FEATURES_CONCURRENT_EXEC=--features concurrent,executable
 FEATURES_LOG_TREE=--features concurrent,executable,tracing-forest
 FEATURES_METAL_EXEC=--features concurrent,executable,metal
+ALL_FEATURES_BUT_ASYNC=--features concurrent,executable,metal,testing,with-debug-info
 
 # -- linting --------------------------------------------------------------------------------------
 
 .PHONY: clippy
 clippy: ## Runs Clippy with configs
-	cargo +nightly clippy --workspace --all-targets --all-features -- -D warnings
+	cargo +nightly clippy --workspace --all-targets ${ALL_FEATURES_BUT_ASYNC} -- -D warnings
 
 
 .PHONY: fix
 fix: ## Runs Fix with configs
-	cargo +nightly fix --allow-staged --allow-dirty --all-targets --all-features
+	cargo +nightly fix --allow-staged --allow-dirty --all-targets ${ALL_FEATURES_BUT_ASYNC}
 
 
 .PHONY: format
@@ -41,7 +42,7 @@ lint: format fix clippy ## Runs all linting tasks at once (Clippy, fixing, forma
 
 .PHONY: doc
 doc: ## Generates & checks documentation
-	$(WARNINGS) cargo doc --all-features --keep-going --release
+	$(WARNINGS) cargo doc ${ALL_FEATURES_BUT_ASYNC} --keep-going --release
 
 .PHONY: mdbook
 mdbook: ## Generates mdbook documentation
@@ -73,7 +74,7 @@ test-package: ## Tests specific package: make test-package package=miden-vm
 
 .PHONY: check
 check: ## Checks all targets and features for errors without code generation
-	cargo check --all-targets --all-features
+	cargo check --all-targets ${ALL_FEATURES_BUT_ASYNC}
 
 # --- building ------------------------------------------------------------------------------------
 

--- a/processor/Cargo.toml
+++ b/processor/Cargo.toml
@@ -20,8 +20,8 @@ doctest = false
 [features]
 concurrent = ["std", "winter-prover/concurrent"]
 default = ["std"]
-testing = ["miden-air/testing"]
 std = ["vm-core/std", "winter-prover/std"]
+testing = ["miden-air/testing"]
 
 [dependencies]
 miden-air = { package = "miden-air", path = "../air", version = "0.10", default-features = false }

--- a/prover/Cargo.toml
+++ b/prover/Cargo.toml
@@ -14,6 +14,7 @@ rust-version.workspace = true
 edition.workspace = true
 
 [features]
+async = ["winter-maybe-async/async"]
 concurrent = ["processor/concurrent", "std", "winter-prover/concurrent"]
 default = ["std"]
 metal = ["dep:miden-gpu", "dep:elsa", "dep:pollster", "concurrent", "std"]
@@ -23,6 +24,7 @@ std = ["air/std", "processor/std", "winter-prover/std"]
 air = { package = "miden-air", path = "../air", version = "0.10", default-features = false }
 processor = { package = "miden-processor", path = "../processor", version = "0.10", default-features = false }
 tracing = { version = "0.1", default-features = false, features = ["attributes"] }
+winter-maybe-async = { package = "winter-maybe-async", version = "0.10", default-features = false }
 winter-prover = { package = "winter-prover", version = "0.10", default-features = false }
 
 [target.'cfg(all(target_arch = "aarch64", target_os = "macos"))'.dependencies]

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -25,6 +25,8 @@ use winter_prover::{
     DefaultTraceLde, ProofOptions as WinterProofOptions, Prover, StarkDomain, TraceInfo,
     TracePolyTable,
 };
+use winter_maybe_async::maybe_async;
+
 #[cfg(feature = "std")]
 use {std::time::Instant, winter_prover::Trace};
 mod gpu;
@@ -206,6 +208,7 @@ where
         PublicInputs::new(program_info, self.stack_inputs.clone(), self.stack_outputs.clone())
     }
 
+    #[maybe_async]
     fn new_trace_lde<E: FieldElement<BaseField = Felt>>(
         &self,
         trace_info: &TraceInfo,
@@ -216,6 +219,7 @@ where
         DefaultTraceLde::new(trace_info, main_trace, domain, partition_options)
     }
 
+    #[maybe_async]
     fn new_evaluator<'a, E: FieldElement<BaseField = Felt>>(
         &self,
         air: &'a ProcessorAir,
@@ -226,6 +230,7 @@ where
     }
 
     #[instrument(skip_all)]
+    #[maybe_async]
     fn build_aux_trace<E: FieldElement<BaseField = Self::BaseField>>(
         &self,
         trace: &Self::Trace,


### PR DESCRIPTION
This PR makes `miden-prover::prove()` method conditionally asynchronous and adds `async` feature to the `miden-prover` crate. These changes are needed to make `miden-base` work with the latest `miden-vm` and also will be needed for #1459.

I also had to modify the Makefile to run all tests/lints etc. without `async` feature enabled as this feature interferes with others. We should find a better way to handle this in the future.