### PR TITLE
Add masm procedure to recover public key hash from signature

### DIFF
--- a/stdlib/asm/crypto/dsa/rpo_falcon512.masm
+++ b/stdlib/asm/crypto/dsa/rpo_falcon512.masm
@@ -125,30 +125,9 @@ end
 #!   Operand stack: []
 #!   Advice stack:  [tau0, tau1, h_0, ..., h_511, s2_0, ..., s2_511, pi_0, ..., pi_1022, ...]
 #! Outputs:
-#!   Operand stack: [PK]
+#!   Operand stack: [PK_HASH]
 export.falcon_recover_pub_key.16
-    # We will store in local addresses:
-    # 1. 0..4 the public key,
-    # 2. 4..8 the inverse of the evaluation point tau as [tau_inv0, tau_inv1, tau0, tau1].
-    
-    # 1) Set up the stack for loading the coefficients of the polynomials, evaluating and hashing them
-    
-    ## a) Set up the accumulator for `horner_eval_base` and the memory pointers
-    push.0.0
-    locaddr.4
-    movup.3
-    # => [ptr, tau_inv_ptr, 0, 0, PK, ...]
-
-    ## b) Save PK to later compare it with the hash of the h polynomial
-    swapw
-    loc_storew.0
-    # => [PK, ptr, tau_inv_ptr, acc1, acc0, ...]
-
-    ## c) Prepare the capacity portion of the state of the hasher
-    padw swapw
-    # => [Y, 0, 0, 0, 0, ptr, tau_inv_ptr, acc1, acc0, ...], where Y is a "garbage" word
-
-    ## d) Load the evaluation point tau from the advice tape, compute its inverse and save both
+    ## Load the evaluation point tau from the advice tape, compute its inverse and save both
     ## Note that we will evaluate the polynomials at `tau_inv = tau^{-1}` as we are loading the coefficients
     ## in the normal order i.e., not in reversed order required for Horner evaluation.
     ## This means that the equality we will be checking is 
@@ -163,7 +142,27 @@ export.falcon_recover_pub_key.16
     loc_storew.4
     # => [tau1, tau0, tau_inv1, tau_inv0, Y, 0, 0, 0, 0, ptr, tau_inv_ptr, acc1, acc0, ...]
 
-    # 2) Load the coefficients of the h polynomial and evaluate it at tau_inv
+    # Load the coefficients of the h polynomial and evaluate it at tau_inv
+    exec.eval_tau_inv
+    # => [Y, D, C, ptr, tau_inv_ptr, acc1, acc0, ...] where D is the digest expected to be PK hash
+    
+    dropw
+    # => [D, C, ptr, tau_inv_ptr, acc1, acc0, ...]
+
+    repeat.4
+        swapw
+        dropw
+    end
+    # => [D]
+end
+
+#! Inputs:
+#!   Operand stack: [tau1, tau0, tau_inv1, tau_inv0, Y, 0, 0, 0, 0, ptr, tau_inv_ptr, acc1, acc0, ...]
+#!   Advice stack:  [tau0, tau1, h_0, ..., h_511, s2_0, ..., s2_511, pi_0, ..., pi_1022, ...]
+#! Outputs:
+#!   Operand stack: [Y, D, C, ptr, tau_inv_ptr, acc1, acc0, ...] where D is the digest expected to be PK
+#!   Advice stack:  [h_0, ..., h_511, s2_0, ..., s2_511, pi_0, ..., pi_1022, ...]
+proc.eval_tau_inv
     repeat.64
         adv_pipe
 
@@ -188,21 +187,6 @@ export.falcon_recover_pub_key.16
 
         hperm
     end
-    # => [Y, D, C, ptr, tau_inv_ptr, acc1, acc0, ...] where D is the digest expected to be PK
-    dropw
-    # => [D, C, ptr, tau_inv_ptr, acc1, acc0, ...] where D is the digest expected to be PK
-
-    mem_storew.0
-    # => [C, ptr, tau_inv_ptr, acc1, acc0, ...]
-
-    repeat.64
-        dropw
-    end
-    # => []
-
-    mem_loadw.0
-    # => [D]
-
 end
 
 
@@ -271,30 +255,7 @@ export.load_h_s2_and_product.8
     # => [tau1, tau0, tau_inv1, tau_inv0, Y, 0, 0, 0, 0, ptr, tau_inv_ptr, acc1, acc0, ...]
 
     # 2) Load the coefficients of the h polynomial and evaluate it at tau_inv
-    repeat.64
-        adv_pipe
-
-        # check that all coefficients are less than Falcon prime
-        dupw.1
-        u32assert2
-        u32overflowing_sub.M assert drop
-        u32overflowing_sub.M assert drop
-        u32assert2
-        u32overflowing_sub.M assert drop
-        u32overflowing_sub.M assert drop
-
-        dupw
-        u32assert2
-        u32overflowing_sub.M assert drop
-        u32overflowing_sub.M assert drop
-        u32assert2
-        u32overflowing_sub.M assert drop
-        u32overflowing_sub.M assert drop
-
-        horner_eval_base
-
-        hperm
-    end
+    exec.eval_tau_inv
     # => [Y, D, C, ptr, tau_inv_ptr, acc1, acc0, ...] where D is the digest expected to be PK
 
     # 3) Load PK, the saved claimed hash of h, and compare hashes
