### PR TITLE
Add `MastForest::advice_map` for the data required in the advice provider before execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 - [BREAKING] `Process` no longer takes ownership of the `Host` (#1571)
 - [BREAKING] `ProcessState` was converted from a trait to a struct (#1571)
 
+#### Enhancements
+- Added `miden_core::mast::MastForest::advice_map` to load it into the advice provider before the `MastForest` execution (#1574).
+
 ## 0.11.0 (2024-11-04)
 
 #### Enhancements

--- a/core/src/advice/map.rs
+++ b/core/src/advice/map.rs
@@ -3,12 +3,12 @@ use alloc::{
     vec::Vec,
 };
 
-use vm_core::{
+use miden_crypto::Felt;
+
+use crate::{
     crypto::hash::RpoDigest,
     utils::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable},
 };
-
-use super::Felt;
 
 // ADVICE MAP
 // ================================================================================================

--- a/core/src/advice/map.rs
+++ b/core/src/advice/map.rs
@@ -1,9 +1,10 @@
 use alloc::{
+    boxed::Box,
     collections::{btree_map::IntoIter, BTreeMap},
     vec::Vec,
 };
 
-use miden_crypto::Felt;
+use miden_crypto::{utils::collections::KvMap, Felt};
 
 use crate::{
     crypto::hash::RpoDigest,
@@ -38,8 +39,18 @@ impl AdviceMap {
     }
 
     /// Removes the value associated with the key and returns the removed element.
-    pub fn remove(&mut self, key: RpoDigest) -> Option<Vec<Felt>> {
-        self.0.remove(&key)
+    pub fn remove(&mut self, key: &RpoDigest) -> Option<Vec<Felt>> {
+        self.0.remove(key)
+    }
+
+    /// Returns the number of key value pairs in the advice map.
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Returns true if the advice map is empty.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
     }
 }
 
@@ -55,6 +66,38 @@ impl IntoIterator for AdviceMap {
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.into_iter()
+    }
+}
+
+impl FromIterator<(RpoDigest, Vec<Felt>)> for AdviceMap {
+    fn from_iter<T: IntoIterator<Item = (RpoDigest, Vec<Felt>)>>(iter: T) -> Self {
+        iter.into_iter().collect::<BTreeMap<RpoDigest, Vec<Felt>>>().into()
+    }
+}
+
+impl KvMap<RpoDigest, Vec<Felt>> for AdviceMap {
+    fn get(&self, key: &RpoDigest) -> Option<&Vec<Felt>> {
+        self.0.get(key)
+    }
+
+    fn contains_key(&self, key: &RpoDigest) -> bool {
+        self.0.contains_key(key)
+    }
+
+    fn len(&self) -> usize {
+        self.len()
+    }
+
+    fn insert(&mut self, key: RpoDigest, value: Vec<Felt>) -> Option<Vec<Felt>> {
+        self.insert(key, value)
+    }
+
+    fn remove(&mut self, key: &RpoDigest) -> Option<Vec<Felt>> {
+        self.remove(key)
+    }
+
+    fn iter(&self) -> Box<dyn Iterator<Item = (&RpoDigest, &Vec<Felt>)> + '_> {
+        Box::new(self.0.iter())
     }
 }
 

--- a/core/src/advice/mod.rs
+++ b/core/src/advice/mod.rs
@@ -1,0 +1,1 @@
+pub(super) mod map;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -123,4 +123,7 @@ pub use operations::{
 pub mod stack;
 pub use stack::{StackInputs, StackOutputs};
 
+mod advice;
+pub use advice::map::AdviceMap;
+
 pub mod utils;

--- a/core/src/mast/mod.rs
+++ b/core/src/mast/mod.rs
@@ -16,7 +16,7 @@ pub use node::{
 };
 use winter_utils::{ByteWriter, DeserializationError, Serializable};
 
-use crate::{Decorator, DecoratorList, Operation};
+use crate::{AdviceMap, Decorator, DecoratorList, Operation};
 
 mod serialization;
 
@@ -50,6 +50,9 @@ pub struct MastForest {
 
     /// All the decorators included in the MAST forest.
     decorators: Vec<Decorator>,
+
+    /// Advice map to be loaded into the VM prior to executing procedures from this MAST forest.
+    advice_map: AdviceMap,
 }
 
 // ------------------------------------------------------------------------------------------------
@@ -463,6 +466,14 @@ impl MastForest {
     pub fn nodes(&self) -> &[MastNode] {
         &self.nodes
     }
+
+    pub fn advice_map(&self) -> &AdviceMap {
+        &self.advice_map
+    }
+
+    pub fn advice_map_mut(&mut self) -> &mut AdviceMap {
+        &mut self.advice_map
+    }
 }
 
 impl Index<MastNodeId> for MastForest {
@@ -689,4 +700,6 @@ pub enum MastForestError {
     EmptyBasicBlock,
     #[error("decorator root of child with node id {0} is missing but required for fingerprint computation")]
     ChildFingerprintMissing(MastNodeId),
+    #[error("advice map key already exists when merging forests: {0}")]
+    AdviceMapKeyCollisionOnMerge(RpoDigest),
 }

--- a/core/src/mast/serialization/mod.rs
+++ b/core/src/mast/serialization/mod.rs
@@ -31,6 +31,7 @@ use string_table::{StringTable, StringTableBuilder};
 use winter_utils::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable};
 
 use super::{DecoratorId, MastForest, MastNode, MastNodeId};
+use crate::AdviceMap;
 
 mod decorator;
 
@@ -149,6 +150,8 @@ impl Serializable for MastForest {
         node_data.write_into(target);
         string_table.write_into(target);
 
+        self.advice_map.write_into(target);
+
         // Write decorator and node infos
         for decorator_info in decorator_infos {
             decorator_info.write_into(target);
@@ -187,6 +190,7 @@ impl Deserializable for MastForest {
         let decorator_data: Vec<u8> = Deserializable::read_from(source)?;
         let node_data: Vec<u8> = Deserializable::read_from(source)?;
         let string_table: StringTable = Deserializable::read_from(source)?;
+        let advice_map = AdviceMap::read_from(source)?;
 
         let mut mast_forest = {
             let mut mast_forest = MastForest::new();
@@ -228,6 +232,8 @@ impl Deserializable for MastForest {
                 let root = MastNodeId::from_u32_safe(root, &mast_forest)?;
                 mast_forest.make_root(root);
             }
+
+            mast_forest.advice_map = advice_map;
 
             mast_forest
         };

--- a/miden/benches/program_execution.rs
+++ b/miden/benches/program_execution.rs
@@ -11,7 +11,7 @@ fn program_execution(c: &mut Criterion) {
 
     let stdlib = StdLibrary::default();
     let mut host = DefaultHost::default();
-    host.load_mast_forest(stdlib.as_ref().mast_forest().clone());
+    host.load_mast_forest(stdlib.as_ref().mast_forest().clone()).unwrap();
 
     group.bench_function("sha256", |bench| {
         let source = "

--- a/miden/src/examples/blake3.rs
+++ b/miden/src/examples/blake3.rs
@@ -22,7 +22,7 @@ pub fn get_example(n: usize) -> Example<DefaultHost<MemAdviceProvider>> {
     );
 
     let mut host = DefaultHost::default();
-    host.load_mast_forest(StdLibrary::default().mast_forest().clone());
+    host.load_mast_forest(StdLibrary::default().mast_forest().clone()).unwrap();
 
     let stack_inputs =
         StackInputs::try_from_ints(INITIAL_HASH_VALUE.iter().map(|&v| v as u64)).unwrap();

--- a/miden/src/repl/mod.rs
+++ b/miden/src/repl/mod.rs
@@ -318,7 +318,8 @@ fn execute(
     let stack_inputs = StackInputs::default();
     let mut host = DefaultHost::default();
     for library in provided_libraries {
-        host.load_mast_forest(library.mast_forest().clone());
+        host.load_mast_forest(library.mast_forest().clone())
+            .map_err(|err| format!("{err}"))?;
     }
 
     let state_iter = processor::execute_iter(&program, stack_inputs, &mut host);

--- a/miden/src/tools/mod.rs
+++ b/miden/src/tools/mod.rs
@@ -38,7 +38,8 @@ impl Analyze {
         // fetch the stack and program inputs from the arguments
         let stack_inputs = input_data.parse_stack_inputs().map_err(Report::msg)?;
         let mut host = DefaultHost::new(input_data.parse_advice_provider().map_err(Report::msg)?);
-        host.load_mast_forest(StdLibrary::default().mast_forest().clone());
+        host.load_mast_forest(StdLibrary::default().mast_forest().clone())
+            .into_diagnostic()?;
 
         let execution_details: ExecutionDetails = analyze(program.as_str(), stack_inputs, host)
             .expect("Could not retrieve execution details");

--- a/miden/tests/integration/exec.rs
+++ b/miden/tests/integration/exec.rs
@@ -1,0 +1,53 @@
+use assembly::Assembler;
+use miden_vm::DefaultHost;
+use processor::{ExecutionOptions, MastForest};
+use prover::{Digest, StackInputs};
+use vm_core::{assert_matches, Program, ONE};
+
+#[test]
+fn advice_map_loaded_before_execution() {
+    let source = "\
+    begin
+        push.1.1.1.1
+        adv.push_mapval
+        dropw
+    end";
+
+    // compile and execute program
+    let program_without_advice_map: Program =
+        Assembler::default().assemble_program(source).unwrap();
+
+    // Test `processor::execute` fails if no advice map provided with the program
+    let mut host = DefaultHost::default();
+    match processor::execute(
+        &program_without_advice_map,
+        StackInputs::default(),
+        &mut host,
+        ExecutionOptions::default(),
+    ) {
+        Ok(_) => panic!("Expected error"),
+        Err(e) => {
+            assert_matches!(e, prover::ExecutionError::AdviceMapKeyNotFound(_));
+        },
+    }
+
+    // Test `processor::execute` works if advice map provided with the program
+    let mast_forest: MastForest = (**program_without_advice_map.mast_forest()).clone();
+
+    let key = Digest::new([ONE, ONE, ONE, ONE]);
+    let value = vec![ONE, ONE];
+
+    let mut mast_forest = mast_forest.clone();
+    mast_forest.advice_map_mut().insert(key, value);
+    let program_with_advice_map =
+        Program::new(mast_forest.into(), program_without_advice_map.entrypoint());
+
+    let mut host = DefaultHost::default();
+    processor::execute(
+        &program_with_advice_map,
+        StackInputs::default(),
+        &mut host,
+        ExecutionOptions::default(),
+    )
+    .unwrap();
+}

--- a/miden/tests/integration/main.rs
+++ b/miden/tests/integration/main.rs
@@ -4,6 +4,7 @@ use test_utils::{build_op_test, build_test};
 
 mod air;
 mod cli;
+mod exec;
 mod exec_iters;
 mod flow_control;
 mod operations;

--- a/miden/tests/integration/operations/decorators/mod.rs
+++ b/miden/tests/integration/operations/decorators/mod.rs
@@ -31,6 +31,16 @@ impl Default for TestHost<MemAdviceProvider> {
 }
 
 impl<A: AdviceProvider> Host for TestHost<A> {
+    type AdviceProvider = A;
+
+    fn advice_provider(&self) -> &Self::AdviceProvider {
+        &self.adv_provider
+    }
+
+    fn advice_provider_mut(&mut self) -> &mut Self::AdviceProvider {
+        &mut self.adv_provider
+    }
+
     fn get_advice(
         &mut self,
         process: ProcessState,

--- a/processor/src/errors.rs
+++ b/processor/src/errors.rs
@@ -24,6 +24,7 @@ use crate::ContextId;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ExecutionError {
     AdviceMapKeyNotFound(Word),
+    AdviceMapKeyAlreadyPresent(Word),
     AdviceStackReadFailed(RowIndex),
     CallerNotInSyscall,
     CircularExternalNode(Digest),
@@ -101,6 +102,10 @@ impl Display for ExecutionError {
             AdviceMapKeyNotFound(key) => {
                 let hex = to_hex(Felt::elements_as_bytes(key));
                 write!(f, "Value for key {hex} not present in the advice map")
+            },
+            AdviceMapKeyAlreadyPresent(key) => {
+                let hex = to_hex(Felt::elements_as_bytes(key));
+                write!(f, "Value for key {hex} already present in the advice map")
             },
             AdviceStackReadFailed(step) => write!(f, "Advice stack read failed at step {step}"),
             CallerNotInSyscall => {

--- a/processor/src/host/advice/injectors/adv_map_injectors.rs
+++ b/processor/src/host/advice/injectors/adv_map_injectors.rs
@@ -43,7 +43,7 @@ pub(crate) fn insert_mem_values_into_adv_map<A: AdviceProvider>(
     }
 
     let key = process.get_stack_word(0);
-    advice_provider.insert_into_map(key, values)?;
+    advice_provider.insert_into_map(key, values);
 
     Ok(HostResponse::None)
 }
@@ -76,7 +76,7 @@ pub(crate) fn insert_hdword_into_adv_map<A: AdviceProvider>(
     let mut values = Vec::with_capacity(2 * WORD_SIZE);
     values.extend_from_slice(&word1);
     values.extend_from_slice(&word0);
-    advice_provider.insert_into_map(key.into(), values)?;
+    advice_provider.insert_into_map(key.into(), values);
 
     Ok(HostResponse::None)
 }
@@ -125,7 +125,7 @@ pub(crate) fn insert_hperm_into_adv_map<A: AdviceProvider>(
             .expect("failed to extract digest from state"),
     );
 
-    advice_provider.insert_into_map(key.into(), values)?;
+    advice_provider.insert_into_map(key.into(), values);
 
     Ok(HostResponse::None)
 }

--- a/processor/src/host/advice/inputs.rs
+++ b/processor/src/host/advice/inputs.rs
@@ -3,9 +3,10 @@ use alloc::vec::Vec;
 use vm_core::{
     crypto::hash::RpoDigest,
     utils::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable},
+    AdviceMap,
 };
 
-use super::{AdviceMap, Felt, InnerNodeInfo, InputError, MerkleStore};
+use super::{Felt, InnerNodeInfo, InputError, MerkleStore};
 
 // ADVICE INPUTS
 // ================================================================================================

--- a/processor/src/host/advice/mod.rs
+++ b/processor/src/host/advice/mod.rs
@@ -26,9 +26,6 @@ pub use providers::{MemAdviceProvider, RecAdviceProvider};
 mod source;
 pub use source::AdviceSource;
 
-mod map;
-pub use map::AdviceMap;
-
 // ADVICE PROVIDER
 // ================================================================================================
 

--- a/processor/src/host/advice/mod.rs
+++ b/processor/src/host/advice/mod.rs
@@ -613,7 +613,7 @@ pub trait AdviceProvider: Sized {
     ///
     /// If the specified key is already present in the advice map, the values under the key
     /// are replaced with the specified values.
-    fn insert_into_map(&mut self, key: Word, values: Vec<Felt>) -> Result<(), ExecutionError>;
+    fn insert_into_map(&mut self, key: Word, values: Vec<Felt>);
 
     /// Returns a signature on a message using a public key.
     fn get_signature(
@@ -729,7 +729,7 @@ where
         T::push_stack(self, source)
     }
 
-    fn insert_into_map(&mut self, key: Word, values: Vec<Felt>) -> Result<(), ExecutionError> {
+    fn insert_into_map(&mut self, key: Word, values: Vec<Felt>) {
         T::insert_into_map(self, key, values)
     }
 

--- a/processor/src/host/advice/providers.rs
+++ b/processor/src/host/advice/providers.rs
@@ -131,9 +131,8 @@ where
         self.map.get(key).map(|v| v.as_slice())
     }
 
-    fn insert_into_map(&mut self, key: Word, values: Vec<Felt>) -> Result<(), ExecutionError> {
+    fn insert_into_map(&mut self, key: Word, values: Vec<Felt>) {
         self.map.insert(key.into(), values);
-        Ok(())
     }
 
     // MERKLE STORE
@@ -272,7 +271,7 @@ impl AdviceProvider for MemAdviceProvider {
         self.provider.push_stack(source)
     }
 
-    fn insert_into_map(&mut self, key: Word, values: Vec<Felt>) -> Result<(), ExecutionError> {
+    fn insert_into_map(&mut self, key: Word, values: Vec<Felt>)  {
         self.provider.insert_into_map(key, values)
     }
 
@@ -390,7 +389,7 @@ impl AdviceProvider for RecAdviceProvider {
         self.provider.push_stack(source)
     }
 
-    fn insert_into_map(&mut self, key: Word, values: Vec<Felt>) -> Result<(), ExecutionError> {
+    fn insert_into_map(&mut self, key: Word, values: Vec<Felt>)  {
         self.provider.insert_into_map(key, values)
     }
 

--- a/processor/src/host/mod.rs
+++ b/processor/src/host/mod.rs
@@ -31,8 +31,16 @@ pub use mast_forest_store::{MastForestStore, MemMastForestStore};
 /// state of the VM ([ProcessState]), which it can use to extract the data required to fulfill the
 /// request.
 pub trait Host {
+    type AdviceProvider: AdviceProvider;
+
     // REQUIRED METHODS
     // --------------------------------------------------------------------------------------------
+
+    /// Returns a reference to the advice provider.
+    fn advice_provider(&self) -> &Self::AdviceProvider;
+
+    /// Returns a mutable reference to the advice provider.
+    fn advice_provider_mut(&mut self) -> &mut Self::AdviceProvider;
 
     /// Returns the requested advice, specified by [AdviceExtractor], from the host to the VM.
     fn get_advice(
@@ -174,6 +182,16 @@ impl<H> Host for &mut H
 where
     H: Host,
 {
+    type AdviceProvider = H::AdviceProvider;
+
+    fn advice_provider(&self) -> &Self::AdviceProvider {
+        H::advice_provider(self)
+    }
+
+    fn advice_provider_mut(&mut self) -> &mut Self::AdviceProvider {
+        H::advice_provider_mut(self)
+    }
+
     fn get_advice(
         &mut self,
         process: ProcessState,
@@ -333,6 +351,16 @@ impl<A> Host for DefaultHost<A>
 where
     A: AdviceProvider,
 {
+    type AdviceProvider = A;
+
+    fn advice_provider(&self) -> &Self::AdviceProvider {
+        &self.adv_provider
+    }
+
+    fn advice_provider_mut(&mut self) -> &mut Self::AdviceProvider {
+        &mut self.adv_provider
+    }
+
     fn get_advice(
         &mut self,
         process: ProcessState,

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -18,7 +18,7 @@ pub use vm_core::{
     crypto::merkle::SMT_DEPTH,
     errors::InputError,
     mast::{MastForest, MastNode, MastNodeId},
-    utils::DeserializationError,
+    utils::{collections::KvMap, DeserializationError},
     AdviceInjector, AssemblyOp, Felt, Kernel, Operation, Program, ProgramInfo, QuadExtension,
     StackInputs, StackOutputs, Word, EMPTY_WORD, ONE, ZERO,
 };
@@ -236,6 +236,17 @@ impl Process {
     ) -> Result<StackOutputs, ExecutionError> {
         if self.system.clk() != 0 {
             return Err(ExecutionError::ProgramAlreadyExecuted);
+        }
+
+        // Load the program's advice data into the advice provider
+        for (digest, values) in program.mast_forest().advice_map().iter() {
+            if let Some(stored_values) = host.advice_provider().get_mapped_values(digest) {
+                if stored_values != values {
+                    return Err(ExecutionError::AdviceMapKeyAlreadyPresent(digest.into()));
+                }
+            } else {
+                host.advice_provider_mut().insert_into_map(digest.into(), values.clone());
+            }
         }
 
         self.execute_mast_node(program.entrypoint(), &program.mast_forest().clone(), host)?;

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -48,7 +48,7 @@ use range::RangeChecker;
 mod host;
 pub use host::{
     advice::{
-        AdviceExtractor, AdviceInputs, AdviceMap, AdviceProvider, AdviceSource, MemAdviceProvider,
+        AdviceExtractor, AdviceInputs, AdviceProvider, AdviceSource, MemAdviceProvider,
         RecAdviceProvider,
     },
     DefaultHost, Host, HostResponse, MastForestStore, MemMastForestStore,

--- a/stdlib/tests/mem/mod.rs
+++ b/stdlib/tests/mem/mod.rs
@@ -31,7 +31,7 @@ fn test_memcopy() {
         assembler.assemble_program(source).expect("Failed to compile test source.");
 
     let mut host = DefaultHost::default();
-    host.load_mast_forest(stdlib.mast_forest().clone());
+    host.load_mast_forest(stdlib.mast_forest().clone()).unwrap();
 
     let mut process =
         Process::new(program.kernel().clone(), StackInputs::default(), ExecutionOptions::default());

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -240,10 +240,10 @@ impl Test {
         let (program, kernel) = self.compile().expect("Failed to compile test source.");
         let mut host = DefaultHost::new(MemAdviceProvider::from(self.advice_inputs.clone()));
         if let Some(kernel) = kernel {
-            host.load_mast_forest(kernel.mast_forest().clone());
+            host.load_mast_forest(kernel.mast_forest().clone()).unwrap();
         }
         for library in &self.libraries {
-            host.load_mast_forest(library.mast_forest().clone());
+            host.load_mast_forest(library.mast_forest().clone()).unwrap();
         }
 
         // execute the test
@@ -339,10 +339,10 @@ impl Test {
         let (program, kernel) = self.compile().expect("Failed to compile test source.");
         let mut host = DefaultHost::new(MemAdviceProvider::from(self.advice_inputs.clone()));
         if let Some(kernel) = kernel {
-            host.load_mast_forest(kernel.mast_forest().clone());
+            host.load_mast_forest(kernel.mast_forest().clone()).unwrap();
         }
         for library in &self.libraries {
-            host.load_mast_forest(library.mast_forest().clone());
+            host.load_mast_forest(library.mast_forest().clone()).unwrap();
         }
         processor::execute(
             &program,
@@ -360,10 +360,10 @@ impl Test {
         let (program, kernel) = self.compile().expect("Failed to compile test source.");
         let mut host = DefaultHost::new(MemAdviceProvider::from(self.advice_inputs.clone()));
         if let Some(kernel) = kernel {
-            host.load_mast_forest(kernel.mast_forest().clone());
+            host.load_mast_forest(kernel.mast_forest().clone()).unwrap();
         }
         for library in &self.libraries {
-            host.load_mast_forest(library.mast_forest().clone());
+            host.load_mast_forest(library.mast_forest().clone()).unwrap();
         }
 
         let mut process = Process::new(
@@ -383,10 +383,10 @@ impl Test {
         let (program, kernel) = self.compile().expect("Failed to compile test source.");
         let mut host = DefaultHost::new(MemAdviceProvider::from(self.advice_inputs.clone()));
         if let Some(kernel) = kernel {
-            host.load_mast_forest(kernel.mast_forest().clone());
+            host.load_mast_forest(kernel.mast_forest().clone()).unwrap();
         }
         for library in &self.libraries {
-            host.load_mast_forest(library.mast_forest().clone());
+            host.load_mast_forest(library.mast_forest().clone()).unwrap();
         }
         let (mut stack_outputs, proof) =
             prover::prove(&program, stack_inputs.clone(), &mut host, ProvingOptions::default())
@@ -409,10 +409,10 @@ impl Test {
         let (program, kernel) = self.compile().expect("Failed to compile test source.");
         let mut host = DefaultHost::new(MemAdviceProvider::from(self.advice_inputs.clone()));
         if let Some(kernel) = kernel {
-            host.load_mast_forest(kernel.mast_forest().clone());
+            host.load_mast_forest(kernel.mast_forest().clone()).unwrap();
         }
         for library in &self.libraries {
-            host.load_mast_forest(library.mast_forest().clone());
+            host.load_mast_forest(library.mast_forest().clone()).unwrap();
         }
         processor::execute_iter(&program, self.stack_inputs.clone(), &mut host)
     }


### PR DESCRIPTION
This PR implements VM-facing part of #1547 and adds advice map to the `MastForest` that is loaded in the advice provider when the `MastForest` executed.

This PR contains changes exposing `AdviceProvider` in `Host` (see [commit](https://github.com/0xPolygonMiden/miden-vm/pull/1574/commits/65a306021b00ec13957a795457577ac16191e8ff)) introduced in #1572 (see [comment](https://github.com/0xPolygonMiden/miden-vm/pull/1572#discussion_r1843676098))