### PR TITLE
Optimize build times

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,17 +8,30 @@ on:
 
 jobs:
   test:
-    name: test ${{matrix.toolchain}} on ubuntu-latest
+    name: test on ubuntu-latest
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        toolchain: [stable, nightly]
-    timeout-minutes: 30
     steps:
       - uses: actions/checkout@main
-      - uses: taiki-e/install-action@nextest
-      - name: Perform tests
-        run: |
-          rustup update --no-self-update ${{matrix.toolchain}}
-          make test
+      - uses: taiki-e/install-action@nextest 
+      - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/next' }}
+      - name: Install rust
+        run: rustup update --no-self-update 
+      - name: Build tests
+        run: make test-build
+      - name: test
+        run: make test
+
+  doc-tests:
+    name: doc-tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@main
+      - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/next' }}
+      - name: Install rust
+        run: rustup update --no-self-update
+      - name: Run doc-tests
+        run: make test-docs

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,9 @@ inherits = "release"
 codegen-units = 1
 lto = true
 
-[profile.test-release]
-inherits = "release"
+[profile.test-dev]
+inherits = "dev"
+opt-level = 1
 debug = true
 debug-assertions = true
 overflow-checks = true

--- a/Makefile
+++ b/Makefile
@@ -50,9 +50,17 @@ book: ## Builds the book & serves documentation site
 
 # --- testing -------------------------------------------------------------------------------------
 
+.PHONY: test-build
+test-build: ## Build the test binary
+	cargo nextest run --cargo-profile test-release --features concurrent,testing --no-run
+
 .PHONY: test
-test: ## Runs all tests with the release profile
-	$(DEBUG_ASSERTIONS) cargo nextest run --cargo-profile test-release --features testing
+test: ## Run all tests
+	$(DEBUG_ASSERTIONS) cargo nextest run --profile default --cargo-profile test-release --features concurrent,testing
+
+.PHONY: test-docs
+test-docs: ## Run documentation tests
+	$(WARNINGS) cargo test --doc $(ALL_FEATURES_BUT_ASYNC)
 
 .PHONY: test-fast
 test-fast: ## Runs all tests with the debug profile

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ help:
 
 # -- variables --------------------------------------------------------------------------------------
 
+BACKTRACE=RUST_BACKTRACE=1
 WARNINGS=RUSTDOCFLAGS="-D warnings"
 DEBUG_ASSERTIONS=RUSTFLAGS="-C debug-assertions"
 FEATURES_CONCURRENT_EXEC=--features concurrent,executable
@@ -52,15 +53,15 @@ book: ## Builds the book & serves documentation site
 
 .PHONY: test-build
 test-build: ## Build the test binary
-	cargo nextest run --cargo-profile test-release --features concurrent,testing --no-run
+	cargo nextest run --cargo-profile test-dev --features concurrent,testing --no-run
 
 .PHONY: test
 test: ## Run all tests
-	$(DEBUG_ASSERTIONS) cargo nextest run --profile default --cargo-profile test-release --features concurrent,testing
+	$(BACKTRACE) cargo nextest run --profile default --cargo-profile test-dev --features concurrent,testing
 
 .PHONY: test-docs
 test-docs: ## Run documentation tests
-	$(WARNINGS) cargo test --doc $(ALL_FEATURES_BUT_ASYNC)
+	cargo test --doc $(ALL_FEATURES_BUT_ASYNC)
 
 .PHONY: test-fast
 test-fast: ## Runs all tests with the debug profile


### PR DESCRIPTION
Closes: #1738 

Namely
- no longer run tests in nightly, as discussed in meetings offline
- remove test timeout
- add caching (which should bring the most significant performance boost)

Contrary to `miden-base`, we don't disable debug-assertions in `winter-prover`, because we want to get the errors if the trace is not properly built