### PR TITLE
refactor: make debug mode the default in the CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -197,6 +197,7 @@
 - The `Module::parse_file` and `Module::parse_str` functions have been removed in favor of calling `Module::parser` and then using the `ModuleParser` methods.
 - The `Compile` trait now requires passing a `SourceManager` reference along with the item to be compiled.
 - Update minimum supported Rust version to 1.80 (#1425).
+- Made `debug` mode the default in the CLI. Added `--release` flag to disable debugging instead of having to enable it.
 
 ## 0.9.2 (2024-05-22) - `stdlib` crate only
 
@@ -435,3 +436,16 @@
 ## 0.1.0 (2021-11-16)
 
 - Initial release (migration of the original [Distaff VM](https://github.com/GuildOfWeavers/distaff) codebase to [Winterfell](https://github.com/novifinancial/winterfell) backend).
+
+## Unreleased
+
+### Added
+
+// ... existing code ...
+
+### Changed
+
+// ... existing code ...
+- Made `debug` mode the default in the CLI. Added `--release` flag to disable debugging instead of having to enable it.
+
+// ... existing code ...

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -440,13 +440,3 @@
 ## 0.1.0 (2021-11-16)
 
 - Initial release (migration of the original [Distaff VM](https://github.com/GuildOfWeavers/distaff) codebase to [Winterfell](https://github.com/novifinancial/winterfell) backend).
-
-## Unreleased
-
-### Added
-
-// ... existing code ...
-
-### Changed
-
-// ... existing code ...

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -197,7 +197,7 @@
 - The `Module::parse_file` and `Module::parse_str` functions have been removed in favor of calling `Module::parser` and then using the `ModuleParser` methods.
 - The `Compile` trait now requires passing a `SourceManager` reference along with the item to be compiled.
 - Update minimum supported Rust version to 1.80 (#1425).
-- Made `debug` mode the default in the CLI. Added `--release` flag to disable debugging instead of having to enable it.
+- Made `debug` mode the default in the CLI. Added `--release` flag to disable debugging instead of having to enable it. (#1728)
 
 ## 0.9.2 (2024-05-22) - `stdlib` crate only
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -446,6 +446,3 @@
 ### Changed
 
 // ... existing code ...
-- Made `debug` mode the default in the CLI. Added `--release` flag to disable debugging instead of having to enable it.
-
-// ... existing code ...

--- a/miden/src/cli/bundle.rs
+++ b/miden/src/cli/bundle.rs
@@ -13,9 +13,9 @@ use stdlib::StdLibrary;
     about = "Bundles .masm files into a single .masl library with access to the stdlib."
 )]
 pub struct BundleCmd {
-    /// Include debug symbols.
-    #[clap(short, long, action)]
-    debug: bool,
+    /// Disable debug symbols (release mode)
+    #[clap(short = 'r', long = "release")]
+    release: bool,
     /// Path to a directory containing the `.masm` files which are part of the library.
     #[clap(value_parser)]
     dir: PathBuf,
@@ -41,7 +41,7 @@ impl BundleCmd {
         println!("Build library");
         println!("============================================================");
 
-        let mut assembler = Assembler::default().with_debug_mode(self.debug);
+        let mut assembler = Assembler::default().with_debug_mode(!self.release);
 
         if self.dir.is_file() {
             return Err(Report::msg("`dir` must be a directory."));

--- a/miden/src/cli/debug/mod.rs
+++ b/miden/src/cli/debug/mod.rs
@@ -55,7 +55,7 @@ impl DebugCmd {
         // Use a single match expression to load the program.
         let program = match ext.as_str() {
             "masp" => get_masp_program(&self.program_file)?,
-            "masm" => get_masm_program(&self.program_file, &libraries)?,
+            "masm" => get_masm_program(&self.program_file, &libraries, true)?,
             _ => return Err(Report::msg("The provided file must have a .masm or .masp extension")),
         };
         let program_hash: [u8; 32] = program.hash().into();

--- a/miden/src/cli/prove.rs
+++ b/miden/src/cli/prove.rs
@@ -62,12 +62,16 @@ pub struct ProveCmd {
     /// Enable tracing to monitor execution of the VM
     #[clap(short = 't', long = "trace")]
     trace: bool,
+
+    /// Disable debug instructions (release mode)
+    #[clap(long = "release")]
+    release: bool,
 }
 
 impl ProveCmd {
     pub fn get_proof_options(&self) -> Result<ProvingOptions, ExecutionOptionsError> {
         let exec_options =
-            ExecutionOptions::new(Some(self.max_cycles), self.expected_cycles, self.trace, false)?;
+            ExecutionOptions::new(Some(self.max_cycles), self.expected_cycles, self.trace, !self.release)?;
         Ok(match self.security.as_str() {
             "96bits" => {
                 if self.rpx {

--- a/miden/src/cli/prove.rs
+++ b/miden/src/cli/prove.rs
@@ -70,8 +70,12 @@ pub struct ProveCmd {
 
 impl ProveCmd {
     pub fn get_proof_options(&self) -> Result<ProvingOptions, ExecutionOptionsError> {
-        let exec_options =
-            ExecutionOptions::new(Some(self.max_cycles), self.expected_cycles, self.trace, !self.release)?;
+        let exec_options = ExecutionOptions::new(
+            Some(self.max_cycles),
+            self.expected_cycles,
+            self.trace,
+            !self.release,
+        )?;
         Ok(match self.security.as_str() {
             "96bits" => {
                 if self.rpx {
@@ -166,7 +170,7 @@ fn load_masp_data(params: &ProveCmd) -> Result<(Program, InputFile), Report> {
 #[instrument(skip_all)]
 fn load_masm_data(params: &ProveCmd) -> Result<(Program, InputFile), Report> {
     let libraries = Libraries::new(&params.library_paths)?;
-    let program = get_masm_program(&params.program_file, &libraries)?;
+    let program = get_masm_program(&params.program_file, &libraries, !params.release)?;
     let input_data = InputFile::read(&params.input_file, &params.program_file)?;
     Ok((program, input_data))
 }

--- a/miden/src/cli/run.rs
+++ b/miden/src/cli/run.rs
@@ -164,7 +164,7 @@ fn run_masm_program(params: &RunCmd) -> Result<(ExecutionTrace, [u8; 32]), Repor
     let libraries = Libraries::new(&params.library_paths)?;
 
     // load program from file and compile
-    let program = get_masm_program(&params.program_file, &libraries)?;
+    let program = get_masm_program(&params.program_file, &libraries, !params.release)?;
     let input_data = InputFile::read(&params.input_file, &params.program_file)?;
 
     let execution_options = ExecutionOptions::new(

--- a/miden/src/cli/run.rs
+++ b/miden/src/cli/run.rs
@@ -47,9 +47,9 @@ pub struct RunCmd {
     #[clap(short = 't', long = "trace")]
     trace: bool,
 
-    /// Enable debug instructions
-    #[clap(short = 'd', long = "debug")]
-    debug: bool,
+    /// Disable debug instructions (release mode)
+    #[clap(short = 'r', long = "release")]
+    release: bool,
 }
 
 impl RunCmd {
@@ -137,7 +137,7 @@ fn run_masp_program(params: &RunCmd) -> Result<(ExecutionTrace, [u8; 32]), Repor
         Some(params.max_cycles),
         params.expected_cycles,
         params.trace,
-        params.debug,
+        !params.release,
     )
     .into_diagnostic()?;
 
@@ -171,7 +171,7 @@ fn run_masm_program(params: &RunCmd) -> Result<(ExecutionTrace, [u8; 32]), Repor
         Some(params.max_cycles),
         params.expected_cycles,
         params.trace,
-        params.debug,
+        !params.release,
     )
     .into_diagnostic()?;
 

--- a/miden/src/cli/utils.rs
+++ b/miden/src/cli/utils.rs
@@ -23,7 +23,12 @@ pub fn get_masp_program(path: &Path) -> Result<vm_core::Program, Report> {
 }
 
 /// Returns a `Program` type from a `.masm` assembly file.
-pub fn get_masm_program(path: &Path, libraries: &Libraries) -> Result<vm_core::Program, Report> {
-    let program = ProgramFile::read(path)?.compile(Debug::On, &libraries.libraries)?;
+pub fn get_masm_program(
+    path: &Path,
+    libraries: &Libraries,
+    debug_on: bool,
+) -> Result<vm_core::Program, Report> {
+    let debug_mode = if debug_on { Debug::On } else { Debug::Off };
+    let program = ProgramFile::read(path)?.compile(debug_mode, &libraries.libraries)?;
     Ok(program)
 }

--- a/miden/src/tools/mod.rs
+++ b/miden/src/tools/mod.rs
@@ -48,7 +48,7 @@ impl Analyze {
         // Use a single match expression to load the program.
         let program = match ext.as_str() {
             "masp" => get_masp_program(&self.program_file)?,
-            "masm" => get_masm_program(&self.program_file, &libraries)?,
+            "masm" => get_masm_program(&self.program_file, &libraries, true)?,
             _ => return Err(Report::msg("The provided file must have a .masm or .masp extension")),
         };
         // let program_hash: [u8; 32] = program.hash().into();

--- a/miden/tests/integration/cli/cli_test.rs
+++ b/miden/tests/integration/cli/cli_test.rs
@@ -83,7 +83,7 @@ use vm_core::Decorator;
 #[test]
 fn cli_bundle_debug() {
     let mut cmd = bin_under_test().command();
-    cmd.arg("bundle").arg("--debug").arg("./tests/integration/cli/data/lib");
+    cmd.arg("bundle").arg("./tests/integration/cli/data/lib");
     cmd.assert().success();
 
     let lib = Library::deserialize_from_file("./tests/integration/cli/data/out.masl").unwrap();


### PR DESCRIPTION
Closes #1725:
- Changed debug mode to be enabled by default in CLI commands
- Added --release flag to disable debug mode (replaces --debug flag)
- Updated affected CLI commands (run.rs and prove.rs)
- Added entry to CHANGELOG.md

All tests and linting checks pass successfully.