### PR TITLE
Update and sync-up the recursive verifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Debug instructions can be enabled in the cli `run` command using `--debug` flag (#1502).
 - Added support for procedure annotation (attribute) syntax to Miden Assembly (#1510).
 - Make `miden-prover::prove()` method conditionally asynchronous (#1563).
+- Update and sync the recursive verifier (#1575).
 
 #### Changes
 

--- a/processor/src/operations/comb_ops.rs
+++ b/processor/src/operations/comb_ops.rs
@@ -14,8 +14,8 @@ impl Process {
     ///            \frac{T_i(x) - T_i(g \cdot z)}{x - g \cdot z} \right)}
     ///
     /// The instruction computes the numerators $\alpha_i \cdot (T_i(x) - T_i(z))$ and
-    /// $\alpha_i \cdot (T_i(x) - T_i(g \cdot z))$ and stores the values in two accumulators $p$
-    /// and $r$, respectively. This instruction is specialized to main trace columns i.e.
+    /// $\alpha_i \cdot (T_i(x) - T_i(g \cdot z))$ and stores the values in two accumulators $r$
+    /// and $p$, respectively. This instruction is specialized to main trace columns i.e.
     /// the values $T_i(x)$ are base field elements.
     ///
     /// The instruction is used in the context of STARK proof verification in order to compute
@@ -44,9 +44,9 @@ impl Process {
     /// 1. Ti for i in 0..=7 stands for the the value of the i-th trace polynomial for the current
     ///    query i.e. T_i(x).
     /// 2. (p0, p1) stands for an extension field element accumulating the values for the quotients
-    ///    with common denominator (x - z).
-    /// 3. (r0, r1) stands for an extension field element accumulating the values for the quotients
     ///    with common denominator (x - gz).
+    /// 3. (r0, r1) stands for an extension field element accumulating the values for the quotients
+    ///    with common denominator (x - z).
     /// 4. x_addr is the memory address from which we are loading the Ti's using the MSTREAM
     ///    instruction.
     /// 5. z_addr is the memory address to the i-th OOD evaluations at z and gz i.e. T_i(z):=
@@ -72,7 +72,7 @@ impl Process {
         // --- compute the updated accumulator values ---------------------------------------------
         let v0 = self.stack.get(7);
         let tx = QuadFelt::new(v0, ZERO);
-        let [p_new, r_new] = [p + alpha * (tx - tz), r + alpha * (tx - tgz)];
+        let [r_new, p_new] = [r + alpha * (tx - tz), p + alpha * (tx - tgz)];
 
         // --- rotate the top 8 elements of the stack ---------------------------------------------
         self.stack.set(0, t0);
@@ -258,8 +258,8 @@ mod tests {
         let a1 = a[1];
         let alpha = QuadFelt::new(a0, a1);
 
-        let p_new = p + alpha * (tx - tz);
-        let r_new = r + alpha * (tx - tgz);
+        let p_new = p + alpha * (tx - tgz);
+        let r_new = r + alpha * (tx - tz);
 
         assert_eq!(p_new.to_base_elements()[1], stack_state[8]);
         assert_eq!(p_new.to_base_elements()[0], stack_state[9]);
@@ -362,10 +362,10 @@ mod tests {
         expected.extend_from_slice(&[ZERO, Felt::from(18_u8), Felt::from(10_u8), Felt::from(2_u8)]);
         // updated accumulators
         expected.extend_from_slice(&[
-            r.to_base_elements()[0],
-            r.to_base_elements()[1],
             p.to_base_elements()[0],
             p.to_base_elements()[1],
+            r.to_base_elements()[0],
+            r.to_base_elements()[1],
         ]);
         // the top 8 stack elements should equal tx since 8 calls to `rcomb_base` implies 8 circular
         // shifts of the top 8 elements i.e., the identity map on the top 8 element.

--- a/processor/src/operations/comb_ops.rs
+++ b/processor/src/operations/comb_ops.rs
@@ -72,7 +72,7 @@ impl Process {
         // --- compute the updated accumulator values ---------------------------------------------
         let v0 = self.stack.get(7);
         let tx = QuadFelt::new(v0, ZERO);
-        let [r_new, p_new] = [r + alpha * (tx - tz), p + alpha * (tx - tgz)];
+        let [p_new, r_new] = [p + alpha * (tx - tgz), r + alpha * (tx - tz)];
 
         // --- rotate the top 8 elements of the stack ---------------------------------------------
         self.stack.set(0, t0);
@@ -337,8 +337,8 @@ mod tests {
         let tz: Vec<QuadFelt> = tz_tgz.iter().step_by(2).map(|e| e.to_owned()).collect();
         let tgz: Vec<QuadFelt> = tz_tgz.iter().skip(1).step_by(2).map(|e| e.to_owned()).collect();
         for i in 0..8 {
-            p += a[i] * (QuadFelt::from(tx[i]) - tz[i]);
-            r += a[i] * (QuadFelt::from(tx[i]) - tgz[i]);
+            p += a[i] * (QuadFelt::from(tx[i]) - tgz[i]);
+            r += a[i] * (QuadFelt::from(tx[i]) - tz[i]);
         }
 
         // prepare the advice stack with the generated data
@@ -362,10 +362,10 @@ mod tests {
         expected.extend_from_slice(&[ZERO, Felt::from(18_u8), Felt::from(10_u8), Felt::from(2_u8)]);
         // updated accumulators
         expected.extend_from_slice(&[
-            p.to_base_elements()[0],
-            p.to_base_elements()[1],
             r.to_base_elements()[0],
             r.to_base_elements()[1],
+            p.to_base_elements()[0],
+            p.to_base_elements()[1],
         ]);
         // the top 8 stack elements should equal tx since 8 calls to `rcomb_base` implies 8 circular
         // shifts of the top 8 elements i.e., the identity map on the top 8 element.

--- a/stdlib/asm/crypto/stark/constants.masm
+++ b/stdlib/asm/crypto/stark/constants.masm
@@ -5,6 +5,8 @@
 const.ROOT_UNITY=7277203076849721926
 const.DOMAIN_OFFSET=7
 const.DOMAIN_OFFSET_INV=2635249152773512046
+const.NUM_CONSTRAINT_COMPOSITION_COEF_MULTIPLIED_BY_TWO_ROUNDED_UP_TO_FOUR=224
+const.NUM_DEEP_COMPOSITION_COEF_MULTIPLIED_BY_TWO_ROUNDED_UP_TO_FOUR=88
 
 
 # MEMORY POINTERS
@@ -157,6 +159,14 @@ end
 
 export.domain_offset_inv
     push.DOMAIN_OFFSET_INV
+end
+
+export.num_constraint_composition_coef_multiplied_by_two_and_rounded_up_to_4
+    push.NUM_CONSTRAINT_COMPOSITION_COEF_MULTIPLIED_BY_TWO_ROUNDED_UP_TO_FOUR
+end
+
+export.num_deep_composition_coef_multiplied_by_two_and_rounded_up_to_4
+    push.NUM_DEEP_COMPOSITION_COEF_MULTIPLIED_BY_TWO_ROUNDED_UP_TO_FOUR
 end
 
 export.public_inputs_ptr

--- a/stdlib/asm/crypto/stark/constants.masm
+++ b/stdlib/asm/crypto/stark/constants.masm
@@ -17,15 +17,15 @@ const.TRACE_DOMAIN_GENERATOR_PTR=4294799999
 const.PUBLIC_INPUTS_PTR=4294800000
 
 # OOD Frames
-# (72 + 9 + 8) * 2 * 2 Felt for current and next trace rows and 8 * 2 Felt for constraint composition
-# polynomials. Total memory slots required: ((72 + 9 + 8) * 2 * 2 + 8 * 2) / 4 = 93
+# (70 + 7) * 2 * 2 Felt for current and next trace rows and 8 * 2 Felt for constraint composition
+# polynomials. Total memory slots required: ((70 + 7) * 2 * 2 + 8 * 2) / 4 = 81
 const.OOD_TRACE_PTR=4294900000
-const.OOD_CONSTRAINT_EVALS_PTR=4294900081
+const.OOD_CONSTRAINT_EVALS_PTR=4294900077
 
 # Current trace row
-# 72 Felt for main portion of trace, 9 * 2 Felt for auxiliary portion of trace and 8 * 2 Felt for
+# 70 Felt for main portion of trace, 7 * 2 Felt for auxiliary portion of trace and 8 * 2 Felt for
 # constraint composition polynomials. Since we store these with the padding to make each of the
-# three portions a multiple of 8, the number of slots required is (80 + 24 + 16) / 4 = 30
+# three portions a multiple of 8, the number of slots required is (72 + 16 + 16) / 4 = 26
 const.CURRENT_TRACE_ROW_PTR=4294900100
 
 # Random elements
@@ -36,7 +36,7 @@ const.AUX_RAND_ELEM_PTR=4294900150
 const.COMPOSITION_COEF_PTR=4294900200
 
 # We need 2 Felt for each trace column and each of the 8 constraint composition columns. We thus need
-# (72 + 9 + 8) * 2 Felt i.e. 44 memory slots.
+# (70 + 7 + 8) * 2 Felt i.e. 43 memory slots.
 const.DEEP_RAND_CC_PTR=4294903000
 
 # FRI
@@ -80,7 +80,6 @@ const.GRINDING_FACTOR_PTR=4294903308
 
 # RPO capacity initialization words
 const.ZERO_WORD_PTR=4294903309
-const.ZERO_ZERO_ZERO_ONE_PTR=4294903310
 
 # State of RPO-based random coin
 const.C_PTR=4294903311
@@ -106,7 +105,7 @@ const.TMP8=4294903322
 #   | TRACE_DOMAIN_GENERATOR_PTR               |       4294799999        |
 #   | PUBLIC_INPUTS_PTR                        |       4294800000        |
 #   | OOD_TRACE_PTR                            |       4294900000        |
-#   | OOD_CONSTRAINT_EVALS_PTR                 |       4294900081        |
+#   | OOD_CONSTRAINT_EVALS_PTR                 |       4294900077        |
 #   | CURRENT_TRACE_ROW_PTR                    |       4294900100        |
 #   | AUX_RAND_ELEM_PTR                        |       4294900150        |
 #   | COMPOSITION_COEF_PTR                     |       4294900200        |
@@ -236,10 +235,6 @@ end
 
 export.zero_word
     push.ZERO_WORD_PTR
-end
-
-export.zero_zero_zero_one_word
-    push.ZERO_ZERO_ZERO_ONE_PTR
 end
 
 #! Returns the pointer to the capacity word of the random coin.

--- a/stdlib/asm/crypto/stark/deep_queries.masm
+++ b/stdlib/asm/crypto/stark/deep_queries.masm
@@ -1,127 +1,5 @@
 use.std::crypto::stark::constants
 
-
-#! Computes a single step of the random linear combination defining the DEEP composition polynomial
-#! that is the input to the FRI protocol. More precisely, the sum in question is:
-#! $$
-#! \sum_{i=0}^k{\alpha_i \cdot \left(\frac{T_i(x) - T_i(z)}{x - z} +
-#!            \frac{T_i(x) - T_i(z \cdot g)}{x - z \cdot g} \right)}
-#! $$
-#!
-#! and the following instruction computes the denominators $\alpha_i \cdot (T_i(x) - T_i(z))$ and
-#! $\alpha_i \cdot (T_i(x) - T_i(z \cdot g))$ and stores the values in two accumulators $r$ and $p$,
-#! respectively. This instruction is specialized to main trace columns i.e. the values $T_i(x)$ are
-#! base field elements.
-#!
-#! The stack transition of the instruction can be visualized as follows:
-#!
-#! +------+------+------+------+------+------+------+------+------+------+------+------+------+------+------+---+
-#! |  T7  |  T6  |  T5  |  T4  |  T3  |  T2  |  T1  |  T0  |  p1  |  p0  |  r1  |  r0  |x_addr|z_addr|a_addr| - |
-#! +------+------+------+------+------+------+------+------+------+------+------+------+------+------+------+---+
-#!
-#!                                                       ||
-#!                                                       \/
-#!
-#! +------+------+------+------+------+------+------+------+------+------+------+------+------+--------+--------+---+
-#! |  T0  |  T7  |  T6  |  T5  |  T4  |  T3  |  T2  |  T1  |  p1' |  p0' |  r1' |  r0' |x_addr|z_addr+1|a_addr+1| - |
-#! +------+------+------+------+------+------+------+------+------+------+------+------+------+--------+--------+---+
-#!
-#!
-#! Here:
-#! 1- Ti for i in 0..=7 stands for the the value of the i-th trace polynomial for the current query i.e. T_i(x).
-#! 2- (p0, p1) stands for an extension field element accumulating the values for the quotients with common denominator (x - gz).
-#! 3- (r0, r1) stands for an extension field element accumulating the values for the quotients with common denominator (x - z).
-#! 4- x_addr is the memory address from which we are loading the Ti's using the MSTREAM instruction.
-#! 5- z_addr is the memory address to the i-th OOD evaluation frame at z and gz i.e. T_i(z):= (T_i(z)0, T_i(z)1)
-#!  and T_i(gz):= (T_i(gz)0, T_i(gz)1)
-#! 6- a_addr is the memory address of the i-th random element used in batching the trace polynomial quotients.
-#!  The random elements a := (a0, a1) are stored in memory as [0, 0, a0, a1].
-#!
-#! Input: [T7, T6, T5, T4, T3, T2, T1, T0, p1, p0, r1, r0, x_addr, z_addr, a_addr, 0]
-#! Output: [T0, T7, T6, T5, T4, T3, T2, T1, p1', p0', r1', r0', x_addr, z_addr+1, a_addr+1, 0]
-export.combine_main
-
-    # 1) Shift trace columns values left
-    movup.7
-    #=> [T0, T7, T6, T5, T4, T3, T2, T1, p1, p0, r1, r0, x_addr, z_addr, a_addr, 0]
-
-    # 2) Get a_addr and update it. This is done here before the element becomes inaccessible.
-
-    # Update a_addr
-    dup.14 add.1 swap.15
-    #=> [a_addr, T0, T7, T6, T5, T4, T3, T2, T1, p1, p0, r1, r0, x_addr, z_addr, a_addr', 0]
-
-    # 3) Load i-th OOD frame portion. This assumes that the OOD frame has been serialized with `current` and `next` rows interleaved.
-    # This also updates the z_addr pointer.
-    dup.14 add.1 swap.15
-    padw movup.4 mem_loadw
-    #=> [Tgz1, Tgz0, Tz1, Tz0, a_addr, T0, T7, T6, T5, T4, T3, T2, T1, p1, p0, r1, r0, x_addr, z_addr', a_addr', 0]
-
-    # 4) Compute the numerators
-
-    # a) Compute T_i - T_i(z). This equals, in the case of T0, (-Tz1, T0 - Tz0)
-    dup.5
-    movup.4
-    #=> [Tz0, T0, Tgz1, Tgz0, Tz1, a_addr, T0, T7, T6, T5, T4, T3, T2, T1, p1, p0, r1, r0, x_addr, z_addr', a_addr', 0]
-
-    sub
-    #=> [T0 - Tz0, Tgz1, Tgz0, Tz1, a_addr, T0, T7, T6, T5, T4, T3, T2, T1, p1, p0, r1, r0, x_addr, z_addr', a_addr', 0]
-
-    swap.3 neg swap.2
-    #=> [Tgz0, Tgz1, -Tz1, T0 - Tz0, a_addr, T0, T7, T6, T5, T4, T3, T2, T1, p1, p0, r1, r0, x_addr, z_addr', a_addr', 0]
-
-    # b) Compute T_i - T_i(gz). This equals, in the case of T0, (-Tgz1, T0 - Tgz0)
-    dup.5 swap sub
-    #=> [T0 - Tgz0, Tgz1, -Tz1, T0 - Tz0, a_addr, T0, T7, T6, T5, T4, T3, T2, T1, p1, p0, r1, r0, x_addr, z_addr', a_addr', 0]
-
-    swap
-    neg
-    #=> [-Tgz1, T0 - Tgz0, -Tz1, T0 - Tz0, a_addr, T0, T7, T6, T5, T4, T3, T2, T1, p1, p0, r1, r0, x_addr, z_addr', a_addr', 0]
-    #=> [Δg1, Δg0, Δ1, Δ0, a_addr, T0, T7, T6, T5, T4, T3, T2, T1, p1, p0, r1, r0, x_addr, z_addr', a_addr', 0]
-    # where Δg1 := -Tgz1, Δg0 := T0 - Tgz0, Δ1 := -Tz1 and Δ0 := T0 - Tz0
-
-    # 5) Multiply by randomness
-
-    # a) Load randomness from memory
-    padw
-    movup.8 mem_loadw drop drop
-    #=> [a1, a0, Δg1, Δg0, Δ1, Δ0, T0, T7, T6, T5, T4, T3, T2, T1, p1, p0, r1, r0, x_addr, z_addr', a_addr', 0]
-
-    # b) Multiply (Δ0, Δ1)
-    dup.1 dup.1
-    movup.7 movup.7
-    #=> [Δ1, Δ0, a1, a0, a1, a0, Δg1, Δg0, T0, T7, T6, T5, T4, T3, T2, T1, p1, p0, r1, r0, x_addr, z_addr', a_addr', 0]
-
-    ext2mul
-    #=> [prod1, prod0, a1, a0, Δg1, Δg0, T0, T7, T6, T5, T4, T3, T2, T1, p1, p0, r1, r0, x_addr, z_addr', a_addr', 0]
-    #   where (prod0, prod1) := (Δ0, Δ1) * (a0, a1)
-
-    movdn.5 movdn.5
-    #=> [a1, a0, Δg1, Δg0, prod1, prod0, T0, T7, T6, T5, T4, T3, T2, T1, p1, p0, r1, r0, x_addr, z_addr', a_addr', 0]
-
-    # c) Multiply (Δg0, Δg1)
-    ext2mul
-    #=> [prodg1, prodg0, prod1, prod0, T0, T7, T6, T5, T4, T3, T2, T1, p1, p0, r1, r0, x_addr, z_addr', a_addr', 0]
-    #   where (prodg0, prodg1) := (Δg0, Δg1) * (a0, a1)
-
-    # 6) Accumulate into (p0, p1) and (r0, r1)
-    movupw.3
-
-    # a) Accumulate into (r0, r1)
-    movup.7 movup.7
-    #=> [prod1, prod0, p1, p0, r1, r0, prodg1, prodg0, T0, T7, T6, T5, T4, T3, T2, T1, x_addr, z_addr', a_addr', 0]
-    movup.5 movup.5 ext2add
-    #=> [r1', r0', p1, p0, prodg1, prodg0, T0, T7, T6, T5, T4, T3, T2, T1, x_addr, z_addr', a_addr', 0]
-
-    # b) Accumulate into (p0, p1)
-    movdn.5 movdn.5 ext2add
-    #=> [p1', p0', r1', r0', T0, T7, T6, T5, T4, T3, T2, T1, x_addr, z_addr', a_addr', 0]
-
-    # c) Prepare for next iteration.
-    movdnw.2
-    #=> [T0, T7, T6, T5, T4, T3, T2, T1, p1', p0', r1', r0', x_addr, z_addr', a_addr', 0]
-end
-
 #! Computes a single step of the random linear combination defining the DEEP composition polynomial
 #! that is the input to the FRI protocol. More precisely, the sum in question is:
 #! $$
@@ -252,7 +130,7 @@ end
 #! Input: [query_ptr, ...]
 #! Output: [index, query_ptr, ...]
 #!
-#! Cycles: 198
+#! Cycles: 219
 proc.load_query_row
     # Main trace portion of the query
 
@@ -280,13 +158,30 @@ proc.load_query_row
     swapw
     #=>[R, ptr, y, y, y, depth, index, query_ptr, ...]
     exec.constants::zero_word mem_loadw
+    add.6
+    swap.3
     padw
     padw
     #=> [Y, Y, 0, 0, 0, 1, ptr, y, y, y]
-    repeat.9
+    repeat.8
         adv_pipe hperm
     end
     #=> [Y, L, Y, ptr, y, y, y, depth, index, query_ptr, ...]
+
+    ## Store the last full word of main segment columns
+    adv_loadw
+    dup.12 mem_storew
+    swapw
+    dropw
+    adv_push.1
+    adv_push.1
+    push.0
+    push.0
+    ## Store the last 2 main segment columns
+    dup.12 add.1 mem_storew
+
+    ## Final hperm
+    hperm
 
     ## Load the leaf value we got using mtree_get
     exec.constants::tmp3 mem_loadw
@@ -301,6 +196,9 @@ proc.load_query_row
     assert_eq
     #=> [Y, ptr, y, y, y, depth, index, query_ptr, ...]
 
+    ## increment ptr to account for the last two words we loaded from the advice tape
+    swapw add.2 swapw
+
 
     # Aux trace part
 
@@ -314,25 +212,19 @@ proc.load_query_row
     #=> [L, R, ptr, y, y, y, depth, index, query_ptr, ...]
 
     ## adv_pipe aux trace portion
-    push.1.0.0.0
+    push.6.0.0.0
     swapw.2
     adv_pipe hperm
-    adv_pipe hperm
+    adv_loadw
+    dup.12 mem_storew
+    swapw
     dropw
     adv_push.1
     adv_push.1
-    push.1
-    push.0
+    push.0.0
 
-    ## Store the 9-th auxiliary column
-    dup.12 mem_storew
-
-    ## Since combine_aux follows a mem_stream we need to store (i.e. pad with) the all zero word in
-    ## order to avoid over-stepping into the constraint polynomial columns.
-    swapw
-    exec.constants::zero_word mem_loadw
-    dup.12 add.1
-    mem_storew
+    ## Store the last aux segment column
+    dup.12 add.1 mem_storew
 
     ## Final hperm
     hperm
@@ -439,7 +331,7 @@ end
 #! The procedure then outputs a stack in the same configuration but with the pointers and accumulators
 #! updated to [Y`, Y`, Acc`, P`, ...] where:
 #!
-#! 1. P` := [CURRENT_TRACE_ROW_PTR+18, OOD_TRACE_PTR+72, DEEP_RAND_CC_PTR+72, 0].
+#! 1. P` := [CURRENT_TRACE_ROW_PTR+18, OOD_TRACE_PTR+70, DEEP_RAND_CC_PTR+70, 0].
 #! 2. [Y`, Y`] is a "garbage" double-word used to later mem_stream auxiliary portion referenced now
 #! by CURRENT_TRACE_ROW_PTR`.
 #! 3. Acc` is the accumulator holding the updated numerator values i.e. with terms involving main
@@ -450,11 +342,16 @@ end
 #!
 #! Cycles: 81
 proc.combine_main_trace_columns
-    repeat.9
+    repeat.8
         mem_stream
         repeat.8
-            exec.combine_main
+            rcomb_base
         end
+    end
+
+    mem_stream
+    repeat.6
+        rcomb_base
     end
 end
 
@@ -470,7 +367,7 @@ end
 #! The procedure then outputs a stack in the same configuration but with the pointers and accumulators
 #! updated to [Y`, Y`, Acc`, P`, ...] where:
 #!
-#! 1. P` := [CURRENT_TRACE_ROW_PTR+6, OOD_TRACE_PTR+9, DEEP_RAND_CC_PTR+9, 0].
+#! 1. P` := [CURRENT_TRACE_ROW_PTR+4, OOD_TRACE_PTR+7, DEEP_RAND_CC_PTR+7, 0].
 #! 2. [Y`, Y`] is a "garbage" double-word used to later mem_stream constraint composition polynomial
 #! trace portion referenced now by CURRENT_TRACE_ROW_PTR`.
 #! 3. Acc` is the accumulator holding the updated numerator values i.e. with terms involving main
@@ -479,19 +376,19 @@ end
 #! Input: [Y, Y, Acc, P, ...]
 #! Output: [Y`, Y`, Acc`, P`, ...]
 #!
-#! Cycles: 12
+#! Cycles: 9
 proc.combine_aux_trace_columns
-    # Compute the random linear combination of the first 8 auxiliary trace columns
-    repeat.2
-        mem_stream
-        repeat.4
-            exec.combine_aux
-        end
+    # Compute the random linear combination of the first 4 auxiliary trace columns
+    mem_stream
+    repeat.4
+        exec.combine_aux
     end
 
-    # and the 9th aux column
+    # Compute the random linear combination of the last 3 auxiliary trace columns
     mem_stream
-    exec.combine_aux
+    repeat.3
+        exec.combine_aux
+    end
 end
 
 #! Computes the random linear combination involving the constraint composition polynomial trace
@@ -512,7 +409,7 @@ end
 #! Input: [Y, Y, Acc, P, ...]
 #! Output: [Acc`, ...]
 #!
-#! Cycles: 33
+#! Cycles: 25
 proc.combine_constraint_poly_columns
     # Save Acc
     swapw.2
@@ -570,7 +467,7 @@ end
 #!
 #! Input: [query_ptr, ...]
 #! Output: [...]
-#! Cycles: 6 + num_queries * 463
+#! Cycles: 6 + num_queries * 473
 export.compute_deep_composition_polynomial_queries
     exec.constants::fri_com_ptr
     dup.1
@@ -583,7 +480,7 @@ export.compute_deep_composition_polynomial_queries
         # Load the (main, aux, constraint)-traces rows associated with the current query and get
         # the index of the query.
         #
-        # Cycles: 200
+        # Cycles: 219
         exec.load_query_row
         #=>[index, query_ptr, query_end_ptr, ...]
 
@@ -629,9 +526,9 @@ export.compute_deep_composition_polynomial_queries
 
         ## d) Compute the random linear combination
         ##
-        ## Cycles: 81 + 12 + 33 = 126
+        ## Cycles: 81 + 9 + 25 = 115
         exec.combine_main_trace_columns
-        exec.combine_aux_trace_columns
+        exec.combine_aux_trace_columns     
         exec.combine_constraint_poly_columns
         #=> [Acc, Z, x, index, query_ptr, query_end_ptr, ...]
 

--- a/stdlib/asm/crypto/stark/ood_frames.masm
+++ b/stdlib/asm/crypto/stark/ood_frames.masm
@@ -7,20 +7,20 @@ use.std::crypto::hashes::rpo
 #!
 #! Input: [...]
 #! Output: [OOD_FRAME_HASH, ...]
-#! Cycles: 106
+#! Cycles: 100
 export.load_evaluation_frame
-    # We have 72 main trace columns and 9 aux trace columns for a total of 162 base field elements
+    # We have 70 main trace columns and 7 aux trace columns for a total of 154 base field elements
     # per row. Since we have two rows, i.e. current and next, the total number of field elements
     # making up the OOD evaluation frame is:
-    # 324 = 40 * 8 + 4
+    # 324 = 38 * 8 + 4
     # The elements are stored from the stack as (a1_1, a1_0, a0_1, a0_0) where a0 is from the
     # current row and a1 from the next row.
 
     exec.constants::ood_trace_ptr
 
-    push.1.0.0.0
+    push.4.0.0.0
     padw padw
-    repeat.40
+    repeat.38
         adv_pipe
         hperm
     end
@@ -29,7 +29,7 @@ export.load_evaluation_frame
     adv_loadw
     dup.12 mem_storew
     swapw
-    exec.constants::zero_zero_zero_one_word mem_loadw
+    exec.constants::zero_word mem_loadw
     hperm
 
     dropw
@@ -113,40 +113,49 @@ end
 #!
 #! Input: [...]
 #! Output: [res1, res0, ...]
-#! Cycles: 118
+#! Cycles: 152
 export.compute_Hz
-    # TODO: remove this
+    # Load the pointer to the OOD constraint polynomials evaluations
     exec.constants::ood_constraint_evals_ptr
-    add.4
-    repeat.3
-        padw
-    end
+    # => [ptr, ...]
 
     # Compute `H(z)`
     ## Load `value_i`'s
 
-    dup.12
-    sub.4
-    mem_loadw
-    swapw.2
+    # Load value_0
+    padw dup.4 mem_loadw
+    # => [0, 0, v0_1, v0_0, ptr, ...]
+   
+    # Load value_1
+    push.0.0 dup.6 add.1 mem_loadw
+    # => [0, 0, v1_1, v1_0, v0_1, v0_0, ptr, ...]
 
-    dup.12
-    sub.3
-    mem_loadw
-    swapw
+    # Load value_2
+    push.0.0 dup.8 add.2 mem_loadw
+    # => [0, 0, v2_1, v2_0, v1_1, v1_0, v0_1, v0_0, ptr, ...]
 
-    dup.12
-    sub.2
-    mem_loadw
+    # Load value_3
+    push.0.0 dup.10 add.3 mem_loadw
+    # => [0, 0, v3_1, v3_0, v2_1, v2_0, v1_1, v1_0, v0_1, v0_0, ptr, ...]
 
-    movup.12
-    sub.1
-    padw
-    movup.4
-    mem_loadw
+    # Load value_4
+    push.0.0 dup.12 add.4 mem_loadw
+    # => [0, 0, v4_1, v4_0, v3_1, v3_0, v2_1, v2_0, v1_1, v1_0, v0_1, v0_0, ptr, ...]
+
+    # Load value_5
+    push.0.0 movup.14 movdn.4 dup.4 add.5 mem_loadw
+    # => [0, 0, v5_1, v5_0, ptr, v4_1, v4_0, v3_1, v3_0, v2_1, v2_0, v1_1, v1_0, v0_1, v0_0, ptr, ...]
+
+    # Load value_6
+    push.0.0 dup.6 add.6 mem_loadw
+    # => [0, 0, v6_1, v6_0, v5_1, v5_0, ptr, v4_1, v4_0, v3_1, v3_0, v2_1, v2_0, v1_1, v1_0, v0_1, v0_0, ptr, ...]
+
+    # Load value_7
+    push.0.0 movup.8 add.7 mem_loadw
+    # => [0, 0, v7_1, v7_0, v6_1, v6_0, v5_1, v5_0, ptr, v4_1, v4_0, v3_1, v3_0, v2_1, v2_0, v1_1, v1_0, v0_1, v0_0, ptr, ...]
 
     ## Load z^N where N is the length of the execution trace
-    padw
+    push.0.0
     exec.constants::z_ptr mem_loadw
     movup.2 drop
     movup.2 drop

--- a/stdlib/asm/crypto/stark/public_inputs.masm
+++ b/stdlib/asm/crypto/stark/public_inputs.masm
@@ -28,7 +28,7 @@ export.load
     end
     adv_loadw
     swapw
-    exec.constants::zero_zero_zero_one_word mem_loadw
+    exec.constants::zero_word mem_loadw
     hperm
 
     dropw

--- a/stdlib/asm/crypto/stark/random_coin.masm
+++ b/stdlib/asm/crypto/stark/random_coin.masm
@@ -95,11 +95,6 @@ export.init_seed
     exec.constants::c_ptr mem_storew
     exec.constants::r1_ptr mem_storew
     exec.constants::r2_ptr mem_storew
-
-    drop
-    push.1
-    swap.3
-    exec.constants::zero_zero_zero_one_word mem_storew
     dropw
     #=> [log(trace_length), num_queries, log(blowup), grinding]
 
@@ -164,36 +159,32 @@ export.init_seed
     exec.constants::trace_domain_generator_ptr mem_store
     #=> [0, trace_length, num_queries, blowup, grinding]
 
-    # clean satck
+    # clean stack
     drop
     #=> [trace_length, num_queries, blowup, grinding]
 
     # Construct the proof context
 
     ##trace layout info
-    push.1208027408
-
+    push.1174472464
     ##field modulus bytes (2 field elements)
     push.1
     push.4294967295
-
     ## field extension and FRI parameters
     push.132103
-
 
     # Hash proof context
     # Cycles: 15
     swapw
-    push.1.0.0.0
-    #=> [0, 0, 0, 1, B, A, ..]
-    swapw.2
-    swapw
-    #=> [B, A, 0, 0, 0, 1, ..]
+    movdn.6
+    push.4.0.0.0
+    movdnw.2
+    # => [B, A, 0, 0, 0, 4, ..]
     hperm
     dropw
     dropw
-    #=> [C]
-end
+    # => [C]
+ end
 
 #! Reseed the random coin with `DATA`
 #!
@@ -422,7 +413,7 @@ end
 #!
 #! Input: [aux_rand_elem_ptr, ...]
 #! Output: [...]
-#! Cycles: 150
+#! Cycles: 159
 export.generate_aux_randomness
 
     push.16 swap
@@ -431,14 +422,14 @@ export.generate_aux_randomness
 end
 
 #! Draw constraint composition random coefficients and save them into memory in the region from
-#! `compos_coef_ptr` `compos_coef_ptr + 118 - 1` as `(r1_1, r1_0, r0_1, r0_0)`
+#! `compos_coef_ptr` `compos_coef_ptr + 112 - 1` as `(r1_1, r1_0, r0_1, r0_0)`
 #!
 #! Input: [compos_coef_ptr, ...]
 #! Output: [...]
-#! Cycles: 1309
+#! Cycles: 1305
 export.generate_constraint_composition_coefficients
 
-    push.236
+    push.224
     swap
     exec.generate_random_coefficients
     #=> [...]
@@ -447,16 +438,16 @@ end
 #! Draw deep composition polynomial random coefficients and save them into memory in the region from
 #! `deep_rand_coef_ptr` to `deep_rand_coef_ptr + 89 - 1` as `(0, 0, r0_1, r0_0)`
 #! The number of coefficients is equal to:
-#! 1. (72 + 9) * 2 Felt for the main and auxiliary traces.
+#! 1. (70 + 7) * 2 Felt for the main and auxiliary traces.
 #! 2. 8 * 2 Felt for constraint polynomial.
-#! Total: 89 tuples of type (Felt, Felt)
+#! Total: 85 tuples of type (Felt, Felt)
 #!
 #! Input: [deep_rand_coef_ptr, ...]
 #! Output: [...]
-#! Cycles: 1693
+#! Cycles: 1624
 export.generate_deep_composition_random_coefficients
-
-    push.92
+    # note that 88 is the next number after 85 divisible by 4
+    push.88
     swap
     exec.generate_random_coefficients_pad
     #=> [...]

--- a/stdlib/asm/crypto/stark/random_coin.masm
+++ b/stdlib/asm/crypto/stark/random_coin.masm
@@ -165,9 +165,14 @@ export.init_seed
 
     # Construct the proof context
 
-    ##trace layout info
+    ## trace layout info, which is the concatenation as u8-s of:
+    ## 1. main segment width
+    ## 2. num auxiliary segments, which always 1
+    ## 3. auxiliary segment width
+    ## 4. number of auxiliary random values
+    ## 5. trace length
     push.1174472464
-    ##field modulus bytes (2 field elements)
+    ## field modulus bytes (2 field elements)
     push.1
     push.4294967295
     ## field extension and FRI parameters
@@ -429,7 +434,7 @@ end
 #! Cycles: 1305
 export.generate_constraint_composition_coefficients
 
-    push.224
+    exec.constants::num_constraint_composition_coef_multiplied_by_two_and_rounded_up_to_4
     swap
     exec.generate_random_coefficients
     #=> [...]
@@ -447,7 +452,7 @@ end
 #! Cycles: 1624
 export.generate_deep_composition_random_coefficients
     # note that 88 is the next number after 85 divisible by 4
-    push.88
+    exec.constants::num_deep_composition_coef_multiplied_by_two_and_rounded_up_to_4
     swap
     exec.generate_random_coefficients_pad
     #=> [...]

--- a/stdlib/asm/crypto/stark/random_coin.masm
+++ b/stdlib/asm/crypto/stark/random_coin.masm
@@ -170,13 +170,17 @@ export.init_seed
     ## 2. num auxiliary segments, which always 1
     ## 3. auxiliary segment width
     ## 4. number of auxiliary random values
-    ## 5. trace length
-    push.1174472464
+    ## 5. trace length (this is already on the stack)
+
+    ## main segment width is 70 and there are 1 auxiliary segments
+    ## of width 7 using 16 random extension field elements
+    push.0x46010710 
     ## field modulus bytes (2 field elements)
-    push.1
-    push.4294967295
+    push.0x01 # lower half of the modulus
+    push.0xffffffff # upper half of the modulus
     ## field extension and FRI parameters
-    push.132103
+    ## field extension degree || FRI folding factor || FRI remainder polynomial max degree
+    push.0x020407
 
     # Hash proof context
     # Cycles: 15
@@ -661,7 +665,15 @@ export.generate_list_indices
     exec.get_rate_2
     hperm
 
-    exec.rpo::squeeze_digest
+    # Save the new state
+    exec.constants::r2_ptr mem_storew
+    dropw
+    # => [R1, C]
+    exec.constants::r1_ptr mem_storew
+    swapw
+    # => [C, R1]
+    exec.constants::c_ptr mem_storew
+    dropw
     #=> [R1, query_ptr, mask, depth, num_queries, ...]
 
 
@@ -694,8 +706,17 @@ export.generate_list_indices
         exec.get_rate_2
         hperm
 
-        exec.rpo::squeeze_digest
-        #=> [R1, query_ptr, mask, depth, num_queries, ...]
+        # Save the new state
+        exec.constants::r2_ptr mem_storew
+        dropw
+        # => [R1, C]
+        exec.constants::r1_ptr mem_storew
+        swapw
+        # => [C, R1]
+        exec.constants::c_ptr mem_storew
+        dropw
+        #=> [R1, query_ptr, mask, depth, num_remaining_iterations, remainder, ...]
+
         movup.7 sub.1 dup movdn.8
         push.0 neq
     end

--- a/stdlib/asm/crypto/stark/verifier.masm
+++ b/stdlib/asm/crypto/stark/verifier.masm
@@ -12,25 +12,25 @@ use.std::crypto::stark::constants
 #!   The following simplifying assumptions are currently made:
 #!   - The blowup is set to 8.
 #!   - The maximal allowed degree of the remainder polynomial is 7.
-#!   - Only the input and output stacks, assumed of fixed size equal to 16, are handled in regards
-#!   to public inputs.
+#!   - The public inputs are composed of the input and output stacks, of fixed size equal to 16.
 #!   - There are two trace segments, main and auxiliary. It is assumed that the main trace segment
-#!   is 73 columns wide while the auxiliary trace segment is 9 columns wide.
+#!   is 70 columns wide while the auxiliary trace segment is 7 columns wide.
 #!   - The OOD evaluation frame is composed of two interleaved rows, current and next, each composed
-#!    of 73 elements representing the main trace portion and 9 elements for the auxiliary trace one.
+#!    of 70 elements representing the main trace portion and 7 elements for the auxiliary trace one.
 #!   - To boost soundness, the protocol is run on a quadratic extension field and this means that
 #!    the OOD evaluation frame is composed of elements in a quadratic extension field i.e. tuples.
-#!    Similarly, elements of the auxiliary trace are quadratic extension field elements.
+#!    Similarly, elements of the auxiliary trace are quadratic extension field elements. The random
+#!    values for computing random linear combinations are also in this extension field.
 #!   - The following procedure makes use of global memory address beyond 3 * 2^30 and these are
 #!    defined in `constants.masm`.
 #!
-#! Input: [log(trace_length), num_queries, log(blowup), grinding]
+#! Input: [log(trace_length), num_queries, log(blowup), grinding, ...]
 #! Output: []
 #! Cycles:
 #!  1- Remainder codeword size 32:
-#!   5000 + num_queries * (40 + num_fri_layers * 76 + 26 + 463) + 83 * num_fri_layers + 10 * log(trace_length) + 1633
+#!   4975 + num_queries * (40 + num_fri_layers * 76 + 26 + 473) + 83 * num_fri_layers + 10 * log(trace_length) + 1633
 #!  2- Remainder codeword size 64:
-#!   5000 + num_queries * (40 + num_fri_layers * 76 + 26 + 463) + 83 * num_fri_layers + 10 * log(trace_length) + 3109
+#!   4975 + num_queries * (40 + num_fri_layers * 76 + 26 + 473) + 83 * num_fri_layers + 10 * log(trace_length) + 3109
 export.verify
 
     #==============================================================================================
@@ -67,7 +67,7 @@ export.verify
 
     # Draw random ExtFelt for the auxiliary trace
     #
-    # Cycles: 150
+    # Cycles: 160
     exec.constants::aux_rand_elem_ptr
     exec.random_coin::generate_aux_randomness
     #=> [...]
@@ -85,7 +85,7 @@ export.verify
     #       III) Draw constraint composition coefficients
     #==============================================================================================
 
-    # Cycles: 1309
+    # Cycles: 1306
     exec.constants::composition_coef_ptr
     exec.random_coin::generate_constraint_composition_coefficients
     #=> [...]
@@ -110,7 +110,7 @@ export.verify
     #           of H over the LDE domain.
     #==============================================================================================
 
-    # Cycles: 106
+    # Cycles: 104
     exec.ood_frames::load_evaluation_frame
     #=> [OOD_FRAME_HASH, ...]
 
@@ -126,7 +126,7 @@ export.verify
 
     # Compute `H(z)`
     #
-    # Cycles: 118
+    # Cycles: 152
     exec.ood_frames::compute_Hz
     #=> [res1, res0, ...]
 
@@ -147,7 +147,7 @@ export.verify
     #       DEEP composition polynomial.
     #============================================
 
-    # Cycles: 1693
+    # Cycles: 1625
     exec.constants::deep_rand_coef_ptr
     exec.random_coin::generate_deep_composition_random_coefficients
 
@@ -221,7 +221,7 @@ export.verify
 
     # Compute deep compostion polynomial queries
     #
-    # Cycles: 14 + num_queries * 463
+    # Cycles: 14 + num_queries * 473
     #=> [query_ptr, ...]
     exec.deep_queries::compute_deep_composition_polynomial_queries
     #=> [query_ptr, ...]

--- a/stdlib/tests/crypto/stark/mod.rs
+++ b/stdlib/tests/crypto/stark/mod.rs
@@ -10,7 +10,6 @@ use verifier_recursive::{generate_advice_inputs, VerifierData};
 // Note: Changes to MidenVM may cause this test to fail when some of the assumptions documented
 // in `stdlib/asm/crypto/stark/verifier.masm` are violated.
 #[test]
-#[ignore]
 fn stark_verifier_e2f4() {
     // An example MASM program to be verified inside Miden VM.
     // Note that output stack-overflow is not yet supported because of the way we handle public
@@ -53,7 +52,7 @@ pub fn generate_recursive_verifier_data(
     let mut host = DefaultHost::new(advice_provider);
 
     let options =
-        ProvingOptions::new(43, 8, 12, FieldExtension::Quadratic, 4, 7, HashFunction::Rpo256);
+        ProvingOptions::new(27, 8, 12, FieldExtension::Quadratic, 4, 7, HashFunction::Rpo256);
 
     let (stack_outputs, proof) = prove(&program, stack_inputs.clone(), &mut host, options).unwrap();
 

--- a/stdlib/tests/crypto/stark/mod.rs
+++ b/stdlib/tests/crypto/stark/mod.rs
@@ -24,8 +24,12 @@ fn stark_verifier_e2f4() {
     stack_inputs[15] = 0;
     stack_inputs[14] = 1;
 
-    let VerifierData { initial_stack, tape, store, advice_map } =
-        generate_recursive_verifier_data(example_source, stack_inputs).unwrap();
+    let VerifierData {
+        initial_stack,
+        advice_stack: tape,
+        store,
+        advice_map,
+    } = generate_recursive_verifier_data(example_source, stack_inputs).unwrap();
 
     // Verify inside Miden VM
     let source = "

--- a/stdlib/tests/crypto/stark/verifier_recursive/channel.rs
+++ b/stdlib/tests/crypto/stark/verifier_recursive/channel.rs
@@ -184,8 +184,7 @@ impl VerifierChannel {
         let (aux_trace_pmt, mut aux_trace_adv_map) =
             unbatch_to_partial_mt(positions.to_vec(), aux_queries_vec, proofs[1].clone());
 
-        let mut trees = vec![];
-        trees.push(main_trace_pmt);
+        let mut trees = vec![main_trace_pmt];
         trees.push(aux_trace_pmt);
 
         main_trace_adv_map.append(&mut aux_trace_adv_map);

--- a/stdlib/tests/crypto/stark/verifier_recursive/channel.rs
+++ b/stdlib/tests/crypto/stark/verifier_recursive/channel.rs
@@ -184,7 +184,7 @@ impl VerifierChannel {
         let (aux_trace_pmt, mut aux_trace_adv_map) =
             unbatch_to_partial_mt(positions.to_vec(), aux_queries_vec, proofs[1].clone());
 
-        let mut trees = Vec::new();
+        let mut trees = vec![];
         trees.push(main_trace_pmt);
         trees.push(aux_trace_pmt);
 

--- a/stdlib/tests/crypto/stark/verifier_recursive/mod.rs
+++ b/stdlib/tests/crypto/stark/verifier_recursive/mod.rs
@@ -155,7 +155,8 @@ pub fn generate_advice_inputs(
     query_positions.sort();
     query_positions.dedup();
 
-    // read advice maps and Merkle paths of the queries to main/aux and constraint composition traces
+    // read advice maps and Merkle paths of the queries to main/aux and constraint composition
+    // traces
     let (mut main_aux_adv_map, mut partial_trees_traces) =
         channel.read_queried_trace_states(&query_positions)?;
     let (mut constraint_adv_map, partial_tree_constraint) =

--- a/stdlib/tests/crypto/stark/verifier_recursive/mod.rs
+++ b/stdlib/tests/crypto/stark/verifier_recursive/mod.rs
@@ -8,6 +8,7 @@ use test_utils::{
     Felt, VerifierError,
 };
 use winter_air::{proof::Proof, Air};
+use winter_fri::VerifierChannel as FriVerifierChannel;
 
 mod channel;
 use channel::VerifierChannel;
@@ -27,21 +28,28 @@ pub fn generate_advice_inputs(
     proof: Proof,
     pub_inputs: <ProcessorAir as Air>::PublicInputs,
 ) -> Result<VerifierData, VerifierError> {
-    //// build a seed for the public coin; the initial seed is the hash of public inputs and proof
-    //// context, but as the protocol progresses, the coin will be reseeded with the info received
-    //// from the prover
-    let mut public_coin_seed = proof.context.to_elements();
-    let trace_len: Felt = public_coin_seed[7];
+    // we need to provide the following instance specific data through the operand stack
+    let proof_context = proof.context.to_elements();
+    let trace_len: Felt = proof_context[1];
+    let num_queries = proof_context[7];
+    let blowup = proof_context[6];
+    let grinding_factor = proof_context[5];
     let initial_stack = vec![
-        public_coin_seed[4].as_int(),
-        (public_coin_seed[5].as_int() as usize).ilog2() as u64,
-        public_coin_seed[6].as_int(),
+        grinding_factor.as_int(),
+        (blowup.as_int() as usize).ilog2() as u64,
+        num_queries.as_int(),
         (trace_len.as_int() as usize).ilog2() as u64,
     ];
 
+    // build a seed for the public coin; the initial seed is the hash of public inputs and proof
+    // context, but as the protocol progresses, the coin will be reseeded with the info received
+    // from the prover
     let mut tape = vec![];
+    let mut public_coin_seed = proof.context.to_elements();
     public_coin_seed.append(&mut pub_inputs.to_elements());
 
+    // add the public inputs, which is nothing but the input and output stacks to the VM, to the
+    // advice tape
     let pub_inputs_int: Vec<u64> = pub_inputs.to_elements().iter().map(|a| a.as_int()).collect();
     tape.extend_from_slice(&pub_inputs_int[..]);
 
@@ -51,14 +59,16 @@ pub fn generate_advice_inputs(
     let mut public_coin: RpoRandomCoin = RpoRandomCoin::new(seed_digest.into());
     let mut channel = VerifierChannel::new(&air, proof)?;
 
-    // 1 ----- trace commitment -------------------------------------------------------------------
+    // 1 ----- main segment trace -----------------------------------------------------------------
     let trace_commitments = channel.read_trace_commitments();
 
-    // reseed the coin with the commitment to the main trace segment
+    // reseed the coin with the commitment to the main segment trace
     public_coin.reseed(trace_commitments[0]);
     tape.extend_from_slice(&digest_to_int_vec(trace_commitments));
 
-    // process auxiliary trace segments, to build a set of random elements for each segment
+    // 2 ----- auxiliary segment trace ------------------------------------------------------------
+
+    // generate the auxiliary random elements
     let mut aux_trace_rand_elements = vec![];
     for commitment in trace_commitments.iter().skip(1) {
         let rand_elements: Vec<QuadExt> = air
@@ -67,85 +77,119 @@ pub fn generate_advice_inputs(
         aux_trace_rand_elements.push(rand_elements);
         public_coin.reseed(*commitment);
     }
-    // build random coefficients for the composition polynomial
+
+    // 3 ----- constraint composition trace -------------------------------------------------------
+
+    // build random coefficients for the composition polynomial. we don't need them but we have to
+    // generate them in order to update the random coin
     let _constraint_coeffs: winter_air::ConstraintCompositionCoefficients<QuadExt> = air
         .get_constraint_composition_coefficients(&mut public_coin)
         .map_err(|_| VerifierError::RandomCoinError)?;
-
-    // 2 ----- constraint commitment --------------------------------------------------------------
     let constraint_commitment = channel.read_constraint_commitment();
     tape.extend_from_slice(&digest_to_int_vec(&[constraint_commitment]));
     public_coin.reseed(constraint_commitment);
 
-    // 3 ----- OOD frames --------------------------------------------------------------
+    // 4 ----- OOD frames --------------------------------------------------------------
+
+    // generate the the OOD point
+    let _z: QuadExt = public_coin.draw().unwrap();
+
+    // read the main and auxiliary segments' OOD frames and add them to advice tape
     let ood_trace_frame = channel.read_ood_trace_frame();
     let _ood_main_trace_frame = ood_trace_frame.main_frame();
     let _ood_aux_trace_frame = ood_trace_frame.aux_frame();
 
-    // TODO: fix
-    tape.extend_from_slice(&to_int_vec(ood_trace_frame.current_row()));
-    public_coin.reseed(Rpo256::hash_elements(ood_trace_frame.current_row()));
+    let mut main_and_aux_frame_states = Vec::new();
+    for col in 0.._ood_main_trace_frame.current().len() {
+        main_and_aux_frame_states.push(_ood_main_trace_frame.current()[col]);
+        main_and_aux_frame_states.push(_ood_main_trace_frame.next()[col]);
+    }
+    for col in 0.._ood_aux_trace_frame.as_ref().unwrap().current().len() {
+        main_and_aux_frame_states.push(_ood_aux_trace_frame.as_ref().unwrap().current()[col]);
+        main_and_aux_frame_states.push(_ood_aux_trace_frame.as_ref().unwrap().next()[col]);
+    }
+    tape.extend_from_slice(&to_int_vec(&main_and_aux_frame_states));
+    public_coin.reseed(Rpo256::hash_elements(&main_and_aux_frame_states));
 
-    // read evaluations of composition polynomial columns
+    // read OOD evaluations of composition polynomial columns
     let ood_constraint_evaluations = channel.read_ood_constraint_evaluations();
     tape.extend_from_slice(&to_int_vec(&ood_constraint_evaluations));
     public_coin.reseed(Rpo256::hash_elements(&ood_constraint_evaluations));
 
-    // 4 ----- FRI  --------------------------------------------------------------------
-    let fri_commitments_digests = channel.fri_layer_commitments().unwrap();
-    let poly = channel.fri_remainder();
+    // 5 ----- FRI  -------------------------------------------------------------------------------
+
+    // read the FRI layer committments as well as remainder polynomial
+    let fri_commitments_digests = channel.read_fri_layer_commitments();
+    let poly = channel.read_remainder().unwrap();
+
+    // Reed-Solomon encode the remainder polynomial as this is needed for the probabilistic NTT
     let twiddles = fft::get_twiddles(poly.len());
     let fri_remainder =
         fft::evaluate_poly_with_offset(&poly, &twiddles, Felt::GENERATOR, BLOWUP_FACTOR);
 
+    // add the above to the advice tape
     let fri_commitments: Vec<u64> = digest_to_int_vec(&fri_commitments_digests);
     tape.extend_from_slice(&fri_commitments);
     tape.extend_from_slice(&to_int_vec(&poly));
     tape.extend_from_slice(&to_int_vec(&fri_remainder));
 
+    // reseed with FRI layer commitments
     let _deep_coefficients = air
         .get_deep_composition_coefficients::<QuadExt, RpoRandomCoin>(&mut public_coin)
         .map_err(|_| VerifierError::RandomCoinError)?;
-    // Reseed with FRI layer commitments
     let layer_commitments = fri_commitments_digests.clone();
     for commitment in layer_commitments.iter() {
         public_coin.reseed(*commitment);
         let _alpha: QuadExt = public_coin.draw().expect("failed to draw random indices");
     }
 
-    // 5 ----- trace and constraint queries -------------------------------------------------------
+    // 6 ----- trace and constraint queries -------------------------------------------------------
 
     // read proof-of-work nonce sent by the prover and draw pseudo-random query positions for
-    // the LDE domain from the public coin.
-    // This is needed in order to construct Partial Merkle Trees
+    // the LDE domain from the public coin
     let pow_nonce = channel.read_pow_nonce();
-    let query_positions = public_coin
+    let mut query_positions = public_coin
         .draw_integers(air.options().num_queries(), air.lde_domain_size(), pow_nonce)
         .map_err(|_| VerifierError::RandomCoinError)?;
+    tape.extend_from_slice(&[pow_nonce]);
+    query_positions.sort();
+    query_positions.dedup();
 
-    // read advice maps and Merkle paths related to trace and constraint composition polynomial
-    // evaluations
-    let (mut advice_map, mut partial_trees_traces) =
+    // read advice maps and Merkle paths of the queries to main/aux and constraint composition traces
+    let (mut main_aux_adv_map, mut partial_trees_traces) =
         channel.read_queried_trace_states(&query_positions)?;
-    let (mut adv_map_constraint, partial_tree_constraint) =
+    let (mut constraint_adv_map, partial_tree_constraint) =
         channel.read_constraint_evaluations(&query_positions)?;
 
-    let domain_size = (air.trace_poly_degree() + 1) * BLOWUP_FACTOR;
-    let mut ress = channel.unbatch::<4, 3>(&query_positions, domain_size, fri_commitments_digests);
+    let (mut partial_trees_fri, mut fri_adv_map) = channel.unbatch_fri_layer_proofs::<4>(
+        &query_positions,
+        air.lde_domain_size(),
+        fri_commitments_digests,
+    );
+
     // consolidate advice maps
-    advice_map.append(&mut adv_map_constraint);
-    advice_map.append(&mut ress.1);
-    let mut partial_trees_fri = ress.0;
+    main_aux_adv_map.append(&mut constraint_adv_map);
+    main_aux_adv_map.append(&mut fri_adv_map);
+
+    // build the full MerkleStore
     partial_trees_fri.append(&mut partial_trees_traces);
     partial_trees_fri.push(partial_tree_constraint);
     let mut store = MerkleStore::new();
     for partial_tree in &partial_trees_fri {
         store.extend(partial_tree.inner_nodes());
     }
-    Ok(VerifierData { initial_stack, tape, store, advice_map })
+
+    Ok(VerifierData {
+        initial_stack,
+        tape,
+        store,
+        advice_map: main_aux_adv_map,
+    })
 }
 
-// Helpers
+// HELPER FUNCTIONS
+// ================================================================================================
+
 pub fn digest_to_int_vec(digest: &[RpoDigest]) -> Vec<u64> {
     digest
         .iter()


### PR DESCRIPTION
As the title says.
We now use the `rcomb_base` and this leads to faster testing times. Also updated is how the `rcomb_base` is defined so that the accumulator for the `(x - z)` quotient is deeper in the stack than the accumulator for the `(x - gz)` quotient.
Other than that, there are some minor cleanups and re-organization for the testing code.