### PR TITLE
refactor: fix clippy warnings (`String::as_bytes`)

### DIFF
--- a/assembly/src/library/namespace.rs
+++ b/assembly/src/library/namespace.rs
@@ -112,7 +112,7 @@ impl LibraryNamespace {
         if matches!(source, Self::KERNEL_PATH | Self::EXEC_PATH | Self::ANON_PATH) {
             return Ok(());
         }
-        if source.as_bytes().len() > Self::MAX_LENGTH {
+        if source.len() > Self::MAX_LENGTH {
             return Err(LibraryNamespaceError::Length);
         }
         if !source.starts_with(|c: char| c.is_ascii_lowercase() && c.is_ascii_alphabetic()) {

--- a/assembly/src/library/path.rs
+++ b/assembly/src/library/path.rs
@@ -192,8 +192,8 @@ impl LibraryPath {
 
     /// Return the size in bytes of this path when displayed as a string
     pub fn byte_len(&self) -> usize {
-        self.inner.components.iter().map(|c| c.as_bytes().len()).sum::<usize>()
-            + self.inner.ns.as_str().as_bytes().len()
+        self.inner.components.iter().map(|c| c.len()).sum::<usize>()
+            + self.inner.ns.as_str().len()
             + (self.inner.components.len() * 2)
     }
 

--- a/assembly/src/parser/scanner.rs
+++ b/assembly/src/parser/scanner.rs
@@ -41,7 +41,7 @@ pub struct Scanner<'input> {
 impl<'input> Scanner<'input> {
     /// Construct a new [Scanner] for the given `source`.
     pub fn new(input: &'input str) -> Self {
-        let end = input.as_bytes().len();
+        let end = input.len();
         assert!(end < u32::MAX as usize, "file too large");
 
         let mut chars = input.char_indices().peekable();

--- a/assembly/src/parser/token.rs
+++ b/assembly/src/parser/token.rs
@@ -860,7 +860,7 @@ impl<'input> Token<'input> {
             // No match, it's an ident
             None => Token::Ident(s),
             // If the match is not exact, it's an ident
-            Some(matched) if matched.len() != s.as_bytes().len() => Token::Ident(s),
+            Some(matched) if matched.len() != s.len() => Token::Ident(s),
             // Otherwise clone the Token corresponding to the keyword that was matched
             Some(matched) => Self::KEYWORDS[matched.pattern().as_usize()].1.clone(),
         }


### PR DESCRIPTION
The lint was introduced lately and is failing on `next`