### PR TITLE
Assembly: remove duplicate code and make recompute private

### DIFF
--- a/assembly/src/assembler/mod.rs
+++ b/assembly/src/assembler/mod.rs
@@ -327,7 +327,6 @@ impl Assembler {
             exports
         };
 
-        // TODO: show a warning if library exports are empty?
         let (mast_forest, id_remappings) = mast_forest_builder.build();
         if let Some(id_remappings) = id_remappings {
             for (_proc_name, node_id) in exports.iter_mut() {

--- a/assembly/src/assembler/mod.rs
+++ b/assembly/src/assembler/mod.rs
@@ -383,7 +383,6 @@ impl Assembler {
 
         // Recompute graph with executable module, and start compiling
         let ast_module_index = self.module_graph.add_ast_module(program)?;
-        self.module_graph.recompute()?;
 
         // Find the executable entrypoint Note: it is safe to use `unwrap_ast()` here, since this is
         // the module we just added, which is in AST representation.

--- a/assembly/src/assembler/mod.rs
+++ b/assembly/src/assembler/mod.rs
@@ -285,18 +285,10 @@ impl Assembler {
         options: CompileOptions,
     ) -> Result<Library, Report> {
         // TODO use add_module_with_options
-        let ast_module_indices =
-            modules.into_iter().try_fold(Vec::default(), |mut acc, module| {
-                module
-                    .compile_with_options(&self.source_manager, options.clone())
-                    .and_then(|module| {
-                        self.module_graph.add_ast_module(module).map_err(Report::from)
-                    })
-                    .map(move |module_id| {
-                        acc.push(module_id);
-                        acc
-                    })
-            })?;
+        let ast_module_indices = modules
+            .into_iter()
+            .map(|module| self.add_module_with_options(module, options.clone()))
+            .collect::<Result<Vec<ModuleIndex>, Report>>()?;
 
         self.module_graph.recompute()?;
 

--- a/assembly/src/assembler/mod.rs
+++ b/assembly/src/assembler/mod.rs
@@ -171,10 +171,8 @@ impl Assembler {
         options: CompileOptions,
     ) -> Result<ModuleIndex, Report> {
         let kind = options.kind;
-        if kind != ModuleKind::Library {
-            return Err(Report::msg(
-                "only library modules are supported by `add_module_with_options`",
-            ));
+        if kind == ModuleKind::Executable {
+            return Err(Report::msg("Executables are supported by `add_module_with_options`"));
         }
 
         let module = module.compile_with_options(&self.source_manager, options)?;

--- a/assembly/src/assembler/mod.rs
+++ b/assembly/src/assembler/mod.rs
@@ -158,7 +158,7 @@ impl Assembler {
     ///
     /// The given module must be a library module, or an error will be returned.
     #[inline]
-    pub fn add_module(&mut self, module: impl Compile) -> Result<(), Report> {
+    pub fn add_module(&mut self, module: impl Compile) -> Result<ModuleIndex, Report> {
         self.add_module_with_options(module, CompileOptions::for_library())
     }
 
@@ -169,7 +169,7 @@ impl Assembler {
         &mut self,
         module: impl Compile,
         options: CompileOptions,
-    ) -> Result<(), Report> {
+    ) -> Result<ModuleIndex, Report> {
         let kind = options.kind;
         if kind != ModuleKind::Library {
             return Err(Report::msg(
@@ -180,9 +180,9 @@ impl Assembler {
         let module = module.compile_with_options(&self.source_manager, options)?;
         assert_eq!(module.kind(), kind, "expected module kind to match compilation options");
 
-        self.module_graph.add_ast_module(module)?;
+        let id = self.module_graph.add_ast_module(module)?;
 
-        Ok(())
+        Ok(id)
     }
 
     /// Adds all modules (defined by ".masm" files) from the specified directory to the module

--- a/assembly/src/assembler/mod.rs
+++ b/assembly/src/assembler/mod.rs
@@ -344,7 +344,12 @@ impl Assembler {
         self,
         modules: impl IntoIterator<Item = impl Compile>,
     ) -> Result<Library, Report> {
-        self.assemble_common(modules, CompileOptions::for_library())
+        let options = CompileOptions {
+            kind: ModuleKind::Library,
+            warnings_as_errors: self.warnings_as_errors,
+            path: None,
+        };
+        self.assemble_common(modules, options)
     }
 
     /// Assembles the provided module into a [KernelLibrary] intended to be used as a Kernel.

--- a/assembly/src/assembler/module_graph/mod.rs
+++ b/assembly/src/assembler/module_graph/mod.rs
@@ -238,6 +238,17 @@ impl ModuleGraph {
         Ok(module_id)
     }
 
+    pub fn add_ast_modules(
+        &mut self,
+        modules: impl Iterator<Item = Box<Module>>,
+    ) -> Result<Vec<ModuleIndex>, AssemblyError> {
+        let idx = modules
+            .into_iter()
+            .map(|m| self.add_module(PendingWrappedModule::Ast(m)))
+            .collect::<Result<Vec<ModuleIndex>, _>>()?;
+        self.recompute()?;
+        Ok(idx)
+    }
     fn is_pending(&self, path: &LibraryPath) -> bool {
         self.pending.iter().any(|m| m.path() == path)
     }

--- a/assembly/src/assembler/module_graph/mod.rs
+++ b/assembly/src/assembler/module_graph/mod.rs
@@ -223,7 +223,9 @@ impl ModuleGraph {
     /// This function will panic if the number of modules exceeds the maximum representable
     /// [ModuleIndex] value, `u16::MAX`.
     pub fn add_ast_module(&mut self, module: Box<Module>) -> Result<ModuleIndex, AssemblyError> {
-        self.add_module(PendingWrappedModule::Ast(module))
+        let res = self.add_module(PendingWrappedModule::Ast(module))?;
+        self.recompute()?;
+        Ok(res)
     }
 
     fn add_module(&mut self, module: PendingWrappedModule) -> Result<ModuleIndex, AssemblyError> {
@@ -340,7 +342,7 @@ impl ModuleGraph {
     /// NOTE: This will return `Err` if we detect a validation error, a cycle in the graph, or an
     /// operation not supported by the current configuration. Basically, for any reason that would
     /// cause the resulting graph to represent an invalid program.
-    pub fn recompute(&mut self) -> Result<(), AssemblyError> {
+    fn recompute(&mut self) -> Result<(), AssemblyError> {
         // It is acceptable for there to be no changes, but if the graph is empty and no changes
         // are being made, we treat that as an error
         if self.modules.is_empty() && self.pending.is_empty() {

--- a/assembly/src/testing.rs
+++ b/assembly/src/testing.rs
@@ -291,7 +291,7 @@ impl TestContext {
     /// other modules.
     #[track_caller]
     pub fn add_module(&mut self, module: impl Compile) -> Result<(), Report> {
-        self.assembler.add_module(module)
+        self.assembler.add_module(module).map(|_| ())
     }
 
     /// Add a module to the [Assembler] constructed by this context, with the fully-qualified
@@ -305,13 +305,15 @@ impl TestContext {
         path: LibraryPath,
         source: impl Compile,
     ) -> Result<(), Report> {
-        self.assembler.add_module_with_options(
-            source,
-            CompileOptions {
-                path: Some(path),
-                ..CompileOptions::for_library()
-            },
-        )
+        self.assembler
+            .add_module_with_options(
+                source,
+                CompileOptions {
+                    path: Some(path),
+                    ..CompileOptions::for_library()
+                },
+            )
+            .map(|_| ())
     }
 
     /// Add the modules of `library` to the [Assembler] constructed by this context.


### PR DESCRIPTION
This PR:
- removes some duplication in assemble_library and assemble_kernel
- adds funtions to add multiple modules at once so that recomputation of the graph can be done only once. In this way `recompute` can be made private.