### PR TITLE
fix: syscall/dyncall/call in syscall now returns an error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [BREAKING] Introduced `HORNERBASE`, `HORNEREXT` and removed `RCOMBBASE` (#1656).
 - Update Falcon verification procedure to use `HORNERBASE` (#1661).
 - Fix the docs and implementation of `EXPACC` (#1676)
+- Running a call/syscall/dyncall while processing a syscall now results in an error (#1680)
 
 
 ## 0.12.0 (2025-01-22)

--- a/processor/src/decoder/tests.rs
+++ b/processor/src/decoder/tests.rs
@@ -10,9 +10,11 @@ use miden_air::trace::{
     CTX_COL_IDX, DECODER_TRACE_RANGE, DECODER_TRACE_WIDTH, FMP_COL_IDX, FN_HASH_RANGE,
     IN_SYSCALL_COL_IDX, SYS_TRACE_RANGE, SYS_TRACE_WIDTH,
 };
+use rstest::rstest;
 use test_utils::rand::rand_value;
 use vm_core::{
-    mast::{BasicBlockNode, MastForest, MastNode, OP_BATCH_SIZE},
+    assert_matches,
+    mast::{BasicBlockNode, MastForest, MastNode, MastNodeId, OP_BATCH_SIZE},
     Program, EMPTY_WORD, ONE, ZERO,
 };
 
@@ -22,7 +24,7 @@ use super::{
     },
     build_op_group,
 };
-use crate::DefaultHost;
+use crate::{DefaultHost, ExecutionError};
 
 // CONSTANTS
 // ================================================================================================
@@ -1416,6 +1418,48 @@ fn dyn_block() {
         assert_eq!(ONE, trace[OP_BITS_EXTRA_COLS_RANGE.start + 1][i]);
         assert_eq!(program_hash, get_hasher_state1(&trace, i));
     }
+}
+
+/// Tests that call, dyncall and syscall are disallowed in a syscall context
+#[rstest]
+#[case(Operation::Dyncall)]
+#[case(Operation::Call)]
+#[case(Operation::SysCall)]
+fn calls_in_syscall(#[case] op: Operation) {
+    let mut process =
+        Process::new(Kernel::default(), StackInputs::default(), ExecutionOptions::default());
+    // set `in_syscall` flag to true
+    process.system.start_syscall();
+
+    let program = {
+        let mut mast_forest = MastForest::new();
+
+        // add dummy block
+        mast_forest.add_block(vec![Operation::Add], None).unwrap();
+
+        let node = match op {
+            Operation::Dyncall => MastNode::new_dyncall(),
+            Operation::Call => MastNode::new_call(
+                MastNodeId::from_u32_safe(0, &mast_forest).unwrap(),
+                &mast_forest,
+            )
+            .unwrap(),
+            Operation::SysCall => MastNode::new_syscall(
+                MastNodeId::from_u32_safe(0, &mast_forest).unwrap(),
+                &mast_forest,
+            )
+            .unwrap(),
+            _ => unreachable!(),
+        };
+
+        let call_node_id = mast_forest.add_node(node).unwrap();
+        mast_forest.make_root(call_node_id);
+
+        Program::new(mast_forest.into(), call_node_id)
+    };
+
+    let err = process.execute(&program, &mut DefaultHost::default());
+    assert_matches!(err, Err(ExecutionError::CallInSyscall(_)));
 }
 
 // HELPER REGISTERS TESTS

--- a/processor/src/errors.rs
+++ b/processor/src/errors.rs
@@ -27,6 +27,8 @@ pub enum ExecutionError {
     AdviceMapKeyAlreadyPresent(Word),
     #[error("advice stack read failed at step {0}")]
     AdviceStackReadFailed(RowIndex),
+    #[error("illegal use of instruction {0} while inside a syscall")]
+    CallInSyscall(&'static str),
     #[error("instruction `caller` used outside of kernel context")]
     CallerNotInSyscall,
     #[error("external node with mast root {0} resolved to an external node")]

--- a/processor/src/system/mod.rs
+++ b/processor/src/system/mod.rs
@@ -181,7 +181,6 @@ impl System {
     ///
     /// A CALL or DYNCALL cannot be started when the VM is executing a SYSCALL.
     pub fn start_call_or_dyncall(&mut self, fn_hash: Word) {
-        debug_assert!(!self.in_syscall, "call in syscall");
         self.ctx = (self.clk + 1).into();
         self.fmp = Felt::new(FMP_MIN);
         self.fn_hash = fn_hash;
@@ -201,7 +200,6 @@ impl System {
     /// Note that this does not change the hash of the function which initiated the context:
     /// for SYSCALLs this remains set to the hash of the last invoked function.
     pub fn start_syscall(&mut self) {
-        debug_assert!(!self.in_syscall, "already in syscall");
         self.ctx = ContextId::root();
         self.fmp = Felt::from(SYSCALL_FMP_MIN);
         self.in_syscall = true;


### PR DESCRIPTION
In the previous implementation, the processor would allow call/dyncall/syscall while in a syscall in release mode (and crash in debug mode). I believe the assumption was that the assembler would not generate such a `MastForest` - but we also have to support/guard against `MastForest`s that weren't generated by the assembler.