### PR TITLE
Update `miden-gpu` dependency to v0.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,9 +202,9 @@ checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
 name = "blake3"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "675f87afced0413c9bb02843499dbbd3882a237645883f71a2b59644a6d2f753"
+checksum = "b17679a8d69b6d7fd9cd9801a536cec9fa5e5970b69f9d4747f70b39b031f5e7"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -771,14 +771,14 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.13.3+wasi-0.2.2",
- "windows-targets 0.52.6",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
 ]
 
 [[package]]
@@ -1114,9 +1114,9 @@ dependencies = [
  "parking_lot",
  "proptest",
  "thiserror 2.0.12",
- "winter-math 0.12.0",
+ "winter-math",
  "winter-rand-utils",
- "winter-utils 0.12.0",
+ "winter-utils",
 ]
 
 [[package]]
@@ -1135,8 +1135,8 @@ dependencies = [
  "sha3",
  "thiserror 2.0.12",
  "winter-crypto",
- "winter-math 0.12.0",
- "winter-utils 0.12.0",
+ "winter-math",
+ "winter-utils",
 ]
 
 [[package]]
@@ -1150,13 +1150,13 @@ dependencies = [
 
 [[package]]
 name = "miden-gpu"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04742d5184bd76e7b92afcd9ca36b7c587a555d5fc4b27bb8f9d64ac57151f9c"
+checksum = "38a93f525671392a07dd8a75855d12f91e57db25e5addf0aa14ecbc9baf7ef86"
 dependencies = [
  "metal",
  "once_cell",
- "winter-math 0.11.0",
+ "winter-math",
 ]
 
 [[package]]
@@ -1226,7 +1226,7 @@ dependencies = [
  "tracing",
  "winter-fri",
  "winter-prover",
- "winter-utils 0.12.0",
+ "winter-utils",
 ]
 
 [[package]]
@@ -1708,6 +1708,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1764,7 +1770,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
- "getrandom 0.3.1",
+ "getrandom 0.3.2",
 ]
 
 [[package]]
@@ -1935,9 +1941,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7178faa4b75a30e269c71e61c353ce2748cf3d76f0c44c393f4e60abf49b825"
+checksum = "e56a18552996ac8d29ecc3b190b4fdbb2d91ca4ec396de7bbffaf43f3d637e96"
 dependencies = [
  "bitflags 2.9.0",
  "errno",
@@ -2219,9 +2225,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488960f40a3fd53d72c2a29a58722561dee8afdd175bd88e3db4677d7b2ba600"
 dependencies = [
  "fastrand",
- "getrandom 0.3.1",
+ "getrandom 0.3.2",
  "once_cell",
- "rustix 1.0.2",
+ "rustix 1.0.3",
  "windows-sys 0.59.0",
 ]
 
@@ -2606,9 +2612,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasi"
-version = "0.13.3+wasi-0.2.2"
+version = "0.14.2+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
 dependencies = [
  "wit-bindgen-rt",
 ]
@@ -2933,8 +2939,8 @@ dependencies = [
  "libm",
  "winter-crypto",
  "winter-fri",
- "winter-math 0.12.0",
- "winter-utils 0.12.0",
+ "winter-math",
+ "winter-utils",
 ]
 
 [[package]]
@@ -2945,8 +2951,8 @@ checksum = "32247cde9f43e5bbd05362caa7274608790ea69b14f7c81cd509aae7127c5ff2"
 dependencies = [
  "blake3",
  "sha3",
- "winter-math 0.12.0",
- "winter-utils 0.12.0",
+ "winter-math",
+ "winter-utils",
 ]
 
 [[package]]
@@ -2956,17 +2962,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4d09d5ac254ac54028ac04751d7ae0cbeb111c6cb08cc30c6400ff61b3203bd"
 dependencies = [
  "winter-crypto",
- "winter-math 0.12.0",
- "winter-utils 0.12.0",
-]
-
-[[package]]
-name = "winter-math"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6020c17839fa107ce4a7cc178e407ebbc24adfac1980f4fa2111198e052700ab"
-dependencies = [
- "winter-utils 0.11.0",
+ "winter-math",
+ "winter-utils",
 ]
 
 [[package]]
@@ -2975,7 +2972,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "326dfe4bfa4072b7c909133a88f8807820d3e49e5dfd246f67981771f74a0ed3"
 dependencies = [
- "winter-utils 0.12.0",
+ "winter-utils",
 ]
 
 [[package]]
@@ -2998,9 +2995,9 @@ dependencies = [
  "winter-air",
  "winter-crypto",
  "winter-fri",
- "winter-math 0.12.0",
+ "winter-math",
  "winter-maybe-async",
- "winter-utils 0.12.0",
+ "winter-utils",
 ]
 
 [[package]]
@@ -3010,14 +3007,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc6321741f063344258c80f0c0255a559ded99bc17fe99fab9577f2460065ddf"
 dependencies = [
  "rand 0.8.5",
- "winter-utils 0.12.0",
+ "winter-utils",
 ]
-
-[[package]]
-name = "winter-utils"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1507ef312ea5569d54c2c7446a18b82143eb2a2e21f5c3ec7cfbe8200c03bd7c"
 
 [[package]]
 name = "winter-utils"
@@ -3037,15 +3028,15 @@ dependencies = [
  "winter-air",
  "winter-crypto",
  "winter-fri",
- "winter-math 0.12.0",
- "winter-utils 0.12.0",
+ "winter-math",
+ "winter-utils",
 ]
 
 [[package]]
 name = "wit-bindgen-rt"
-version = "0.33.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
  "bitflags 2.9.0",
 ]

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ WARNINGS=RUSTDOCFLAGS="-D warnings"
 DEBUG_ASSERTIONS=RUSTFLAGS="-C debug-assertions"
 FEATURES_CONCURRENT_EXEC=--features concurrent,executable
 FEATURES_LOG_TREE=--features concurrent,executable,tracing-forest
