### PR TITLE
CUDA acceleration for trace and constraint commitments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45862d1c77f2228b9e10bc609d5bc203d86ebc9b87ad8d5d5167a6c9abf739d9"
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -634,6 +640,7 @@ checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
 dependencies = [
  "futures-channel",
  "futures-core",
+ "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -655,6 +662,17 @@ name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
@@ -680,11 +698,15 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -766,6 +788,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "home"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+dependencies = [
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "indenter"
@@ -1082,12 +1113,20 @@ dependencies = [
 [[package]]
 name = "miden-gpu"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04742d5184bd76e7b92afcd9ca36b7c587a555d5fc4b27bb8f9d64ac57151f9c"
 dependencies = [
+ "allocator-api2",
+ "cc",
  "metal",
+ "miden-crypto",
  "once_cell",
+ "rayon",
+ "sppark",
+ "thiserror 2.0.3",
+ "tracing",
+ "winter-air",
  "winter-math",
+ "winter-prover",
+ "winterfell",
 ]
 
 [[package]]
@@ -1157,6 +1196,7 @@ dependencies = [
  "miden-gpu",
  "miden-processor",
  "pollster",
+ "serial_test",
  "tracing",
  "winter-maybe-async",
  "winter-prover",
@@ -1818,6 +1858,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b202022bb57c049555430e11fc22fea12909276a80a4c3d368da36ac1d88ed"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1828,6 +1877,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdd"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49c1eeaf4b6a87c7479688c6d52b9f1153cedd3c489300564f932b065c6eab95"
 
 [[package]]
 name = "semver"
@@ -1892,6 +1947,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial_test"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b258109f244e1d6891bf1053a55d63a5cd4f8f4c30cf9a1280989f80e7a1fa9"
+dependencies = [
+ "futures",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1934,6 +2014,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
+name = "slab"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1950,6 +2039,16 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "sppark"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac5090642d9ae844edd9a5c23cb1fce6724ca88d50c55178ee8d1f656df5826b"
+dependencies = [
+ "cc",
+ "which",
+]
 
 [[package]]
 name = "stable_deref_trait"
@@ -2492,6 +2591,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2843,6 +2954,17 @@ dependencies = [
  "winter-fri",
  "winter-math",
  "winter-utils",
+]
+
+[[package]]
+name = "winterfell"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6bdcd01333bbf4a349d8d13f269281524bd6d1a36ae3a853187f0665bf1cfd4"
+dependencies = [
+ "winter-air",
+ "winter-prover",
+ "winter-verifier",
 ]
 
 [[package]]

--- a/air/src/options.rs
+++ b/air/src/options.rs
@@ -129,6 +129,21 @@ impl ProvingOptions {
         self
     }
 
+    /// Sets partitions for this [ProvingOptions].
+    ///
+    /// Partitions can be provided to split traces during proving and distribute work across
+    /// multiple devices. The number of partitions should be equal to the number of devices.
+    pub const fn with_partitions(mut self, num_partitions: usize) -> Self {
+        let hash_rate = match self.hash_fn {
+            HashFunction::Blake3_192 => 6,
+            HashFunction::Blake3_256 => 8,
+            HashFunction::Rpo256 => 8,
+            HashFunction::Rpx256 => 8,
+        };
+        self.proof_options = self.proof_options.with_partitions(num_partitions, hash_rate);
+        self
+    }
+
     // PUBLIC ACCESSORS
     // --------------------------------------------------------------------------------------------
 

--- a/miden/Cargo.toml
+++ b/miden/Cargo.toml
@@ -55,6 +55,7 @@ executable = [
     "dep:rustyline",
     "dep:tracing-subscriber",
 ]
+cuda = ["prover/cuda", "std"]
 metal = ["prover/metal", "std"]
 std = ["assembly/std", "processor/std", "prover/std", "verifier/std"]
 # For internal use, not meant to be used by users

--- a/miden/src/cli/prove.rs
+++ b/miden/src/cli/prove.rs
@@ -4,6 +4,8 @@ use assembly::diagnostics::{IntoDiagnostic, Report, WrapErr};
 use clap::Parser;
 use miden_vm::{internal::InputFile, ProvingOptions};
 use processor::{DefaultHost, ExecutionOptions, ExecutionOptionsError, Program};
+#[cfg(all(target_arch = "x86_64", feature = "cuda"))]
+use prover::get_num_of_gpus;
 use stdlib::StdLibrary;
 use tracing::instrument;
 
@@ -65,6 +67,11 @@ impl ProveCmd {
     pub fn get_proof_options(&self) -> Result<ProvingOptions, ExecutionOptionsError> {
         let exec_options =
             ExecutionOptions::new(Some(self.max_cycles), self.expected_cycles, self.trace, false)?;
+
+        let partitions = 1;
+        #[cfg(all(target_arch = "x86_64", feature = "cuda"))]
+        let partitions = get_num_of_gpus();
+
         Ok(match self.security.as_str() {
             "96bits" => {
                 if self.rpx {
@@ -82,7 +89,8 @@ impl ProveCmd {
             },
             other => panic!("{} is not a valid security setting", other),
         }
-        .with_execution_options(exec_options))
+        .with_execution_options(exec_options)
+        .with_partitions(partitions))
     }
 
     pub fn execute(&self) -> Result<(), Report> {

--- a/prover/Cargo.toml
+++ b/prover/Cargo.toml
@@ -17,7 +17,8 @@ edition.workspace = true
 async = ["winter-maybe-async/async"]
 concurrent = ["processor/concurrent", "std", "winter-prover/concurrent"]
 default = ["std"]
-metal = ["dep:miden-gpu", "dep:elsa", "dep:pollster", "concurrent", "std"]
+metal = ["dep:miden-gpu", "miden-gpu/metal", "dep:elsa", "dep:pollster", "concurrent", "std"]
+cuda = ["dep:miden-gpu", "miden-gpu/cuda", "std"]
 std = ["air/std", "processor/std", "winter-prover/std"]
 
 [dependencies]
@@ -29,5 +30,11 @@ winter-prover = { package = "winter-prover", version = "0.11", default-features 
 
 [target.'cfg(all(target_arch = "aarch64", target_os = "macos"))'.dependencies]
 elsa = { version = "1.9", optional = true }
-miden-gpu = { version = "0.4", optional = true }
+miden-gpu = { path = "../../miden-gpu", optional = true }
 pollster = { version = "0.4", optional = true }
+
+[target.'cfg(target_arch = "x86_64")'.dependencies]
+miden-gpu = { path = "../../miden-gpu", optional = true }
+
+[dev-dependencies]
+serial_test = "3.1"

--- a/prover/README.md
+++ b/prover/README.md
@@ -45,6 +45,7 @@ Miden prover can be compiled with the following features:
 * `std` - enabled by default and relies on the Rust standard library.
 * `concurrent` - implies `std` and also enables multi-threaded proof generation.
 * `metal` - enables [Metal](https://en.wikipedia.org/wiki/Metal_(API))-based acceleration of proof generation (for recursive proofs) on supported platforms (e.g., Apple silicon).
+* `cuda` - enables [Cuda](https://en.wikipedia.org/wiki/CUDA)-based acceleration of proof generation (for recursive proofs) on supported platforms.
 * `no_std` does not rely on the Rust standard library and enables compilation to WebAssembly.
     * Only the `wasm32-unknown-unknown` and `wasm32-wasip1` targets are officially supported.
 

--- a/prover/src/gpu/cuda/mod.rs
+++ b/prover/src/gpu/cuda/mod.rs
@@ -1,0 +1,135 @@
+//! This module contains GPU acceleration logic for Nvidia CUDA devices.
+
+use std::marker::PhantomData;
+
+use air::{AuxRandElements, PartitionOptions};
+use miden_gpu::{
+    cuda::{constraints::CudaConstraintCommitment, merkle::MerkleTree, trace_lde::CudaTraceLde},
+    HashFn,
+};
+use processor::crypto::{ElementHasher, Hasher};
+use winter_prover::{
+    crypto::Digest, matrix::ColMatrix, CompositionPoly, CompositionPolyTrace,
+    ConstraintCompositionCoefficients, DefaultConstraintEvaluator, Prover, StarkDomain, TraceInfo,
+    TracePolyTable,
+};
+
+use crate::{
+    crypto::{RandomCoin, Rpo256},
+    ExecutionProver, ExecutionTrace, Felt, FieldElement, ProcessorAir, PublicInputs,
+    WinterProofOptions,
+};
+
+#[cfg(test)]
+mod tests;
+
+// CONSTANTS
+// ================================================================================================
+
+const DIGEST_SIZE: usize = Rpo256::DIGEST_RANGE.end - Rpo256::DIGEST_RANGE.start;
+
+// CUDA RPO/RPX PROVER
+// ================================================================================================
+
+/// Wraps an [ExecutionProver] and provides GPU acceleration for building trace commitments.
+pub(crate) struct CudaExecutionProver<H, D, R>
+where
+    H: Hasher<Digest = D> + ElementHasher<BaseField = R::BaseField>,
+    D: Digest + From<[Felt; DIGEST_SIZE]> + Into<[Felt; DIGEST_SIZE]>,
+    R: RandomCoin<BaseField = Felt, Hasher = H> + Send,
+{
+    pub execution_prover: ExecutionProver<H, R>,
+    pub hash_fn: HashFn,
+    phantom_data: PhantomData<D>,
+}
+
+impl<H, D, R> CudaExecutionProver<H, D, R>
+where
+    H: Hasher<Digest = D> + ElementHasher<BaseField = R::BaseField>,
+    D: Digest + From<[Felt; DIGEST_SIZE]> + Into<[Felt; DIGEST_SIZE]>,
+    R: RandomCoin<BaseField = Felt, Hasher = H> + Send,
+{
+    pub fn new(execution_prover: ExecutionProver<H, R>, hash_fn: HashFn) -> Self {
+        CudaExecutionProver {
+            execution_prover,
+            hash_fn,
+            phantom_data: PhantomData,
+        }
+    }
+}
+
+impl<H, D, R> Prover for CudaExecutionProver<H, D, R>
+where
+    H: Hasher<Digest = D> + ElementHasher<BaseField = R::BaseField> + Send + Sync,
+    D: Digest + From<[Felt; DIGEST_SIZE]> + Into<[Felt; DIGEST_SIZE]>,
+    R: RandomCoin<BaseField = Felt, Hasher = H> + Send,
+{
+    type BaseField = Felt;
+    type Air = ProcessorAir;
+    type Trace = ExecutionTrace;
+    type VC = MerkleTree<Self::HashFn>;
+    type HashFn = H;
+    type RandomCoin = R;
+    type TraceLde<E: FieldElement<BaseField = Felt>> = CudaTraceLde<E, H>;
+    type ConstraintCommitment<E: FieldElement<BaseField = Felt>> = CudaConstraintCommitment<E, H>;
+    type ConstraintEvaluator<'a, E: FieldElement<BaseField = Felt>> =
+        DefaultConstraintEvaluator<'a, ProcessorAir, E>;
+
+    fn get_pub_inputs(&self, trace: &ExecutionTrace) -> PublicInputs {
+        self.execution_prover.get_pub_inputs(trace)
+    }
+
+    fn options(&self) -> &WinterProofOptions {
+        self.execution_prover.options()
+    }
+
+    fn new_trace_lde<E: FieldElement<BaseField = Felt>>(
+        &self,
+        trace_info: &TraceInfo,
+        main_trace: &ColMatrix<Felt>,
+        domain: &StarkDomain<Felt>,
+        partition_options: PartitionOptions,
+    ) -> (Self::TraceLde<E>, TracePolyTable<E>) {
+        CudaTraceLde::new(trace_info, main_trace, domain, partition_options, self.hash_fn)
+    }
+
+    fn new_evaluator<'a, E: FieldElement<BaseField = Felt>>(
+        &self,
+        air: &'a ProcessorAir,
+        aux_rand_elements: Option<AuxRandElements<E>>,
+        composition_coefficients: ConstraintCompositionCoefficients<E>,
+    ) -> Self::ConstraintEvaluator<'a, E> {
+        self.execution_prover
+            .new_evaluator(air, aux_rand_elements, composition_coefficients)
+    }
+
+    fn build_aux_trace<E>(
+        &self,
+        main_trace: &Self::Trace,
+        aux_rand_elements: &AuxRandElements<E>,
+    ) -> ColMatrix<E>
+    where
+        E: FieldElement<BaseField = Self::BaseField>,
+    {
+        self.execution_prover.build_aux_trace(main_trace, aux_rand_elements)
+    }
+
+    fn build_constraint_commitment<E>(
+        &self,
+        composition_poly_trace: CompositionPolyTrace<E>,
+        num_constraint_composition_columns: usize,
+        domain: &StarkDomain<Self::BaseField>,
+        partition_options: PartitionOptions,
+    ) -> (Self::ConstraintCommitment<E>, CompositionPoly<E>)
+    where
+        E: FieldElement<BaseField = Self::BaseField>,
+    {
+        CudaConstraintCommitment::new(
+            composition_poly_trace,
+            num_constraint_composition_columns,
+            domain,
+            partition_options,
+            self.hash_fn,
+        )
+    }
+}

--- a/prover/src/gpu/cuda/tests.rs
+++ b/prover/src/gpu/cuda/tests.rs
@@ -1,0 +1,234 @@
+use alloc::vec::Vec;
+use std::vec;
+
+use air::{ProvingOptions, StarkField};
+use miden_gpu::{
+    cuda::util::{DIGEST_SIZE, RATE},
+    HashFn,
+};
+use processor::{
+    crypto::{Hasher, RpoDigest, RpoRandomCoin, Rpx256, RpxDigest, RpxRandomCoin},
+    math::fft,
+    StackInputs, StackOutputs,
+};
+use serial_test::serial;
+use winter_prover::{crypto::Digest, CompositionPolyTrace, TraceLde};
+
+use crate::{gpu::cuda::CudaExecutionProver, *};
+
+fn build_trace_commitment_on_gpu_with_padding_matches_cpu<
+    R: RandomCoin<BaseField = Felt, Hasher = H> + Send,
+    H: ElementHasher<BaseField = Felt> + Hasher<Digest = D> + Send + Sync,
+    D: Digest + From<[Felt; DIGEST_SIZE]>,
+>(
+    hash_fn: HashFn,
+) {
+    let is_rpx = matches!(hash_fn, HashFn::Rpx256);
+
+    let cpu_prover = create_test_prover::<R, H>(is_rpx);
+    let gpu_prover = CudaExecutionProver::new(create_test_prover::<R, H>(is_rpx), hash_fn);
+    let num_rows = 1 << 8;
+    let trace_info = get_trace_info(1, num_rows);
+    let trace = gen_random_trace(num_rows, RATE + 1);
+    let domain = StarkDomain::from_twiddles(fft::get_twiddles(num_rows), 8, Felt::GENERATOR);
+
+    let (cpu_trace_lde, cpu_polys) = cpu_prover.new_trace_lde::<Felt>(&trace_info, &trace, &domain);
+    let (gpu_trace_lde, gpu_polys) = gpu_prover.new_trace_lde::<Felt>(&trace_info, &trace, &domain);
+
+    assert_eq!(
+        cpu_trace_lde.get_main_trace_commitment(),
+        gpu_trace_lde.get_main_trace_commitment()
+    );
+    assert_eq!(
+        cpu_polys.main_trace_polys().collect::<Vec<_>>(),
+        gpu_polys.main_trace_polys().collect::<Vec<_>>()
+    );
+}
+
+fn build_trace_commitment_on_gpu_without_padding_matches_cpu<
+    R: RandomCoin<BaseField = Felt, Hasher = H> + Send,
+    H: ElementHasher<BaseField = Felt> + Hasher<Digest = D> + Send + Sync,
+    D: Digest + From<[Felt; DIGEST_SIZE]>,
+>(
+    hash_fn: HashFn,
+) {
+    let is_rpx = matches!(hash_fn, HashFn::Rpx256);
+
+    let cpu_prover = create_test_prover::<R, H>(is_rpx);
+    let gpu_prover = CudaExecutionProver::new(create_test_prover::<R, H>(is_rpx), hash_fn);
+    let num_rows = 1 << 8;
+    let trace_info = get_trace_info(8, num_rows);
+    let trace = gen_random_trace(num_rows, RATE);
+    let domain = StarkDomain::from_twiddles(fft::get_twiddles(num_rows), 8, Felt::GENERATOR);
+
+    let (cpu_trace_lde, cpu_polys) = cpu_prover.new_trace_lde::<Felt>(&trace_info, &trace, &domain);
+    let (gpu_trace_lde, gpu_polys) = gpu_prover.new_trace_lde::<Felt>(&trace_info, &trace, &domain);
+
+    assert_eq!(
+        cpu_trace_lde.get_main_trace_commitment(),
+        gpu_trace_lde.get_main_trace_commitment()
+    );
+    assert_eq!(
+        cpu_polys.main_trace_polys().collect::<Vec<_>>(),
+        gpu_polys.main_trace_polys().collect::<Vec<_>>()
+    );
+}
+
+fn build_constraint_commitment_on_gpu_with_padding_matches_cpu<
+    R: RandomCoin<BaseField = Felt, Hasher = H> + Send,
+    H: ElementHasher<BaseField = Felt> + Hasher<Digest = D> + Send + Sync,
+    D: Digest + From<[Felt; DIGEST_SIZE]>,
+>(
+    hash_fn: HashFn,
+) {
+    let is_rpx = matches!(hash_fn, HashFn::Rpx256);
+
+    let cpu_prover = create_test_prover::<R, H>(is_rpx);
+    let gpu_prover = CudaExecutionProver::new(create_test_prover::<R, H>(is_rpx), hash_fn);
+    let num_rows = 1 << 8;
+    let ce_blowup_factor = 2;
+    let values = get_random_values::<Felt>(num_rows * ce_blowup_factor);
+    let domain = StarkDomain::from_twiddles(fft::get_twiddles(num_rows), 8, Felt::GENERATOR);
+
+    let (commitment_cpu, composition_poly_cpu) = cpu_prover.build_constraint_commitment(
+        CompositionPolyTrace::new(values.clone()),
+        2,
+        &domain,
+    );
+    let (commitment_gpu, composition_poly_gpu) =
+        gpu_prover.build_constraint_commitment(CompositionPolyTrace::new(values), 2, &domain);
+
+    assert_eq!(commitment_cpu.root(), commitment_gpu.root());
+    assert_ne!(0, composition_poly_cpu.data().num_base_cols() % RATE);
+    assert_eq!(composition_poly_cpu.into_columns(), composition_poly_gpu.into_columns());
+}
+
+fn build_constraint_commitment_on_gpu_without_padding_matches_cpu<
+    R: RandomCoin<BaseField = Felt, Hasher = H> + Send,
+    H: ElementHasher<BaseField = Felt> + Hasher<Digest = D> + Send + Sync,
+    D: Digest + From<[Felt; DIGEST_SIZE]>,
+>(
+    hash_fn: HashFn,
+) {
+    let is_rpx = matches!(hash_fn, HashFn::Rpx256);
+
+    let cpu_prover = create_test_prover::<R, H>(is_rpx);
+    let gpu_prover = CudaExecutionProver::new(create_test_prover::<R, H>(is_rpx), hash_fn);
+    let num_rows = 1 << 8;
+    let ce_blowup_factor = 8;
+    let values = get_random_values::<Felt>(num_rows * ce_blowup_factor);
+    let domain = StarkDomain::from_twiddles(fft::get_twiddles(num_rows), 8, Felt::GENERATOR);
+
+    let (commitment_cpu, composition_poly_cpu) = cpu_prover.build_constraint_commitment(
+        CompositionPolyTrace::new(values.clone()),
+        8,
+        &domain,
+    );
+    let (commitment_gpu, composition_poly_gpu) =
+        gpu_prover.build_constraint_commitment(CompositionPolyTrace::new(values), 8, &domain);
+
+    assert_eq!(commitment_cpu.root(), commitment_gpu.root());
+    assert_eq!(0, composition_poly_cpu.data().num_base_cols() % RATE);
+    assert_eq!(composition_poly_cpu.into_columns(), composition_poly_gpu.into_columns());
+}
+
+#[test]
+#[serial]
+fn rpo_build_trace_commitment_on_gpu_with_padding_matches_cpu() {
+    build_trace_commitment_on_gpu_with_padding_matches_cpu::<RpoRandomCoin, Rpo256, RpoDigest>(
+        HashFn::Rpo256,
+    );
+}
+
+#[test]
+#[serial]
+fn rpx_build_trace_commitment_on_gpu_with_padding_matches_cpu() {
+    build_trace_commitment_on_gpu_with_padding_matches_cpu::<RpxRandomCoin, Rpx256, RpxDigest>(
+        HashFn::Rpx256,
+    );
+}
+
+#[test]
+#[serial]
+fn rpo_build_trace_commitment_on_gpu_without_padding_matches_cpu() {
+    build_trace_commitment_on_gpu_without_padding_matches_cpu::<RpoRandomCoin, Rpo256, RpoDigest>(
+        HashFn::Rpo256,
+    );
+}
+
+#[test]
+#[serial]
+fn rpx_build_trace_commitment_on_gpu_without_padding_matches_cpu() {
+    build_trace_commitment_on_gpu_without_padding_matches_cpu::<RpxRandomCoin, Rpx256, RpxDigest>(
+        HashFn::Rpx256,
+    );
+}
+
+#[test]
+#[serial]
+fn rpo_build_constraint_commitment_on_gpu_with_padding_matches_cpu() {
+    build_constraint_commitment_on_gpu_with_padding_matches_cpu::<RpoRandomCoin, Rpo256, RpoDigest>(
+        HashFn::Rpo256,
+    );
+}
+
+#[test]
+#[serial]
+fn rpx_build_constraint_commitment_on_gpu_with_padding_matches_cpu() {
+    build_constraint_commitment_on_gpu_with_padding_matches_cpu::<RpxRandomCoin, Rpx256, RpxDigest>(
+        HashFn::Rpx256,
+    );
+}
+
+#[test]
+#[serial]
+fn rpo_build_constraint_commitment_on_gpu_without_padding_matches_cpu() {
+    build_constraint_commitment_on_gpu_without_padding_matches_cpu::<
+        RpoRandomCoin,
+        Rpo256,
+        RpoDigest,
+    >(HashFn::Rpo256);
+}
+
+#[test]
+#[serial]
+fn rpx_build_constraint_commitment_on_gpu_without_padding_matches_cpu() {
+    build_constraint_commitment_on_gpu_without_padding_matches_cpu::<
+        RpxRandomCoin,
+        Rpx256,
+        RpxDigest,
+    >(HashFn::Rpx256);
+}
+
+fn gen_random_trace(num_rows: usize, num_cols: usize) -> ColMatrix<Felt> {
+    ColMatrix::new((0..num_cols as u64).map(|col| vec![Felt::new(col); num_rows]).collect())
+}
+
+fn get_random_values<E: FieldElement>(num_rows: usize) -> Vec<E> {
+    (0..num_rows).map(|i| E::from(i as u32)).collect()
+}
+
+fn get_trace_info(num_cols: usize, num_rows: usize) -> TraceInfo {
+    TraceInfo::new(num_cols, num_rows)
+}
+
+fn create_test_prover<
+    R: RandomCoin<BaseField = Felt, Hasher = H> + Send,
+    H: ElementHasher<BaseField = Felt>,
+>(
+    use_rpx: bool,
+) -> ExecutionProver<H, R> {
+    if use_rpx {
+        ExecutionProver::new(
+            ProvingOptions::with_128_bit_security_rpx(),
+            StackInputs::default(),
+            StackOutputs::default(),
+        )
+    } else {
+        ExecutionProver::new(
+            ProvingOptions::with_128_bit_security(true),
+            StackInputs::default(),
+            StackOutputs::default(),
+        )
+    }
+}

--- a/prover/src/gpu/metal/mod.rs
+++ b/prover/src/gpu/metal/mod.rs
@@ -120,7 +120,31 @@ where
             .new_evaluator(air, aux_rand_elements, composition_coefficients)
     }
 
-    fn build_constraint_commitment<E: FieldElement<BaseField = Felt>>(
+    /// Evaluates constraint composition polynomial over the LDE domain and builds a commitment
+    /// to these evaluations.
+    ///
+    /// The evaluation is done by evaluating each composition polynomial column over the LDE
+    /// domain.
+    ///
+    /// The commitment is computed by hashing each row in the evaluation matrix, and then building
+    /// a Merkle tree from the resulting hashes.
+    ///
+    /// The composition polynomial columns are evaluated on the CPU. Afterwards the commitment
+    /// is computed on the GPU.
+    ///
+    /// ```text
+    ///        ─────────────────────────────────────────────────────
+    ///              ┌───┐ ┌───┐
+    ///  CPU:   ... ─┤fft├─┤fft├─┐                           ┌─ ...
+    ///              └───┘ └───┘ │                           │
+    ///        ╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴┼╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴┼╴╴╴╴╴╴
+    ///                          │ ┌──────────┐ ┌──────────┐ │
+    ///  GPU:                    └─┤   hash   ├─┤   hash   ├─┘
+    ///                            └──────────┘ └──────────┘
+    ///        ────┼────────┼────────┼────────┼────────┼────────┼───
+    ///           t=n     t=n+1    t=n+2     t=n+3   t=n+4    t=n+5
+    /// ```
+    fn build_constraint_commitment<E: FieldElement<BaseField = Self::BaseField>>(
         &self,
         composition_poly_trace: CompositionPolyTrace<E>,
         num_constraint_composition_columns: usize,

--- a/prover/src/gpu/mod.rs
+++ b/prover/src/gpu/mod.rs
@@ -1,2 +1,5 @@
 #[cfg(all(feature = "metal", target_arch = "aarch64", target_os = "macos"))]
 pub mod metal;
+
+#[cfg(all(feature = "cuda", target_arch = "x86_64"))]
+pub mod cuda;

--- a/verifier/src/lib.rs
+++ b/verifier/src/lib.rs
@@ -83,6 +83,14 @@ pub fn verify(
             let opts = AcceptableOptions::OptionSet(vec![
                 ProvingOptions::RECURSIVE_96_BITS,
                 ProvingOptions::RECURSIVE_128_BITS,
+                ProvingOptions::RECURSIVE_96_BITS.with_partitions(1, 8),
+                ProvingOptions::RECURSIVE_128_BITS.with_partitions(1, 8),
+                ProvingOptions::RECURSIVE_96_BITS.with_partitions(2, 8),
+                ProvingOptions::RECURSIVE_128_BITS.with_partitions(2, 8),
+                ProvingOptions::RECURSIVE_96_BITS.with_partitions(3, 8),
+                ProvingOptions::RECURSIVE_128_BITS.with_partitions(3, 8),
+                ProvingOptions::RECURSIVE_96_BITS.with_partitions(4, 8),
+                ProvingOptions::RECURSIVE_128_BITS.with_partitions(4, 8),
             ]);
             verify_proof::<ProcessorAir, Rpo256, RpoRandomCoin, MerkleTree<_>>(
                 proof, pub_inputs, &opts,
@@ -92,6 +100,14 @@ pub fn verify(
             let opts = AcceptableOptions::OptionSet(vec![
                 ProvingOptions::RECURSIVE_96_BITS,
                 ProvingOptions::RECURSIVE_128_BITS,
+                ProvingOptions::RECURSIVE_96_BITS.with_partitions(1, 8),
+                ProvingOptions::RECURSIVE_128_BITS.with_partitions(1, 8),
+                ProvingOptions::RECURSIVE_96_BITS.with_partitions(2, 8),
+                ProvingOptions::RECURSIVE_128_BITS.with_partitions(2, 8),
+                ProvingOptions::RECURSIVE_96_BITS.with_partitions(3, 8),
+                ProvingOptions::RECURSIVE_128_BITS.with_partitions(3, 8),
+                ProvingOptions::RECURSIVE_96_BITS.with_partitions(4, 8),
+                ProvingOptions::RECURSIVE_128_BITS.with_partitions(4, 8),
             ]);
             verify_proof::<ProcessorAir, Rpx256, RpxRandomCoin, MerkleTree<_>>(
                 proof, pub_inputs, &opts,


### PR DESCRIPTION
Integrate CUDA hardware acceleration from miden-gpu. Supersedes https://github.com/0xPolygonMiden/miden-vm/pull/1474 and https://github.com/0xPolygonMiden/miden-vm/pull/1589

Blocked on the release of https://github.com/0xPolygonMiden/miden-gpu/pull/41. Make sure to update Cargo.toml