### PR TITLE
Typo and improvement for clarity and consistency in: Update README.md

### DIFF
--- a/assembly/README.md
+++ b/assembly/README.md
@@ -44,7 +44,7 @@ let program = assembler.assemble_program(&Path::new("./example.masm")).unwrap();
 As noted above, the default assembler is instantiated with nothing in it but
 the source code you provide. If you want to support more complex programs, you
 will want to factor code into libraries and modules, and then link all of them
-together at once. This can be acheived using a set of builder methods of the
+together at once. This can be achieved using a set of builder methods of the
 `Assembler` struct, e.g. `with_kernel_from_module`, `with_library`, etc.
 
 We'll look at a few of these in more detail below. See the module documentation
@@ -99,7 +99,7 @@ code in the form of its abstract syntax tree. You can construct and load
 
 ### Program Kernels
 
-A _program kernel_ defines a set of procedures which can be invoked via
+A _program kernel_ defines a set of procedures that can be invoked via
 `syscall` instructions. Miden programs are always compiled against some kernel,
 and by default this kernel is empty, and so no `syscall` instructions are
 allowed.


### PR DESCRIPTION
Hi,

I have two suggestions for clarity or consistency in this text:

First, a typo in "acheived" should be "achieved".

Secondly, "A program kernel defines a set of procedures which can be invoked via syscall instructions."

I suggest changing "which" to "that" for better clarity and consistency.

Thanks.