-FEATURES_METAL_EXEC=--features concurrent,executable,metal
+FEATURES_METAL_EXEC=--features concurrent,executable,metal,tracing-forest
 ALL_FEATURES_BUT_ASYNC=--features concurrent,executable,metal,testing,with-debug-info,internal
 
 # -- linting --------------------------------------------------------------------------------------

--- a/prover/Cargo.toml
+++ b/prover/Cargo.toml
@@ -29,5 +29,5 @@ winter-prover = { package = "winter-prover", version = "0.12", default-features 
 
 [target.'cfg(all(target_arch = "aarch64", target_os = "macos"))'.dependencies]
 elsa = { version = "1.9", optional = true }
-miden-gpu = { version = "0.4", optional = true }
+miden-gpu = { version = "0.5", optional = true }
 pollster = { version = "0.4", optional = true }

--- a/prover/src/gpu/metal/mod.rs
+++ b/prover/src/gpu/metal/mod.rs
@@ -4,7 +4,7 @@
 
 use std::{boxed::Box, marker::PhantomData, time::Instant, vec::Vec};
 
-use air::{AuxRandElements, LagrangeKernelEvaluationFrame, PartitionOptions};
+use air::{AuxRandElements, PartitionOptions};
 use elsa::FrozenVec;
 use miden_gpu::{
     HashFn,
@@ -328,32 +328,6 @@ where
     /// Returns blowup factor which was used to extend the original execution trace into trace LDE.
     fn blowup(&self) -> usize {
         self.blowup
-    }
-
-    /// Populates the provided Lagrange kernel frame starting at the current row (as defined by
-    /// lde_step).
-    /// Note that unlike EvaluationFrame, the Lagrange kernel frame includes only the Lagrange
-    /// kernel column (as opposed to all columns).
-    fn read_lagrange_kernel_frame_into(
-        &self,
-        lde_step: usize,
-        col_idx: usize,
-        frame: &mut LagrangeKernelEvaluationFrame<E>,
-    ) {
-        if let Some(aux_segment) = self.aux_segment_lde.as_ref() {
-            let frame = frame.frame_mut();
-            frame.truncate(0);
-
-            frame.push(aux_segment.get(col_idx, lde_step));
-
-            let frame_length = self.trace_info.length().ilog2() as usize + 1;
-            for i in 0..frame_length - 1 {
-                let shift = self.blowup() * (1 << i);
-                let next_lde_step = (lde_step + shift) % self.trace_len();
-
-                frame.push(aux_segment.get(col_idx, next_lde_step));
-            }
-        }
     }
 
     /// Returns the trace info


### PR DESCRIPTION
This PR updates `miden-gpu` dependency to v0.5 and fixes the current issues with `metal` builds.