### PR TITLE
Fix/err

### DIFF
--- a/air/src/constraints/stack/u32_ops/mod.rs
+++ b/air/src/constraints/stack/u32_ops/mod.rs
@@ -284,7 +284,7 @@ pub fn enforce_check_element_validity<E: FieldElement<BaseField = Felt>>(
 
     let v_hi_comp = E::ONE - m * (E::from(TWO_32) - E::ONE - limbs.v_hi());
 
-    // Enforces that the agggregation of the limbs forms a valid field element.
+    // Enforces that the aggregation of the limbs forms a valid field element.
     result[0] = u32_split_mul_madd * are_equal(v_hi_comp * limbs.v_lo(), E::ZERO);
 
     1

--- a/assembly/README.md
+++ b/assembly/README.md
@@ -44,7 +44,7 @@ let program = assembler.assemble_program(&Path::new("./example.masm")).unwrap();
 As noted above, the default assembler is instantiated with nothing in it but
 the source code you provide. If you want to support more complex programs, you
 will want to factor code into libraries and modules, and then link all of them
-together at once. This can be acheived using a set of builder methods of the
+together at once. This can be achieved using a set of builder methods of the
 `Assembler` struct, e.g. `with_kernel_from_module`, `with_library`, etc.
 
 We'll look at a few of these in more detail below. See the module documentation


### PR DESCRIPTION
# Fix: Corrected typos in source files and documentation

## Changes
1. **Corrected typo in `assembly/README.md:47`**:
   - "acheived" corrected to "achieved".

2. **Corrected typo in `air/src/constraints/stack/u32_ops/mod.rs:287`**:
   - "agggregation" corrected to "aggregation".

## Purpose
- Improved documentation and code accuracy by fixing typos.