@@ -335,7 +296,6 @@ export.load_h_s2_and_product.8
         hperm
     end
     # => [Y, Y, C, ptr, tau_inv_ptr, s2(tau)_1, s2(tau)_0, h(tau)_1, h(tau)_0, ...]
-
 
     # 5) Load claimed h * s2 in Z_Q[x]
 

--- a/stdlib/asm/crypto/dsa/rpo_falcon512.masm
+++ b/stdlib/asm/crypto/dsa/rpo_falcon512.masm
@@ -121,6 +121,8 @@ export.hash_to_point.8
     dropw
 end
 
+# PUBLIC-KEY-HASH RECOVERY FROM SIGNATURE
+# =============================================================================================
 
 #!   Operand stack: []
 #!   Advice stack:  [tau0, tau1, h_0, ..., h_511, s2_0, ..., s2_511, pi_0, ..., pi_1022, ...]
@@ -156,6 +158,11 @@ export.falcon_recover_pub_key.16
     # => [D]
 end
 
+# @dev What should be the title of this procedure? 
+# Since it is used in falcon_recover_pub_key & load_h_s2_and_product 
+# It might make sense to have it as a standalone helper procedure 
+
+#! Loads and evaluates s2 at tau_inv
 #! Inputs:
 #!   Operand stack: [tau1, tau0, tau_inv1, tau_inv0, Y, 0, 0, 0, 0, ptr, tau_inv_ptr, acc1, acc0, ...]
 #!   Advice stack:  [tau0, tau1, h_0, ..., h_511, s2_0, ..., s2_511, pi_0, ..., pi_1022, ...]
@@ -188,7 +195,6 @@ proc.eval_tau_inv
         hperm
     end
 end
-
 
 # PROBABILISTIC POLYNOMIAL MULTIPLICATION IN Z_Q[x]
 # =============================================================================================

--- a/stdlib/asm/crypto/dsa/rpo_falcon512.masm
+++ b/stdlib/asm/crypto/dsa/rpo_falcon512.masm
@@ -122,6 +122,90 @@ export.hash_to_point.8
 end
 
 
+#!   Operand stack: []
+#!   Advice stack:  [tau0, tau1, h_0, ..., h_511, s2_0, ..., s2_511, pi_0, ..., pi_1022, ...]
+#! Outputs:
+#!   Operand stack: [PK]
+export.falcon_recover_pub_key.16
+    # We will store in local addresses:
+    # 1. 0..4 the public key,
+    # 2. 4..8 the inverse of the evaluation point tau as [tau_inv0, tau_inv1, tau0, tau1].
+    
+    # 1) Set up the stack for loading the coefficients of the polynomials, evaluating and hashing them
+    
+    ## a) Set up the accumulator for `horner_eval_base` and the memory pointers
+    push.0.0
+    locaddr.4
+    movup.3
+    # => [ptr, tau_inv_ptr, 0, 0, PK, ...]
+
+    ## b) Save PK to later compare it with the hash of the h polynomial
+    swapw
+    loc_storew.0
+    # => [PK, ptr, tau_inv_ptr, acc1, acc0, ...]
+
+    ## c) Prepare the capacity portion of the state of the hasher
+    padw swapw
+    # => [Y, 0, 0, 0, 0, ptr, tau_inv_ptr, acc1, acc0, ...], where Y is a "garbage" word
+
+    ## d) Load the evaluation point tau from the advice tape, compute its inverse and save both
+    ## Note that we will evaluate the polynomials at `tau_inv = tau^{-1}` as we are loading the coefficients
+    ## in the normal order i.e., not in reversed order required for Horner evaluation.
+    ## This means that the equality we will be checking is 
+    ## pi(tau_inv) * tau^1023 == h(tau_inv) * tau^511 * s2(tau_inv) * tau^511
+    ##
+    ## which simplifies to
+    ##
+    ## pi(tau_inv) * tau == h(tau_inv) * s2(tau_inv)
+    adv_push.2 
+    dup.1 dup.1 ext2inv
+    movup.3 movup.3
+    loc_storew.4
+    # => [tau1, tau0, tau_inv1, tau_inv0, Y, 0, 0, 0, 0, ptr, tau_inv_ptr, acc1, acc0, ...]
+
+    # 2) Load the coefficients of the h polynomial and evaluate it at tau_inv
+    repeat.64
+        adv_pipe
+
+        # check that all coefficients are less than Falcon prime
+        dupw.1
+        u32assert2
+        u32overflowing_sub.M assert drop
+        u32overflowing_sub.M assert drop
+        u32assert2
+        u32overflowing_sub.M assert drop
+        u32overflowing_sub.M assert drop
+
+        dupw
+        u32assert2
+        u32overflowing_sub.M assert drop
+        u32overflowing_sub.M assert drop
+        u32assert2
+        u32overflowing_sub.M assert drop
+        u32overflowing_sub.M assert drop
+
+        horner_eval_base
+
+        hperm
+    end
+    # => [Y, D, C, ptr, tau_inv_ptr, acc1, acc0, ...] where D is the digest expected to be PK
+    dropw
+    # => [D, C, ptr, tau_inv_ptr, acc1, acc0, ...] where D is the digest expected to be PK
+
+    mem_storew.0
+    # => [C, ptr, tau_inv_ptr, acc1, acc0, ...]
+
+    repeat.64
+        dropw
+    end
+    # => []
+
+    mem_loadw.0
+    # => [D]
+
+end
+
+
 # PROBABILISTIC POLYNOMIAL MULTIPLICATION IN Z_Q[x]
 # =============================================================================================
 

