### PR TITLE
fix: relax identifier rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.13.2 TBD
+
+#### Changes
+- Relaxed rules for identifiers created via `Ident::new`, `ProcedureName::new`,
+  `LibraryNamespace::new`, and `Library::new_from_components`
+- [BREAKING] Renamed `Ident::new_unchecked` and `ProcedureName::new_unchecked`
+  to `from_raw_parts`
+
 ## 0.13.1 (2025-03-21) - `stdlib` crate only
 
 #### Enhancements

--- a/assembly/src/ast/attribute/meta.rs
+++ b/assembly/src/ast/attribute/meta.rs
@@ -85,7 +85,7 @@ impl<'a> FromIterator<(&'a str, MetaExpr)> for Meta {
         Self::KeyValue(
             iter.into_iter()
                 .map(|(k, v)| {
-                    let k = Ident::new_unchecked(Span::new(SourceSpan::UNKNOWN, Arc::from(k)));
+                    let k = Ident::from_raw_parts(Span::new(SourceSpan::UNKNOWN, Arc::from(k)));
                     (k, v)
                 })
                 .collect(),
@@ -173,7 +173,7 @@ impl From<Ident> for MetaItem {
 
 impl From<&str> for MetaItem {
     fn from(value: &str) -> Self {
-        Self::Expr(MetaExpr::String(Ident::new_unchecked(Span::new(
+        Self::Expr(MetaExpr::String(Ident::from_raw_parts(Span::new(
             SourceSpan::UNKNOWN,
             Arc::from(value),
         ))))
@@ -182,7 +182,7 @@ impl From<&str> for MetaItem {
 
 impl From<String> for MetaItem {
     fn from(value: String) -> Self {
-        Self::Expr(MetaExpr::String(Ident::new_unchecked(Span::new(
+        Self::Expr(MetaExpr::String(Ident::from_raw_parts(Span::new(
             SourceSpan::UNKNOWN,
             Arc::from(value.into_boxed_str()),
         ))))
@@ -235,7 +235,7 @@ where
 {
     fn from(entry: (&str, V)) -> Self {
         let (key, value) = entry;
-        let key = Ident::new_unchecked(Span::new(SourceSpan::UNKNOWN, Arc::from(key)));
+        let key = Ident::from_raw_parts(Span::new(SourceSpan::UNKNOWN, Arc::from(key)));
         Self::KeyValue(key, value.into())
     }
 }
@@ -247,7 +247,7 @@ where
     fn from(entry: (String, V)) -> Self {
         let (key, value) = entry;
         let key =
-            Ident::new_unchecked(Span::new(SourceSpan::UNKNOWN, Arc::from(key.into_boxed_str())));
+            Ident::from_raw_parts(Span::new(SourceSpan::UNKNOWN, Arc::from(key.into_boxed_str())));
         Self::KeyValue(key, value.into())
     }
 }

--- a/assembly/src/ast/attribute/meta/expr.rs
+++ b/assembly/src/ast/attribute/meta/expr.rs
@@ -33,13 +33,13 @@ impl From<Ident> for MetaExpr {
 
 impl From<&str> for MetaExpr {
     fn from(value: &str) -> Self {
-        Self::String(Ident::new_unchecked(Span::new(SourceSpan::UNKNOWN, Arc::from(value))))
+        Self::String(Ident::from_raw_parts(Span::new(SourceSpan::UNKNOWN, Arc::from(value))))
     }
 }
 
 impl From<String> for MetaExpr {
     fn from(value: String) -> Self {
-        Self::String(Ident::new_unchecked(Span::new(
+        Self::String(Ident::from_raw_parts(Span::new(
             SourceSpan::UNKNOWN,
             Arc::from(value.into_boxed_str()),
         )))

--- a/assembly/src/ast/ident.rs
+++ b/assembly/src/ast/ident.rs
@@ -12,7 +12,9 @@ use crate::{SourceSpan, Span, Spanned};
 pub enum IdentError {
     #[error("invalid identifier: cannot be empty")]
     Empty,
-    #[error("invalid identifier '{ident}': must contain only ascii graphic characters")]
+    #[error(
+        "invalid identifier '{ident}': must contain only unicode alphanumeric or ascii graphic characters"
+    )]
     InvalidChars { ident: Arc<str> },
     #[error("invalid identifier: length exceeds the maximum of {max} bytes")]
     InvalidLength { max: usize },
@@ -69,7 +71,8 @@ impl Ident {
     /// This can fail if:
     ///
     /// * The identifier exceeds the maximum allowed identifier length
-    /// * The identifier contains non-graphic characters (e.g. whitespace, control)
+    /// * The identifier contains something other than Unicode alphanumeric or ASCII graphic
+    ///   characters (e.g. whitespace, control)
     pub fn new(source: impl AsRef<str>) -> Result<Self, IdentError> {
         source.as_ref().parse()
     }
@@ -79,7 +82,8 @@ impl Ident {
     /// This can fail if:
     ///
     /// * The identifier exceeds the maximum allowed identifier length
-    /// * The identifier contains non-graphic characters (e.g. whitespace, control)
+    /// * The identifier contains something other than Unicode alphanumeric or ASCII graphic
+    ///   characters (e.g. whitespace, control)
     pub fn new_with_span(span: SourceSpan, source: impl AsRef<str>) -> Result<Self, IdentError> {
         source.as_ref().parse::<Self>().map(|id| id.with_span(span))
     }

--- a/assembly/src/ast/ident.rs
+++ b/assembly/src/ast/ident.rs
@@ -87,12 +87,14 @@ impl Ident {
     }
 
     /// This allows constructing an [Ident] directly from a ref-counted string that is known to be
-    /// a valid identifier, and so does not require re-parsing/re-validating. This must _not_ be
-    /// used to bypass validation when you have an identifier that is not valid, and such
-    /// identifiers will be caught during compilation and result in a panic being raised.
+    /// a valid identifier, and so does not require re-parsing/re-validating.
+    ///
+    /// This should _not_ be used to bypass validation, as other parts of the assembler still may
+    /// re-validate identifiers, notably during deserialization, and may result in a panic being
+    /// raised.
     ///
     /// NOTE: This function is perma-unstable, it may be removed or modified at any time.
-    pub fn new_unchecked(name: Span<Arc<str>>) -> Self {
+    pub fn from_raw_parts(name: Span<Arc<str>>) -> Self {
         let (span, name) = name.into_parts();
         Self { span, name }
     }

--- a/assembly/src/ast/ident.rs
+++ b/assembly/src/ast/ident.rs
@@ -14,8 +14,6 @@ pub enum IdentError {
     Empty,
     #[error("invalid identifier '{ident}': must contain only ascii graphic characters")]
     InvalidChars { ident: Arc<str> },
-    #[error("invalid identifier: must start with ascii alphabetic character")]
-    InvalidStart,
     #[error("invalid identifier: length exceeds the maximum of {max} bytes")]
     InvalidLength { max: usize },
     #[error("invalid identifier: {0}")]

--- a/assembly/src/ast/immediate.rs
+++ b/assembly/src/ast/immediate.rs
@@ -36,6 +36,14 @@ impl<T> Immediate<T> {
         matches!(self, Self::Value(_))
     }
 
+    /// Override the source span of this immediate with `span`
+    pub fn with_span(self, span: SourceSpan) -> Self {
+        match self {
+            Self::Constant(id) => Self::Constant(id.with_span(span)),
+            Self::Value(value) => Self::Value(Span::new(span, value.into_inner())),
+        }
+    }
+
     /// Transform the type of this immediate from T to U, using `map`
     pub fn map<U, F>(self, map: F) -> Immediate<U>
     where

--- a/assembly/src/ast/procedure/name.rs
+++ b/assembly/src/ast/procedure/name.rs
@@ -206,7 +206,7 @@ impl ProcedureName {
     /// so by construction all such identifiers are valid.
     ///
     /// NOTE: This function is perma-unstable, it may be removed or modified at any time.
-    pub fn new_unchecked(name: Ident) -> Self {
+    pub fn from_raw_parts(name: Ident) -> Self {
         Self(name)
     }
 
@@ -214,7 +214,7 @@ impl ProcedureName {
     /// (i.e., `main`).
     pub fn main() -> Self {
         let name = Arc::from(Self::MAIN_PROC_NAME.to_string().into_boxed_str());
-        Self(Ident::new_unchecked(Span::unknown(name)))
+        Self(Ident::from_raw_parts(Span::unknown(name)))
     }
 
     /// Is this the reserved name for the executable entrypoint (i.e. `main`)?
@@ -349,7 +349,7 @@ impl FromStr for ProcedureName {
             Some((_, c)) if c.is_ascii_uppercase() => Err(IdentError::Casing(CaseKindError::Snake)),
             Some(_) => Err(IdentError::InvalidChars { ident: s.into() }),
         }?;
-        Ok(Self(Ident::new_unchecked(Span::unknown(raw))))
+        Ok(Self(Ident::from_raw_parts(Span::unknown(raw))))
     }
 }
 

--- a/assembly/src/ast/procedure/name.rs
+++ b/assembly/src/ast/procedure/name.rs
@@ -145,11 +145,9 @@ impl Deserializable for QualifiedProcedureName {
 ///
 /// The symbol represented by this type must comply with the following rules:
 ///
-/// - It must start with an ASCII alphabetic character, or one of: `_`, `.`, or `$`
-/// - If it starts with a non-ASCII alphabetic character, it must contain at least one ASCII
-///   alphabetic character, e.g. `_`, `$_` are not valid symbols, but `_a` or `$_a` are.
-/// - Otherwise, the name may consist of any number of printable ASCII characters, e.g.
-///   alphanumerics, punctuation, etc. Control characters and the like are explicitly not allowed.
+/// - It must consist only of alphanumeric characters, or ASCII graphic characters.
+/// - If it starts with a non-alphabetic character, it must contain at least one alphanumeric
+///   character, e.g. `_`, `$_` are not valid procedure symbols, but `_a` or `$_a` are.
 ///
 /// NOTE: In Miden Assembly source files, a procedure name must be quoted in double-quotes if it
 /// contains any characters other than ASCII alphanumerics, or `_`. See examples below.
@@ -167,7 +165,8 @@ impl Deserializable for QualifiedProcedureName {
 ///   ...
 /// end
 ///
-/// # A symbol which contains `::`, which would be treated as a namespace operator, so requires quoting
+/// # A symbol which contains `::`, which would be treated as a namespace operator, so requires
+/// # quoting
 /// proc."std::foo"
 ///   ...
 /// end
@@ -325,8 +324,7 @@ impl FromStr for ProcedureName {
                             let tok = &s[1..pos];
                             break Ok(Arc::from(tok.to_string().into_boxed_str()));
                         },
-                        c if c.is_alphanumeric() => continue,
-                        '_' | '$' | '-' | '!' | '?' | '<' | '>' | ':' | '.' => continue,
+                        c if c.is_alphanumeric() || c.is_ascii_graphic() => continue,
                         _ => break Err(IdentError::InvalidChars { ident: s.into() }),
                     }
                 } else {

--- a/assembly/src/ast/tests.rs
+++ b/assembly/src/ast/tests.rs
@@ -36,9 +36,9 @@ macro_rules! exec {
     ($name:path) => {{
         let path = stringify!($name);
         let (module, name) = path.split_once("::").expect("invalid procedure path");
-        let name =
-            Ident::new_unchecked(Span::unknown(Arc::from(name.to_string().into_boxed_str())));
-        let name = ProcedureName::new_unchecked(name);
+        let name = Ident::new(Span::unknown(Arc::from(name.to_string().into_boxed_str())))
+            .expect("invalid identifier");
+        let name = ProcedureName::new(name).expect("invalid procedure name");
 
         inst!(Exec(InvocationTarget::ProcedurePath { name, module: module.parse().unwrap() }))
     }};
@@ -53,7 +53,7 @@ macro_rules! call {
     ($name:path) => {{
         let path = stringify!($name);
         let (module, name) = path.split_once("::").expect("invalid procedure path");
-        let name = ProcedureName::new_unchecked(Default::default(), name);
+        let name = ProcedureName::new(Default::default(), name).expect("invalid procedure name");
 
         inst!(Call(InvocationTarget::ProcedurePath { name, module }))
     }};

--- a/assembly/src/library/namespace.rs
+++ b/assembly/src/library/namespace.rs
@@ -153,7 +153,7 @@ impl LibraryNamespace {
 
     /// Create an [Ident] representing this namespace.
     pub fn to_ident(&self) -> Ident {
-        Ident::new_unchecked(Span::unknown(self.as_refcounted_str()))
+        Ident::from_raw_parts(Span::unknown(self.as_refcounted_str()))
     }
 }
 

--- a/assembly/src/library/namespace.rs
+++ b/assembly/src/library/namespace.rs
@@ -104,6 +104,14 @@ impl LibraryNamespace {
     }
 
     /// Checks if `source` is a valid [LibraryNamespace]
+    ///
+    /// The rules for valid library namespaces are:
+    ///
+    /// * Must be lowercase
+    /// * Must start with an ASCII alphabetic character, with the exception of reserved special
+    ///   namespaces
+    /// * May only contain alphanumeric unicode characters, or a character from the ASCII graphic
+    ///   set, see [char::is_ascii_graphic].
     pub fn validate(source: impl AsRef<str>) -> Result<(), LibraryNamespaceError> {
         let source = source.as_ref();
         if source.is_empty() {
@@ -118,7 +126,7 @@ impl LibraryNamespace {
         if !source.starts_with(|c: char| c.is_ascii_lowercase() && c.is_ascii_alphabetic()) {
             return Err(LibraryNamespaceError::InvalidStart);
         }
-        if !source.chars().all(|c| c.is_ascii_alphanumeric() || matches!(c, '_')) {
+        if !source.chars().all(|c| c.is_ascii_graphic() || c.is_alphanumeric()) {
             return Err(LibraryNamespaceError::InvalidChars);
         }
         Ok(())

--- a/assembly/src/library/path.rs
+++ b/assembly/src/library/path.rs
@@ -415,7 +415,7 @@ impl LibraryPath {
         S: AsRef<str>,
     {
         let component = component.as_ref().to_string().into_boxed_str();
-        let component = Ident::new_unchecked(Span::unknown(Arc::from(component)));
+        let component = Ident::from_raw_parts(Span::unknown(Arc::from(component)));
         let mut path = self.clone();
         path.push_ident(component);
         path
@@ -438,7 +438,7 @@ impl<'a> TryFrom<Vec<LibraryPathComponent<'a>>> for LibraryPath {
             match component {
                 LibraryPathComponent::Normal(ident) => components.push(ident.clone()),
                 LibraryPathComponent::Namespace(LibraryNamespace::User(name)) => {
-                    components.push(Ident::new_unchecked(Span::unknown(name.clone())));
+                    components.push(Ident::from_raw_parts(Span::unknown(name.clone())));
                 },
                 LibraryPathComponent::Namespace(_) => return Err(PathError::UnsupportedJoin),
             }

--- a/assembly/src/library/path.rs
+++ b/assembly/src/library/path.rs
@@ -140,8 +140,9 @@ impl LibraryPath {
     /// * The path is empty.
     /// * The path prefix represents an invalid namespace, see [LibraryNamespace] for details.
     /// * Any component of the path is empty.
-    /// * Any component is not a valid bare identifier in Miden Assembly syntax, i.e. lowercase
-    ///   alphanumeric with underscores allowed, starts with alphabetic character.
+    /// * Any component is not a valid identifier (quoted or unquoted) in Miden Assembly syntax,
+    ///   i.e. starts with an ASCII alphabetic character, contains only printable ASCII characters,
+    ///   except for `::`, which must only be used as a path separator.
     pub fn new(source: impl AsRef<str>) -> Result<Self, PathError> {
         let source = source.as_ref();
         if source.is_empty() {
@@ -585,6 +586,9 @@ mod tests {
         let path = LibraryPath::new("foo::bar::baz").unwrap();
         assert_eq!(path.num_components(), 3);
 
+        let path = LibraryPath::new("miden:base/account@0.1.0").unwrap();
+        assert_eq!(path.num_components(), 1);
+
         let path = LibraryPath::new("#exec::bar::baz").unwrap();
         assert_eq!(path.num_components(), 3);
 
@@ -605,9 +609,6 @@ mod tests {
 
         let path = LibraryPath::new("::foo");
         assert_matches!(path, Err(PathError::InvalidNamespace(LibraryNamespaceError::Empty)));
-
-        let path = LibraryPath::new("foo::1bar");
-        assert_matches!(path, Err(PathError::InvalidComponent(IdentError::InvalidStart)));
 
         let path = LibraryPath::new("#foo::bar");
         assert_matches!(

--- a/assembly/src/parser/error.rs
+++ b/assembly/src/parser/error.rs
@@ -151,14 +151,6 @@ pub enum ParsingError {
         #[label]
         span: SourceSpan,
     },
-    #[error("invalid character in identifier")]
-    #[diagnostic(help(
-        "bare identifiers must be lowercase alphanumeric with '_', quoted identifiers can include any graphical character"
-    ))]
-    InvalidIdentCharacter {
-        #[label]
-        span: SourceSpan,
-    },
     #[error("unclosed quoted identifier")]
     #[diagnostic()]
     UnclosedQuote {

--- a/assembly/src/parser/error.rs
+++ b/assembly/src/parser/error.rs
@@ -140,9 +140,20 @@ pub enum ParsingError {
         span: SourceSpan,
         expected: Vec<String>,
     },
+    #[error("{error}")]
+    #[diagnostic(help(
+        "bare identifiers must be lowercase alphanumeric with '_', quoted identifiers can include any graphical character"
+    ))]
+    InvalidIdentifier {
+        #[source]
+        #[diagnostic(source)]
+        error: crate::ast::IdentError,
+        #[label]
+        span: SourceSpan,
+    },
     #[error("invalid character in identifier")]
     #[diagnostic(help(
-        "bare identifiers must be lowercase alphanumeric with '_', quoted identifiers can include uppercase, as well as '.' and '$'"
+        "bare identifiers must be lowercase alphanumeric with '_', quoted identifiers can include any graphical character"
     ))]
     InvalidIdentCharacter {
         #[label]

--- a/assembly/src/parser/grammar.lalrpop
+++ b/assembly/src/parser/grammar.lalrpop
@@ -487,7 +487,8 @@ QuotedString: Ident = {
             interned.insert(value.clone());
             value
         });
-        Ident::new_unchecked(Span::new(span!(source_file.id(), l, r), value))
+        let span = span!(source_file.id(), l, r);
+        Ident::from_raw_parts(Span::new(span, value))
     }
 }
 
@@ -1448,19 +1449,24 @@ ProcedureName: ProcedureName = {
 
 #[inline]
 BareProcedureName: ProcedureName = {
-    <BareIdent> => ProcedureName::new_unchecked(<>),
+    <BareIdent> => ProcedureName::from_raw_parts(<>),
 }
 
 #[inline]
 QuotedProcedureName: ProcedureName = {
-    <l:@L> <name:quoted_ident> <r:@R> => {
+    <l:@L> <name:quoted_ident> <r:@R> =>? {
         let name = interned.get(name).cloned().unwrap_or_else(|| {
             let name = Arc::<str>::from(name.to_string().into_boxed_str());
             interned.insert(name.clone());
             name
         });
-        let id = Ident::new_unchecked(Span::new(span!(source_file.id(), l, r), name));
-        ProcedureName::new_unchecked(id)
+        let span = span!(source_file.id(), l, r);
+        Ident::validate(&name)
+            .map_err(|error| ParseError::User {
+                error: ParsingError::InvalidIdentifier { error, span },
+            })?;
+        let id = Ident::from_raw_parts(Span::new(span, name));
+        Ok(ProcedureName::from_raw_parts(id))
     }
 }
 
@@ -1514,13 +1520,18 @@ MaybeQualifiedProcedurePath: InvocationTarget = {
 
 #[inline]
 BareIdent: Ident = {
-    <l:@L> <name:bare_ident> <r:@R> => {
+    <l:@L> <name:bare_ident> <r:@R> =>? {
         let name = interned.get(name).cloned().unwrap_or_else(|| {
             let name = Arc::<str>::from(name.to_string().into_boxed_str());
             interned.insert(name.clone());
             name
         });
-        Ident::new_unchecked(Span::new(span!(source_file.id(), l, r), name))
+        let span = span!(source_file.id(), l, r);
+        Ident::validate(&name)
+            .map_err(|error| ParseError::User {
+                error: ParsingError::InvalidIdentifier { error, span },
+            })?;
+        Ok(Ident::from_raw_parts(Span::new(span, name)))
     },
 
     OpcodeName,
@@ -1598,7 +1609,7 @@ OpcodeName: Ident = {
             interned.insert(name.clone());
             name
         });
-        Ident::new_unchecked(Span::new(span!(source_file.id(), l, r), name))
+        Ident::from_raw_parts(Span::new(span!(source_file.id(), l, r), name))
     }
 }
 
@@ -1774,13 +1785,19 @@ ConstantExpr100: ConstantExpr = {
 
 #[inline]
 ConstantName: Ident = {
-    <l:@L> <name:const_ident> <r:@R> => {
+    <l:@L> <name:const_ident> <r:@R> =>? {
         let name = interned.get(name).cloned().unwrap_or_else(|| {
             let name = Arc::<str>::from(name.to_string().into_boxed_str());
             interned.insert(name.clone());
             name
         });
-        Ident::new_unchecked(Span::new(span!(source_file.id(), l, r), name))
+        let span = span!(source_file.id(), l, r);
+
+        Ident::validate(&name)
+            .map_err(|error| ParseError::User {
+                error: ParsingError::InvalidIdentifier { error, span },
+            })?;
+        Ok(Ident::from_raw_parts(Span::new(span, name)))
     }
 }
 

--- a/assembly/src/parser/lexer.rs
+++ b/assembly/src/parser/lexer.rs
@@ -453,10 +453,7 @@ impl<'input> Lexer<'input> {
                         Token::QuotedString(self.slice_span(span))
                     });
                 },
-                c if c.is_ascii_alphanumeric() => {
-                    self.skip();
-                },
-                '_' | '$' | '-' | '!' | '?' | '<' | '>' | ':' | '.' => {
+                c if c.is_alphanumeric() || c.is_ascii_graphic() => {
                     self.skip();
                 },
                 _ => {

--- a/miden/tests/integration/cli/cli_test.rs
+++ b/miden/tests/integration/cli/cli_test.rs
@@ -82,16 +82,22 @@ use vm_core::Decorator;
 
 #[test]
 fn cli_bundle_debug() {
+    let output_file = std::env::temp_dir().join("cli_bundle_debug.masl");
+
     let mut cmd = bin_under_test().command();
-    cmd.arg("bundle").arg("--debug").arg("./tests/integration/cli/data/lib");
+    cmd.arg("bundle")
+        .arg("--debug")
+        .arg("./tests/integration/cli/data/lib")
+        .arg("--output")
+        .arg(output_file.as_path());
     cmd.assert().success();
 
-    let lib = Library::deserialize_from_file("./tests/integration/cli/data/out.masl").unwrap();
+    let lib = Library::deserialize_from_file(&output_file).unwrap();
     // If there are any AsmOp decorators in the forest, the bundle is in debug mode.
     let found_one_asm_op =
         lib.mast_forest().decorators().iter().any(|d| matches!(d, Decorator::AsmOp(_)));
     assert!(found_one_asm_op);
-    fs::remove_file("./tests/integration/cli/data/out.masl").unwrap();
+    fs::remove_file(&output_file).unwrap();
 }
 
 #[test]
@@ -105,25 +111,33 @@ fn cli_bundle_no_exports() {
 
 #[test]
 fn cli_bundle_kernel() {
+    let output_file = std::env::temp_dir().join("cli_bundle_kernel.masl");
+
     let mut cmd = bin_under_test().command();
     cmd.arg("bundle")
         .arg("./tests/integration/cli/data/lib")
         .arg("--kernel")
-        .arg("./tests/integration/cli/data/kernel_main.masm");
+        .arg("./tests/integration/cli/data/kernel_main.masm")
+        .arg("--output")
+        .arg(output_file.as_path());
     cmd.assert().success();
-    fs::remove_file("./tests/integration/cli/data/out.masl").unwrap()
+    fs::remove_file(&output_file).unwrap()
 }
 
 /// A kernel can bundle with a library w/o exports.
 #[test]
 fn cli_bundle_kernel_noexports() {
+    let output_file = std::env::temp_dir().join("cli_bundle_kernel.masl");
+
     let mut cmd = bin_under_test().command();
     cmd.arg("bundle")
         .arg("./tests/integration/cli/data/lib_noexports")
         .arg("--kernel")
-        .arg("./tests/integration/cli/data/kernel_main.masm");
+        .arg("./tests/integration/cli/data/kernel_main.masm")
+        .arg("--output")
+        .arg(output_file.as_path());
     cmd.assert().success();
-    fs::remove_file("./tests/integration/cli/data/out.masl").unwrap()
+    fs::remove_file(&output_file).unwrap()
 }
 
 #[test]


### PR DESCRIPTION
This reworks the handling of identifiers in the assembly AST (i.e. `Ident`, `ProcedureName`, `LibraryNamespace`, and `LibraryPath`):

* Renames `new_unchecked` to avoid confusion about its intended use and safety profile
* Relaxes the validation rules for identifiers to allow most all printable, non-whitespace characters, with certain exceptions for the higher-level types that build on `Ident`
* Moves responsibility for stricter validation rules to the Miden Assembly parser where it belongs (and was largely already being handled by the lexer).
* Fixed a conflict in the CLI test suite that arises due when some of the tests are running multi-threaded concurrently

This situation occurred because these types were originally only consumed by the parser, but were repurposed so that downstream projects such as the compiler could produce the AST directly. In general, Rust (as an example) does not need to adhere to the rules we apply to Miden Assembly sources (which only exist to avoid syntax ambiguity anyway, not for any other practical reason).

This fixes 0xPolygonMiden/compiler#441

@bobbinth I didn't actually mean to add you as a reviewer (but feel free!), I just misclicked, but GitHub doesn't let you remove reviewers once added, so 🤷‍♂️ 