### PR TITLE
Assembler: enable vendoring of compiled libraries (fixes #1435)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### Changes
 - Update minimum supported Rust version to 1.84.
 - Change Chiplet Fields to Public (#1629).
+- Added to the `Assembler` the ability to vendor a compiled library.
 
 
 ## 0.12.0 (2025-01-22)

--- a/assembly/src/assembler/mast_forest_builder.rs
+++ b/assembly/src/assembler/mast_forest_builder.rs
@@ -487,14 +487,11 @@ impl MastForestBuilder {
     ) -> Result<MastNodeId, AssemblyError> {
         if let Some(root_id) = self.vendored_mast.find_procedure_root(mast_root) {
             for old_id in SubtreeIterator::new(&root_id, &self.vendored_mast.clone()) {
-                let mut node = self.vendored_mast[old_id].clone();
-                node.remap_children(&self.vendored_remapping);
+                let node = self.vendored_mast[old_id].remap_children(&self.vendored_remapping);
                 let new_id = self.ensure_node(node)?;
                 self.vendored_remapping.insert(old_id, new_id);
             }
-            let mut new_root_id = root_id;
-            new_root_id.remap(&self.vendored_remapping);
-            Ok(root_id)
+            Ok(root_id.remap(&self.vendored_remapping))
         } else {
             self.ensure_node(MastNode::new_external(mast_root))
         }

--- a/assembly/src/assembler/mast_forest_builder.rs
+++ b/assembly/src/assembler/mast_forest_builder.rs
@@ -1,19 +1,22 @@
 use alloc::{
     collections::{BTreeMap, BTreeSet},
+    sync::Arc,
     vec::Vec,
 };
 use core::ops::{Index, IndexMut};
 
+use miette::{IntoDiagnostic, Report};
 use vm_core::{
     crypto::hash::RpoDigest,
     mast::{
         DecoratorFingerprint, DecoratorId, MastForest, MastNode, MastNodeFingerprint, MastNodeId,
+        Remapping, SubtreeIterator,
     },
     Decorator, DecoratorList, Operation,
 };
 
 use super::{GlobalProcedureIndex, Procedure};
-use crate::AssemblyError;
+use crate::{AssemblyError, Library};
 
 // CONSTANTS
 // ================================================================================================
@@ -59,9 +62,36 @@ pub struct MastForestBuilder {
     /// used as a candidate set of nodes that may be eliminated if the are not referenced by any
     /// other node in the forest and are not a root of any procedure.
     merged_basic_block_ids: BTreeSet<MastNodeId>,
+    /// A MastForest that contains vendored libraries, it's used to find precompiled procedures and
+    /// copy their subtrees instead of inserting external nodes.
+    vendored_mast: Arc<MastForest>,
+    /// Keeps track of the new ids assigned to nodes that are copied from the vendored_mast.
+    vendored_remapping: Remapping,
 }
 
 impl MastForestBuilder {
+    /// Creates a new builder that can access vendored libraries.
+    ///
+    /// When [`Self::vendor_or_ensure_external`] is called, if the root is present in the vendored
+    /// libraries, the body of the function is copied in the MAST Forest being built. Otherwise an
+    /// external node is inserted and the funtion body is expected to be found in a library added at
+    /// runtime.
+    pub fn new<'a>(
+        vendored_libraries: impl IntoIterator<Item = &'a Library>,
+    ) -> Result<Self, Report> {
+        // All vendored library are merged into a single MastForest.
+        let forests = vendored_libraries.into_iter().map(|lib| lib.mast_forest().as_ref());
+        let (vendored_mast, _remapping) = MastForest::merge(forests).into_diagnostic()?;
+        // The adviceMap of the vendored forest is copied to the forest being built.
+        let mut mast_forest = MastForest::default();
+        *mast_forest.advice_map_mut() = vendored_mast.advice_map().clone();
+        Ok(MastForestBuilder {
+            mast_forest,
+            vendored_mast: Arc::new(vendored_mast),
+            ..Self::default()
+        })
+    }
+
     /// Removes the unused nodes that were created as part of the assembly process, and returns the
     /// resulting MAST forest.
     ///
@@ -449,9 +479,25 @@ impl MastForestBuilder {
         self.ensure_node(MastNode::new_dyncall())
     }
 
-    /// Adds an external node to the forest, and returns the [`MastNodeId`] associated with it.
-    pub fn ensure_external(&mut self, mast_root: RpoDigest) -> Result<MastNodeId, AssemblyError> {
-        self.ensure_node(MastNode::new_external(mast_root))
+    /// If the root is present in the vendored MAST, its subtree is copied. Otherwise an
+    /// external node is added to the forest.
+    pub fn vendor_or_ensure_external(
+        &mut self,
+        mast_root: RpoDigest,
+    ) -> Result<MastNodeId, AssemblyError> {
+        if let Some(root_id) = self.vendored_mast.find_procedure_root(mast_root) {
+            for old_id in SubtreeIterator::new(&root_id, &self.vendored_mast.clone()) {
+                let mut node = self.vendored_mast[old_id].clone();
+                node.remap_children(&self.vendored_remapping);
+                let new_id = self.ensure_node(node)?;
+                self.vendored_remapping.insert(old_id, new_id);
+            }
+            let mut new_root_id = root_id;
+            new_root_id.remap(&self.vendored_remapping);
+            Ok(root_id)
+        } else {
+            self.ensure_node(MastNode::new_external(mast_root))
+        }
     }
 
     pub fn set_before_enter(&mut self, node_id: MastNodeId, decorator_ids: Vec<DecoratorId>) {

--- a/assembly/src/assembler/mast_forest_builder.rs
+++ b/assembly/src/assembler/mast_forest_builder.rs
@@ -65,10 +65,9 @@ impl MastForestBuilder {
     /// Removes the unused nodes that were created as part of the assembly process, and returns the
     /// resulting MAST forest.
     ///
-    /// It also returns the map from old node IDs to new node IDs; or `None` if the `MastForest` was
-    /// unchanged. Any [`MastNodeId`] used in reference to the old [`MastForest`] should be remapped
-    /// using this map.
-    pub fn build(mut self) -> (MastForest, Option<BTreeMap<MastNodeId, MastNodeId>>) {
+    /// It also returns the map from old node IDs to new node IDs. Any [`MastNodeId`] used in
+    /// reference to the old [`MastForest`] should be remapped using this map.
+    pub fn build(mut self) -> (MastForest, BTreeMap<MastNodeId, MastNodeId>) {
         let nodes_to_remove = get_nodes_to_remove(self.merged_basic_block_ids, &self.mast_forest);
         let id_remappings = self.mast_forest.remove_nodes(&nodes_to_remove);
 

--- a/assembly/src/assembler/mod.rs
+++ b/assembly/src/assembler/mod.rs
@@ -326,11 +326,9 @@ impl Assembler {
         };
 
         let (mast_forest, id_remappings) = mast_forest_builder.build();
-        if let Some(id_remappings) = id_remappings {
-            for (_proc_name, node_id) in exports.iter_mut() {
-                if let Some(&new_node_id) = id_remappings.get(node_id) {
-                    *node_id = new_node_id;
-                }
+        for (_proc_name, node_id) in exports.iter_mut() {
+            if let Some(&new_node_id) = id_remappings.get(node_id) {
+                *node_id = new_node_id;
             }
         }
 
@@ -402,9 +400,7 @@ impl Assembler {
 
         // in case the node IDs changed, update the entrypoint ID to the new value
         let (mast_forest, id_remappings) = mast_forest_builder.build();
-        let entry_node_id = id_remappings
-            .map(|id_remappings| id_remappings[&entry_node_id])
-            .unwrap_or(entry_node_id);
+        let entry_node_id = id_remappings.get(&entry_node_id).unwrap_or(&entry_node_id);
 
         Ok(Program::with_kernel(
             mast_forest.into(),

--- a/assembly/src/assembler/mod.rs
+++ b/assembly/src/assembler/mod.rs
@@ -170,7 +170,7 @@ impl Assembler {
         module: impl Compile,
         options: CompileOptions,
     ) -> Result<ModuleIndex, Report> {
-        let ids = self.add_modules_with_options(vec![module], options)?;
+        let ids = self.add_modules_with_options([module], options)?;
         Ok(ids[0])
     }
 
@@ -196,7 +196,7 @@ impl Assembler {
                 Ok(module)
             })
             .collect::<Result<Vec<_>, Report>>()?;
-        let ids = self.module_graph.add_ast_modules(modules.into_iter())?;
+        let ids = self.module_graph.add_ast_modules(modules)?;
         Ok(ids)
     }
     /// Adds all modules (defined by ".masm" files) from the specified directory to the module

--- a/assembly/src/assembler/mod.rs
+++ b/assembly/src/assembler/mod.rs
@@ -71,6 +71,8 @@ pub struct Assembler {
     warnings_as_errors: bool,
     /// Whether the assembler enables extra debugging information.
     in_debug_mode: bool,
+    /// Collects libraries that can be used during assembly to vendor procedures.
+    vendored_libraries: BTreeMap<RpoDigest, Library>,
 }
 
 impl Default for Assembler {
@@ -82,6 +84,7 @@ impl Default for Assembler {
             module_graph,
             warnings_as_errors: false,
             in_debug_mode: false,
+            vendored_libraries: BTreeMap::new(),
         }
     }
 }
@@ -97,6 +100,7 @@ impl Assembler {
             module_graph,
             warnings_as_errors: false,
             in_debug_mode: false,
+            vendored_libraries: BTreeMap::new(),
         }
     }
 
@@ -223,13 +227,11 @@ impl Assembler {
 
     /// Adds the compiled library to provide modules for the compilation.
     ///
-    /// We only current support adding non-vendored libraries - that is, the source code of exported
-    /// procedures is not included in the program that compiles against the library. The library's
-    /// source code is instead expected to be loaded in the processor at execution time. Hence, all
-    /// calls to library procedures will be compiled down to a [`vm_core::mast::ExternalNode`] (i.e.
-    /// a reference to the procedure's MAST root). This means that when executing a program compiled
-    /// against a library, the processor will not be able to differentiate procedures with the same
-    /// MAST root but different decorators.
+    /// All calls to the library's procedures will be compiled down to a
+    /// [`vm_core::mast::ExternalNode`] (i.e. a reference to the procedure's MAST root).
+    /// The library's source code is expected to be loaded in the processor at execution time.
+    /// This means that when executing a program compiled against a library, the processor will not
+    /// be able to differentiate procedures with the same MAST root but different decorators.
     ///
     /// Hence, it is not recommended to export two procedures that have the same MAST root (i.e. are
     /// identical except for their decorators). Note however that we don't expect this scenario to
@@ -249,6 +251,27 @@ impl Assembler {
     /// See [`Self::add_library`] for more detailed information.
     pub fn with_library(mut self, library: impl AsRef<Library>) -> Result<Self, Report> {
         self.add_library(library)?;
+        Ok(self)
+    }
+
+    /// Adds a compiled library from which procedures will be vendored into the assembled code.
+    ///
+    /// Vendoring in this context means that when a procedure from this library is invoked from the
+    /// assembled code, the entire procedure MAST will be copied into the assembled code. Thus,
+    /// when the resulting code is executed on the VM, the vendored library does not need to be
+    /// provided to the VM to resolve external calls.
+    pub fn add_vendored_library(&mut self, library: impl AsRef<Library>) -> Result<(), Report> {
+        self.add_library(&library)?;
+        self.vendored_libraries
+            .insert(*library.as_ref().digest(), library.as_ref().clone());
+        Ok(())
+    }
+
+    /// Adds a compiled library from which procedures will be vendored into the assembled code.
+    ///
+    /// See [`Self::add_vendored_library`]
+    pub fn with_vendored_library(mut self, library: impl AsRef<Library>) -> Result<Self, Report> {
+        self.add_vendored_library(library)?;
         Ok(self)
     }
 }
@@ -298,9 +321,9 @@ impl Assembler {
         modules: impl IntoIterator<Item = impl Compile>,
         options: CompileOptions,
     ) -> Result<Library, Report> {
-        let ast_module_indices = self.add_modules_with_options(modules, options)?;
+        let mut mast_forest_builder = MastForestBuilder::new(self.vendored_libraries.values())?;
 
-        let mut mast_forest_builder = MastForestBuilder::default();
+        let ast_module_indices = self.add_modules_with_options(modules, options)?;
 
         let mut exports = {
             let mut exports = BTreeMap::new();
@@ -391,7 +414,8 @@ impl Assembler {
             .ok_or(SemanticAnalysisError::MissingEntrypoint)?;
 
         // Compile the module graph rooted at the entrypoint
-        let mut mast_forest_builder = MastForestBuilder::default();
+        let mut mast_forest_builder = MastForestBuilder::new(self.vendored_libraries.values())?;
+
         self.compile_subgraph(entrypoint, &mut mast_forest_builder)?;
         let entry_node_id = mast_forest_builder
             .get_procedure(entrypoint)
@@ -400,7 +424,7 @@ impl Assembler {
 
         // in case the node IDs changed, update the entrypoint ID to the new value
         let (mast_forest, id_remappings) = mast_forest_builder.build();
-        let entry_node_id = id_remappings.get(&entry_node_id).unwrap_or(&entry_node_id);
+        let entry_node_id = *id_remappings.get(&entry_node_id).unwrap_or(&entry_node_id);
 
         Ok(Program::with_kernel(
             mast_forest.into(),
@@ -765,8 +789,10 @@ impl Assembler {
         }
     }
 
-    /// Verifies the validity of the MAST root as a procedure root hash, and returns the ID of the
-    /// [`core::mast::ExternalNode`] that wraps it.
+    /// Verifies the validity of the MAST root as a procedure root hash, and adds it to the forest.
+    ///
+    /// If the root is present in the vendored MAST, its subtree is copied. Otherwise an
+    /// external node is added to the forest.
     fn ensure_valid_procedure_mast_root(
         &self,
         kind: InvokeKind,
@@ -818,7 +844,7 @@ impl Assembler {
             Some(_) | None => (),
         }
 
-        mast_forest_builder.ensure_external(mast_root)
+        mast_forest_builder.vendor_or_ensure_external(mast_root)
     }
 }
 

--- a/assembly/src/assembler/module_graph/mod.rs
+++ b/assembly/src/assembler/module_graph/mod.rs
@@ -207,10 +207,6 @@ impl ModuleGraph {
 
     /// Add `module` to the graph.
     ///
-    /// NOTE: This operation only adds a module to the graph, but does not perform the
-    /// important analysis needed for compilation, you must call [recompute] once all modules
-    /// are added to ensure the analysis results reflect the current version of the graph.
-    ///
     /// # Errors
     ///
     /// This operation can fail for the following reasons:
@@ -223,9 +219,8 @@ impl ModuleGraph {
     /// This function will panic if the number of modules exceeds the maximum representable
     /// [ModuleIndex] value, `u16::MAX`.
     pub fn add_ast_module(&mut self, module: Box<Module>) -> Result<ModuleIndex, AssemblyError> {
-        let res = self.add_module(PendingWrappedModule::Ast(module))?;
-        self.recompute()?;
-        Ok(res)
+        let ids = self.add_ast_modules([module])?;
+        Ok(ids[0])
     }
 
     fn add_module(&mut self, module: PendingWrappedModule) -> Result<ModuleIndex, AssemblyError> {
@@ -242,7 +237,7 @@ impl ModuleGraph {
 
     pub fn add_ast_modules(
         &mut self,
-        modules: impl Iterator<Item = Box<Module>>,
+        modules: impl IntoIterator<Item = Box<Module>>,
     ) -> Result<Vec<ModuleIndex>, AssemblyError> {
         let idx = modules
             .into_iter()

--- a/core/src/mast/mod.rs
+++ b/core/src/mast/mod.rs
@@ -179,15 +179,14 @@ impl MastForest {
     /// removal (i.e. will point to an incorrect node after the removal), and this removal operation
     /// would result in an invalid [`MastForest`].
     ///
-    /// It also returns the map from old node IDs to new node IDs; or `None` if the set of nodes to
-    /// remove was empty. Any [`MastNodeId`] used in reference to the old [`MastForest`] should be
-    /// remapped using this map.
+    /// It also returns the map from old node IDs to new node IDs. Any [`MastNodeId`] used in
+    /// reference to the old [`MastForest`] should be remapped using this map.
     pub fn remove_nodes(
         &mut self,
         nodes_to_remove: &BTreeSet<MastNodeId>,
-    ) -> Option<BTreeMap<MastNodeId, MastNodeId>> {
+    ) -> BTreeMap<MastNodeId, MastNodeId> {
         if nodes_to_remove.is_empty() {
-            return None;
+            return [].into();
         }
 
         let old_nodes = mem::take(&mut self.nodes);
@@ -196,7 +195,7 @@ impl MastForest {
 
         self.remap_and_add_nodes(retained_nodes, &id_remappings);
         self.remap_and_add_roots(old_root_ids, &id_remappings);
-        Some(id_remappings)
+        id_remappings
     }
 
     pub fn set_before_enter(&mut self, node_id: MastNodeId, decorator_ids: Vec<DecoratorId>) {

--- a/core/src/mast/mod.rs
+++ b/core/src/mast/mod.rs
@@ -599,10 +599,8 @@ impl MastNodeId {
     }
 
     /// Remap the NodeId to its new position using the given [`Remapping`].
-    pub fn remap(&mut self, remapping: &Remapping) {
-        if let Some(new_id) = remapping.get(self) {
-            self.0 = new_id.0
-        }
+    pub fn remap(&self, remapping: &Remapping) -> Self {
+        *remapping.get(self).unwrap_or(self)
     }
 }
 

--- a/core/src/mast/node/call_node.rs
+++ b/core/src/mast/node/call_node.rs
@@ -169,8 +169,10 @@ impl CallNode {
 
 /// Mutators
 impl CallNode {
-    pub fn remap_children(&mut self, remapping: &Remapping) {
-        self.callee.remap(remapping)
+    pub fn remap_children(&self, remapping: &Remapping) -> Self {
+        let mut node = self.clone();
+        node.callee = node.callee.remap(remapping);
+        node
     }
 
     /// Sets the list of decorators to be executed before this node.

--- a/core/src/mast/node/call_node.rs
+++ b/core/src/mast/node/call_node.rs
@@ -9,7 +9,7 @@ use miden_formatting::{
 
 use crate::{
     chiplets::hasher,
-    mast::{DecoratorId, MastForest, MastForestError, MastNodeId},
+    mast::{DecoratorId, MastForest, MastForestError, MastNodeId, Remapping},
     OPCODE_CALL, OPCODE_SYSCALL,
 };
 
@@ -169,6 +169,10 @@ impl CallNode {
 
 /// Mutators
 impl CallNode {
+    pub fn remap_children(&mut self, remapping: &Remapping) {
+        self.callee.remap(remapping)
+    }
+
     /// Sets the list of decorators to be executed before this node.
     pub fn set_before_enter(&mut self, decorator_ids: Vec<DecoratorId>) {
         self.before_enter = decorator_ids;

--- a/core/src/mast/node/join_node.rs
+++ b/core/src/mast/node/join_node.rs
@@ -110,9 +110,11 @@ impl JoinNode {
 
 /// Mutators
 impl JoinNode {
-    pub fn remap_children(&mut self, remapping: &Remapping) {
-        self.children[0].remap(remapping);
-        self.children[1].remap(remapping);
+    pub fn remap_children(&self, remapping: &Remapping) -> Self {
+        let mut node = self.clone();
+        node.children[0] = node.children[0].remap(remapping);
+        node.children[1] = node.children[1].remap(remapping);
+        node
     }
 
     /// Sets the list of decorators to be executed before this node.

--- a/core/src/mast/node/join_node.rs
+++ b/core/src/mast/node/join_node.rs
@@ -5,7 +5,7 @@ use miden_crypto::{hash::rpo::RpoDigest, Felt};
 
 use crate::{
     chiplets::hasher,
-    mast::{DecoratorId, MastForest, MastForestError, MastNodeId},
+    mast::{DecoratorId, MastForest, MastForestError, MastNodeId, Remapping},
     prettier::PrettyPrint,
     OPCODE_JOIN,
 };
@@ -110,6 +110,11 @@ impl JoinNode {
 
 /// Mutators
 impl JoinNode {
+    pub fn remap_children(&mut self, remapping: &Remapping) {
+        self.children[0].remap(remapping);
+        self.children[1].remap(remapping);
+    }
+
     /// Sets the list of decorators to be executed before this node.
     pub fn set_before_enter(&mut self, decorator_ids: Vec<DecoratorId>) {
         self.before_enter = decorator_ids;

--- a/core/src/mast/node/loop_node.rs
+++ b/core/src/mast/node/loop_node.rs
@@ -6,7 +6,7 @@ use miden_formatting::prettier::PrettyPrint;
 
 use crate::{
     chiplets::hasher,
-    mast::{DecoratorId, MastForest, MastForestError, MastNodeId},
+    mast::{DecoratorId, MastForest, MastForestError, MastNodeId, Remapping},
     OPCODE_LOOP,
 };
 
@@ -99,6 +99,10 @@ impl LoopNode {
 
 /// Mutators
 impl LoopNode {
+    pub fn remap_children(&mut self, remapping: &Remapping) {
+        self.body.remap(remapping);
+    }
+
     /// Sets the list of decorators to be executed before this node.
     pub fn set_before_enter(&mut self, decorator_ids: Vec<DecoratorId>) {
         self.before_enter = decorator_ids;

--- a/core/src/mast/node/loop_node.rs
+++ b/core/src/mast/node/loop_node.rs
@@ -99,8 +99,10 @@ impl LoopNode {
 
 /// Mutators
 impl LoopNode {
-    pub fn remap_children(&mut self, remapping: &Remapping) {
-        self.body.remap(remapping);
+    pub fn remap_children(&self, remapping: &Remapping) -> Self {
+        let mut node = self.clone();
+        node.body = node.body.remap(remapping);
+        node
     }
 
     /// Sets the list of decorators to be executed before this node.

--- a/core/src/mast/node/mod.rs
+++ b/core/src/mast/node/mod.rs
@@ -144,13 +144,14 @@ impl MastNode {
     }
 
     /// Remap the node children to their new positions indicated by the given [`Remapping`].
-    pub fn remap_children(&mut self, remapping: &Remapping) {
+    pub fn remap_children(&self, remapping: &Remapping) -> Self {
+        use MastNode::*;
         match self {
-            MastNode::Join(join_node) => join_node.remap_children(remapping),
-            MastNode::Split(split_node) => split_node.remap_children(remapping),
-            MastNode::Loop(loop_node) => loop_node.remap_children(remapping),
-            MastNode::Call(call_node) => call_node.remap_children(remapping),
-            MastNode::Block(_) | MastNode::Dyn(_) | MastNode::External(_) => (),
+            Join(join_node) => Join(join_node.remap_children(remapping)),
+            Split(split_node) => Split(split_node.remap_children(remapping)),
+            Loop(loop_node) => Loop(loop_node.remap_children(remapping)),
+            Call(call_node) => Call(call_node.remap_children(remapping)),
+            Block(_) | Dyn(_) | External(_) => self.clone(),
         }
     }
 

--- a/core/src/mast/node/split_node.rs
+++ b/core/src/mast/node/split_node.rs
@@ -112,9 +112,11 @@ impl SplitNode {
 
 /// Mutators
 impl SplitNode {
-    pub fn remap_children(&mut self, remapping: &Remapping) {
-        self.branches[0].remap(remapping);
-        self.branches[1].remap(remapping);
+    pub fn remap_children(&self, remapping: &Remapping) -> Self {
+        let mut node = self.clone();
+        node.branches[0] = node.branches[0].remap(remapping);
+        node.branches[1] = node.branches[1].remap(remapping);
+        node
     }
 
     /// Sets the list of decorators to be executed before this node.

--- a/core/src/mast/node/split_node.rs
+++ b/core/src/mast/node/split_node.rs
@@ -6,7 +6,7 @@ use miden_formatting::prettier::PrettyPrint;
 
 use crate::{
     chiplets::hasher,
-    mast::{DecoratorId, MastForest, MastForestError, MastNodeId},
+    mast::{DecoratorId, MastForest, MastForestError, MastNodeId, Remapping},
     OPCODE_SPLIT,
 };
 
@@ -112,6 +112,11 @@ impl SplitNode {
 
 /// Mutators
 impl SplitNode {
+    pub fn remap_children(&mut self, remapping: &Remapping) {
+        self.branches[0].remap(remapping);
+        self.branches[1].remap(remapping);
+    }
+
     /// Sets the list of decorators to be executed before this node.
     pub fn set_before_enter(&mut self, decorator_ids: Vec<DecoratorId>) {
         self.before_enter = decorator_ids;

--- a/miden/tests/integration/cli/cli_test.rs
+++ b/miden/tests/integration/cli/cli_test.rs
@@ -103,3 +103,25 @@ fn cli_bundle_output() {
     assert!(Path::new("test.masl").exists());
     fs::remove_file("test.masl").unwrap()
 }
+
+#[test]
+// First compile a library to a .masl file, then run a program that uses it.
+fn cli_run_with_lib() -> Result<(), Box<dyn std::error::Error>> {
+    let mut cmd = bin_under_test().command();
+    cmd.arg("bundle")
+        .arg("./tests/integration/cli/data/lib")
+        .arg("--output")
+        .arg("lib.masl");
+    cmd.assert().success();
+
+    let mut cmd = bin_under_test().command();
+    cmd.arg("run")
+        .arg("-a")
+        .arg("./tests/integration/cli/data/main.masm")
+        .arg("-l")
+        .arg("./lib.masl");
+    cmd.assert().success();
+
+    fs::remove_file("lib.masl").unwrap();
+    Ok(())
+}

--- a/miden/tests/integration/cli/data/main.masm
+++ b/miden/tests/integration/cli/data/main.masm
@@ -1,0 +1,5 @@
+use.lib::lib
+
+begin
+    exec.lib::lib_proc
+end


### PR DESCRIPTION
Before this MR, the only ways to link a library during assembly are:
- Add the module sources. The library is effectively recompiled as part of the new library/program
- Add a compiled library. In this case all references to this library are compiled as external nodes

This MR adds the possibility to link a compiled library during assembly but have its MAST forest be merged in the resulting library/program. Two desirable properties:
- No external nodes are added for procedures that are present in vendored libraries, which improves performance.
- No unused procedures are present in the resulting program/library. If the vendored library contains extra unused procedures they are removed during assembly.