### PR TITLE
fix: include entire memory word in horner bus requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Using a non-binary value as a loop condition now results in an error (#1685)
 - [BREAKING] Update CLI to accept masm or masp files as input for the run and prove commands (#1683).
 - [BREAKING] Remove `Assembler::assemble_common()` from the public interface (#1689).
+- Fix `Horner{Base, Ext}` bus requests to memory chiplet (#1689)
 
 ## 0.12.0 (2025-01-22)
 

--- a/processor/src/chiplets/aux_trace/bus/memory.rs
+++ b/processor/src/chiplets/aux_trace/bus/memory.rs
@@ -206,6 +206,8 @@ pub(super) fn build_horner_eval_request<E: FieldElement<BaseField = Felt>>(
 ) -> E {
     let eval_point_0 = main_trace.helper_register(0, row);
     let eval_point_1 = main_trace.helper_register(1, row);
+    let mem_junk_0 = main_trace.helper_register(2, row);
+    let mem_junk_1 = main_trace.helper_register(3, row);
     let eval_point_ptr = main_trace.stack_element(13, row);
     let op_label = Felt::from(MEMORY_READ_WORD_LABEL);
 
@@ -217,7 +219,7 @@ pub(super) fn build_horner_eval_request<E: FieldElement<BaseField = Felt>>(
         ctx,
         addr: eval_point_ptr,
         clk,
-        word: [eval_point_0, eval_point_1, ZERO, ZERO],
+        word: [eval_point_0, eval_point_1, mem_junk_0, mem_junk_1],
         source: "horner_eval_* req",
     };
 


### PR DESCRIPTION
Fixes bus issue observed in https://github.com/0xPolygonMiden/miden-base/pull/1183.

We reproduced the same pattern that made `RCOMBBASE` break the bus previously - namely to assume that the memory is zeroed for the last 2 elements of the word where the evaluation point is stored. This PR then sends the entire word on the bus, instead of just the first 2 elements.

By the way, to debug this, all I did was to turn on the processor's `bus-debugger` feature in `miden-base`, and then saw a bunch of outstanding requests/responses. Zooming in on a request/response pair that happened on the same clock cycle:

```
The following requests are still outstanding:
- ...
- horner_eval_* req: { op_label: 27, ctx: 4006, addr: 1073744388, clk: 11338, word: [3848212099958106608, 12007821194187770238, 0, 0] }
- ...

The following responses are still outstanding:
- ...
- memory chiplet: { op_label: 27, ctx: 4006, addr: 1073744388, clk: 11338, word: [3848212099958106608, 12007821194187770238, 1261444012884607196, 11679722184891227643] }
- ...
```

it was easy to see that the `ZERO, ZERO` that we insert in the bus request caused the issue.