### PR TITLE
Fix processor `Loop` processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Update Falcon verification procedure to use `HORNERBASE` (#1661).
 - Fix the docs and implementation of `EXPACC` (#1676)
 - Running a call/syscall/dyncall while processing a syscall now results in an error (#1680)
+- Using a non-binary value as a loop condition now results in an error (#1685)
 
 
 ## 0.12.0 (2025-01-22)

--- a/miden/tests/integration/flow_control/mod.rs
+++ b/miden/tests/integration/flow_control/mod.rs
@@ -55,6 +55,21 @@ fn conditional_loop() {
 }
 
 #[test]
+fn faulty_condition_from_loop() {
+    let source = "
+        begin
+            push.1
+            while.true
+                push.100
+            end
+            drop
+        end";
+
+    let test = build_test!(source, &[10]);
+    expect_exec_error_matches!(test, ExecutionError::NotBinaryValue(_));
+}
+
+#[test]
 fn counter_controlled_loop() {
     // --- entering the loop ----------------------------------------------------------------------
     // compute 2^10

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -370,6 +370,10 @@ impl Process {
                 self.execute_mast_node(node.body(), program, host)?;
             }
 
+            if self.stack.peek() != ZERO {
+                return Err(ExecutionError::NotBinaryValue(self.stack.peek()));
+            }
+
             // end the LOOP block and drop the condition from the stack
             self.end_loop_node(node, true, host)
         } else if condition == ZERO {


### PR DESCRIPTION
Using a non-binary value as a condition from inside the loop wouldn't result in an error (and would crash in debug mode). It now properly returns an error.