--- a/stdlib/tests/crypto/falcon.rs
+++ b/stdlib/tests/crypto/falcon.rs
@@ -192,7 +192,6 @@ fn test_falcon512_recover_pub_key_failure() {
     let raw_stack_state = test.get_last_stack_state().as_int_vec();
     let stack_state: Vec<Felt> = raw_stack_state.into_iter().map(Felt::new).collect();
 
-    // Assert that the recovered stack state does not equal the correct stack state.
     assert_ne!(correct_stack_state, stack_state);
 }
 
@@ -210,7 +209,7 @@ fn test_falcon512_probabilistic_product_failure() {
     expect_exec_error_matches!(
         test,
         ExecutionError::FailedAssertion{ clk, err_code, err_msg }
-        if clk == RowIndex::from(3182) && err_code == 0 && err_msg.is_none()
+        if clk == RowIndex::from(3188) && err_code == 0 && err_msg.is_none()
     );
 }
 

--- a/stdlib/tests/crypto/falcon.rs
+++ b/stdlib/tests/crypto/falcon.rs
@@ -164,18 +164,36 @@ fn test_falcon512_recover_pub_key() {
     let (pub_key, advice_stack): (Vec<u64>, Vec<u64>) =
         generate_data_probabilistic_product_test(h, s2, false);
 
-    // println!("pub_key: {:?}", pub_key);
     let empty_operand_stack: Vec<u64> = vec![];
 
     let test = build_test!(FALCON_RECOVER_PUB_KEY_SOURCE, &empty_operand_stack, &advice_stack);
-    println!("len: {:?}", advice_stack.len());
 
     let stack_state = test.get_last_stack_state();
-    println!("stack: {:?}", stack_state);
-
     let expected_stack: Vec<Felt> = pub_key.iter().rev().map(|&val| Felt::new(val)).collect();
 
     assert_eq!(&expected_stack, &stack_state[..expected_stack.len()]);
+}
+
+#[test]
+fn test_falcon512_recover_pub_key_failure() {
+    let h: Polynomial<Felt> = Polynomial::new(random_coefficients());
+    let s2: Polynomial<Felt> = Polynomial::new(random_coefficients());
+    let (pub_key, mut advice_stack): (Vec<u64>, Vec<u64>) =
+        generate_data_probabilistic_product_test(h, s2, false);
+
+    let empty_operand_stack: Vec<u64> = vec![];
+
+    let correct_stack_state: Vec<Felt> = pub_key.iter().rev().map(|&val| Felt::new(val)).collect();
+
+    // modify h_0 by 1
+    advice_stack[2] += 1;
+
+    let test = build_test!(FALCON_RECOVER_PUB_KEY_SOURCE, &empty_operand_stack, &advice_stack);
+    let raw_stack_state = test.get_last_stack_state().as_int_vec();
+    let stack_state: Vec<Felt> = raw_stack_state.into_iter().map(Felt::new).collect();
+
+    // Assert that the recovered stack state does not equal the correct stack state.
+    assert_ne!(correct_stack_state, stack_state);
 }
 
 #[test]

--- a/stdlib/tests/crypto/falcon.rs
+++ b/stdlib/tests/crypto/falcon.rs
@@ -168,9 +168,10 @@ fn test_falcon512_recover_pub_key() {
     let empty_operand_stack: Vec<u64> = vec![];
 
     let test = build_test!(FALCON_RECOVER_PUB_KEY_SOURCE, &empty_operand_stack, &advice_stack);
+    println!("len: {:?}", advice_stack.len());
 
     let stack_state = test.get_last_stack_state();
-    // println!("stack: {:?}", stack_state);
+    println!("stack: {:?}", stack_state);
 
     let expected_stack: Vec<Felt> = pub_key.iter().rev().map(|&val| Felt::new(val)).collect();
 


### PR DESCRIPTION
This is currently a draft PR because there probably is a more efficient way to recover the public key hash associated with a given signature. Adding a procedure with this functionality is very useful for smart contracts and particularly multi-signature wallets. 

This is the linked discussion: https://github.com/0xPolygonMiden/miden-base/issues/1212