### PR TITLE
refactor: store memory addresses in `MemoryAddress(u32)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 #### Changes
 - [BREAKING] `ExecutionOptions::with_debugging()` now takes a boolean parameter (#1761)
+- Use `MemoryAddress(u32)` for `VmState` memory addresses instead of plain `u64` (#1758).
 
 
 ## 0.13.2 (2025-04-02)

--- a/miden/src/cli/debug/command.rs
+++ b/miden/src/cli/debug/command.rs
@@ -1,3 +1,5 @@
+use processor::MemoryAddress;
+
 /// debug commands supported by the debugger
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum DebugCommand {
@@ -9,7 +11,7 @@ pub enum DebugCommand {
     PrintStack,
     PrintStackItem(usize),
     PrintMem,
-    PrintMemAddress(u32),
+    PrintMemAddress(MemoryAddress),
     Clock,
     Quit,
     Help,
@@ -123,7 +125,7 @@ impl DebugCommand {
 
         match (command, argument) {
             (Self::PrintMem, Some(arg)) => Ok(Self::PrintMemAddress(
-                u32::try_from(arg).expect("memory address should not exceed 2^32"),
+                u32::try_from(arg).expect("memory address should not exceed 2^32").into(),
             )),
             (Self::PrintStack, Some(arg)) => Ok(Self::PrintStackItem(arg as usize)),
             (_, Some(_)) => unreachable!("the command was previously parsed within this block"),

--- a/miden/src/cli/debug/command.rs
+++ b/miden/src/cli/debug/command.rs
@@ -9,7 +9,7 @@ pub enum DebugCommand {
     PrintStack,
     PrintStackItem(usize),
     PrintMem,
-    PrintMemAddress(u64),
+    PrintMemAddress(u32),
     Clock,
     Quit,
     Help,
@@ -122,7 +122,9 @@ impl DebugCommand {
             })?;
 
         match (command, argument) {
-            (Self::PrintMem, Some(arg)) => Ok(Self::PrintMemAddress(arg)),
+            (Self::PrintMem, Some(arg)) => Ok(Self::PrintMemAddress(
+                u32::try_from(arg).expect("memory address should not exceed 2^32"),
+            )),
             (Self::PrintStack, Some(arg)) => Ok(Self::PrintStackItem(arg as usize)),
             (_, Some(_)) => unreachable!("the command was previously parsed within this block"),
             (_, None) => Ok(command),

--- a/miden/src/cli/debug/executor.rs
+++ b/miden/src/cli/debug/executor.rs
@@ -98,7 +98,7 @@ impl DebugExecutor {
             DebugCommand::PrintStack => self.print_stack(),
             DebugCommand::PrintStackItem(index) => self.print_stack_item(index),
             DebugCommand::PrintMem => self.print_memory(),
-            DebugCommand::PrintMemAddress(address) => self.print_memory_entry(address.into()),
+            DebugCommand::PrintMemAddress(address) => self.print_memory_entry(address),
             DebugCommand::Clock => println!("{}", self.vm_state.clk),
             DebugCommand::Help => Self::print_help(),
             DebugCommand::Quit => return false,
@@ -172,7 +172,7 @@ impl DebugExecutor {
 
         match entry {
             Some(&mem) => print_mem_address(address, mem),
-            None => println!("memory at address '{}' not found", address.as_u32()),
+            None => println!("memory at address '{address}' not found"),
         }
     }
 

--- a/miden/src/cli/debug/executor.rs
+++ b/miden/src/cli/debug/executor.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use miden_vm::{DefaultHost, MemAdviceProvider, Program, StackInputs, VmState, VmStateIterator};
+use processor::MemoryAddress;
 
 use super::DebugCommand;
 use crate::utils::print_mem_address;
@@ -97,7 +98,7 @@ impl DebugExecutor {
             DebugCommand::PrintStack => self.print_stack(),
             DebugCommand::PrintStackItem(index) => self.print_stack_item(index),
             DebugCommand::PrintMem => self.print_memory(),
-            DebugCommand::PrintMemAddress(address) => self.print_memory_entry(address),
+            DebugCommand::PrintMemAddress(address) => self.print_memory_entry(address.into()),
             DebugCommand::Clock => println!("{}", self.vm_state.clk),
             DebugCommand::Help => Self::print_help(),
             DebugCommand::Quit => return false,
@@ -163,15 +164,15 @@ impl DebugExecutor {
     }
 
     /// Prints specified memory entry.
-    pub fn print_memory_entry(&self, address: u64) {
-        let entry = self.vm_state.memory.iter().find_map(|(addr, mem)| match address == *addr {
+    pub fn print_memory_entry(&self, address: MemoryAddress) {
+        let entry = self.vm_state.memory.iter().find_map(|(addr, mem)| match &address == addr {
             true => Some(mem),
             false => None,
         });
 
         match entry {
             Some(&mem) => print_mem_address(address, mem),
-            None => println!("memory at address '{address}' not found"),
+            None => println!("memory at address '{}' not found", address.as_u32()),
         }
     }
 

--- a/miden/src/repl/mod.rs
+++ b/miden/src/repl/mod.rs
@@ -2,7 +2,7 @@ use std::{collections::BTreeSet, path::PathBuf};
 
 use assembly::{Assembler, Library};
 use miden_vm::{DefaultHost, StackInputs, math::Felt};
-use processor::ContextId;
+use processor::{ContextId, MemoryAddress};
 use rustyline::{DefaultEditor, error::ReadlineError};
 use stdlib::StdLibrary;
 
@@ -173,7 +173,7 @@ pub fn start_repl(library_paths: &Vec<PathBuf>, use_stdlib: bool) {
     let mut should_print_stack = false;
 
     // state of the entire memory at the latest clock cycle.
-    let mut memory: Vec<(u64, Felt)> = Vec::new();
+    let mut memory: Vec<(MemoryAddress, Felt)> = Vec::new();
 
     // initializing readline.
     let mut rl = DefaultEditor::new().expect("Readline couldn't be initialized");
@@ -251,7 +251,7 @@ pub fn start_repl(library_paths: &Vec<PathBuf>, use_stdlib: bool) {
                             }
                             // in case the flag has not been initialized.
                             if !mem_at_addr_present {
-                                println!("Memory at address {} is empty", addr);
+                                println!("Memory at address {:?} is empty", addr);
                             }
                         },
                         Err(msg) => println!("{}", msg),
@@ -307,7 +307,7 @@ pub fn start_repl(library_paths: &Vec<PathBuf>, use_stdlib: bool) {
 fn execute(
     program: String,
     provided_libraries: &[Library],
-) -> Result<(Vec<(u64, Felt)>, Vec<Felt>), String> {
+) -> Result<(Vec<(MemoryAddress, Felt)>, Vec<Felt>), String> {
     // compile program
     let mut assembler = Assembler::default();
 
@@ -340,7 +340,7 @@ fn execute(
 }
 
 /// Parses the address in integer form from `!mem[addr]` command, otherwise throws an error.
-fn read_mem_address(mem_str: &str) -> Result<u64, String> {
+fn read_mem_address(mem_str: &str) -> Result<MemoryAddress, String> {
     // the first five characters is "!mem[" and the digit character should start from 6th
     // element.
     let remainder = &mem_str[5..];
@@ -354,11 +354,11 @@ fn read_mem_address(mem_str: &str) -> Result<u64, String> {
     }
 
     // convert the parsed digits into integer form.
-    let addr = &remainder[..digits_end]
+    let addr: u32 = remainder[..digits_end]
         .parse()
         .expect("The input address couldn't be parsed into an integer");
 
-    Ok(*addr)
+    Ok(addr.into())
 }
 
 /// Parses `!use` command. Adds the provided module to the program imports, or prints the list of

--- a/miden/src/repl/mod.rs
+++ b/miden/src/repl/mod.rs
@@ -251,7 +251,7 @@ pub fn start_repl(library_paths: &Vec<PathBuf>, use_stdlib: bool) {
                             }
                             // in case the flag has not been initialized.
                             if !mem_at_addr_present {
-                                println!("Memory at address {:?} is empty", addr);
+                                println!("Memory at address {addr} is empty");
                             }
                         },
                         Err(msg) => println!("{}", msg),

--- a/miden/src/utils.rs
+++ b/miden/src/utils.rs
@@ -3,5 +3,5 @@ use vm_core::Felt;
 
 /// Prints the memory address along with the memory value at that address.
 pub fn print_mem_address(addr: MemoryAddress, mem_value: Felt) {
-    println!("{:?} {mem_value}", addr)
+    println!("{addr} {mem_value}")
 }

--- a/miden/src/utils.rs
+++ b/miden/src/utils.rs
@@ -1,6 +1,7 @@
+use processor::MemoryAddress;
 use vm_core::Felt;
 
 /// Prints the memory address along with the memory value at that address.
-pub fn print_mem_address(addr: u64, mem_value: Felt) {
-    println!("{addr} {mem_value}")
+pub fn print_mem_address(addr: MemoryAddress, mem_value: Felt) {
+    println!("{:?} {mem_value}", addr)
 }

--- a/miden/tests/integration/exec_iters.rs
+++ b/miden/tests/integration/exec_iters.rs
@@ -20,7 +20,7 @@ fn test_exec_iter() {
     let fmp = Felt::new(2u64.pow(30));
     let next_fmp = fmp + ONE;
     // TODO: double check this value
-    let mem = vec![(1_u64, Felt::from(13_u32))];
+    let mem = vec![(1u32.into(), Felt::from(13_u32))];
     let mem_storew1_loc = Some(Location {
         path: path.clone(),
         start: 33.into(),
@@ -311,7 +311,7 @@ fn test_exec_iter() {
             )),
             stack: [17, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0].to_elements(),
             fmp: next_fmp,
-            memory: vec![(1_u64, 13_u32.into()), (2u64.pow(30) + 1, 17_u32.into())],
+            memory: vec![(1u32.into(), 13_u32.into()), ((2u32.pow(30) + 1).into(), 17_u32.into())],
         },
         VmState {
             clk: RowIndex::from(19),
@@ -329,7 +329,7 @@ fn test_exec_iter() {
             )),
             stack: [12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0, 0].to_elements(),
             fmp: next_fmp,
-            memory: vec![(1_u64, 13_u32.into()), (2u64.pow(30) + 1, 17_u32.into())],
+            memory: vec![(1u32.into(), 13_u32.into()), ((2u32.pow(30) + 1).into(), 17_u32.into())],
         },
         VmState {
             clk: RowIndex::from(20),
@@ -339,7 +339,7 @@ fn test_exec_iter() {
             stack: [18446744069414584320, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0]
                 .to_elements(),
             fmp: next_fmp,
-            memory: vec![(1_u64, 13_u32.into()), (2u64.pow(30) + 1, 17_u32.into())],
+            memory: vec![(1u32.into(), 13_u32.into()), ((2u32.pow(30) + 1).into(), 17_u32.into())],
         },
         VmState {
             clk: RowIndex::from(21),
@@ -348,7 +348,7 @@ fn test_exec_iter() {
             asmop: None,
             stack: [12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0].to_elements(),
             fmp,
-            memory: vec![(1_u64, 13_u32.into()), (2u64.pow(30) + 1, 17_u32.into())],
+            memory: vec![(1u32.into(), 13_u32.into()), ((2u32.pow(30) + 1).into(), 17_u32.into())],
         },
         VmState {
             clk: RowIndex::from(22),
@@ -357,7 +357,7 @@ fn test_exec_iter() {
             asmop: None,
             stack: [12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0].to_elements(),
             fmp,
-            memory: vec![(1_u64, 13_u32.into()), (2u64.pow(30) + 1, 17_u32.into())],
+            memory: vec![(1u32.into(), 13_u32.into()), ((2u32.pow(30) + 1).into(), 17_u32.into())],
         },
         VmState {
             clk: RowIndex::from(23),
@@ -366,7 +366,7 @@ fn test_exec_iter() {
             asmop: None,
             stack: [12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0].to_elements(),
             fmp,
-            memory: vec![(1_u64, 13_u32.into()), (2u64.pow(30) + 1, 17_u32.into())],
+            memory: vec![(1u32.into(), 13_u32.into()), ((2u32.pow(30) + 1).into(), 17_u32.into())],
         },
         VmState {
             clk: RowIndex::from(24),
@@ -375,7 +375,7 @@ fn test_exec_iter() {
             asmop: None,
             stack: [12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 0, 0, 0].to_elements(),
             fmp,
-            memory: vec![(1_u64, 13_u32.into()), (2u64.pow(30) + 1, 17_u32.into())],
+            memory: vec![(1u32.into(), 13_u32.into()), ((2u32.pow(30) + 1).into(), 17_u32.into())],
         },
     ];
     for (expected, t) in expected_states.iter().zip(traces) {

--- a/processor/src/chiplets/memory/mod.rs
+++ b/processor/src/chiplets/memory/mod.rs
@@ -16,7 +16,7 @@ use super::{
     EMPTY_WORD, Felt, FieldElement, ONE, RangeChecker, TraceFragment, Word,
     utils::{split_element_u32_into_u16, split_u32_into_u16},
 };
-use crate::{errors::ErrorContext, system::ContextId};
+use crate::{MemoryAddress, errors::ErrorContext, system::ContextId};
 
 mod errors;
 pub use errors::MemoryError;
@@ -139,7 +139,7 @@ impl Memory {
     /// Returns the entire memory state for the specified execution context at the specified cycle.
     /// The state is returned as a vector of (address, value) tuples, and includes addresses which
     /// have been accessed at least once.
-    pub fn get_state_at(&self, ctx: ContextId, clk: RowIndex) -> Vec<(u64, Felt)> {
+    pub fn get_state_at(&self, ctx: ContextId, clk: RowIndex) -> Vec<(MemoryAddress, Felt)> {
         if clk == 0 {
             return vec![];
         }

--- a/processor/src/chiplets/memory/tests.rs
+++ b/processor/src/chiplets/memory/tests.rs
@@ -17,7 +17,7 @@ use super::{
     FieldElement, Memory, ONE, TraceFragment, V_COL_RANGE, WORD_COL_IDX,
     segment::{MemoryAccessType, MemoryOperation},
 };
-use crate::{ContextId, MemoryError, errors::ErrorContext};
+use crate::{ContextId, MemoryAddress, MemoryError, errors::ErrorContext};
 
 #[test]
 fn mem_init() {
@@ -468,10 +468,10 @@ fn mem_get_state_at() {
     assert_eq!(
         mem.get_state_at(ContextId::root(), clk),
         vec![
-            (addr_start.into(), word1234[0]),
-            (u64::from(addr_start) + 1_u64, word1234[1]),
-            (u64::from(addr_start) + 2_u64, word1234[2]),
-            (u64::from(addr_start) + 3_u64, word1234[3])
+            (MemoryAddress(addr_start), word1234[0]),
+            (MemoryAddress(addr_start + 1), word1234[1]),
+            (MemoryAddress(addr_start + 2), word1234[2]),
+            (MemoryAddress(addr_start + 3), word1234[3])
         ]
     );
     assert_eq!(mem.get_state_at(3.into(), clk), vec![]);
@@ -481,10 +481,10 @@ fn mem_get_state_at() {
     assert_eq!(
         mem.get_state_at(ContextId::root(), clk),
         vec![
-            (addr_start.into(), word4567[0]),
-            (u64::from(addr_start) + 1_u64, word4567[1]),
-            (u64::from(addr_start) + 2_u64, word4567[2]),
-            (u64::from(addr_start) + 3_u64, word4567[3])
+            (MemoryAddress(addr_start), word4567[0]),
+            (MemoryAddress(addr_start + 1), word4567[1]),
+            (MemoryAddress(addr_start + 2), word4567[2]),
+            (MemoryAddress(addr_start + 3), word4567[3])
         ]
     );
     assert_eq!(mem.get_state_at(3.into(), clk), vec![]);

--- a/processor/src/debug.rs
+++ b/processor/src/debug.rs
@@ -9,8 +9,8 @@ use miden_air::RowIndex;
 use vm_core::{AssemblyOp, FieldElement, Operation, StackOutputs};
 
 use crate::{
-    Chiplets, ChipletsLengths, Decoder, ExecutionError, Felt, Process, Stack, System,
-    TraceLenSummary, range::RangeChecker, system::ContextId,
+    Chiplets, ChipletsLengths, Decoder, ExecutionError, Felt, MemoryAddress, Process, Stack,
+    System, TraceLenSummary, range::RangeChecker, system::ContextId,
 };
 
 /// VmState holds a current process state information at a specific clock cycle.
@@ -22,7 +22,7 @@ pub struct VmState {
     pub asmop: Option<AsmOpInfo>,
     pub fmp: Felt,
     pub stack: Vec<Felt>,
-    pub memory: Vec<(u64, Felt)>,
+    pub memory: Vec<(MemoryAddress, Felt)>,
 }
 
 impl fmt::Display for VmState {

--- a/processor/src/host/debug.rs
+++ b/processor/src/host/debug.rs
@@ -5,7 +5,7 @@ use miden_air::RowIndex;
 use vm_core::{DebugOptions, Felt};
 
 use super::ProcessState;
-use crate::system::ContextId;
+use crate::{MemoryAddress, system::ContextId};
 
 // DEBUG HANDLER
 // ================================================================================================
@@ -84,12 +84,12 @@ impl Printer {
 
         // print the main part of the memory (wihtout the last value)
         for (addr, value) in mem.iter().take(mem.len() - 1) {
-            print_mem_address(addr.0, Some(*value), false, false, element_width);
+            print_mem_address(*addr, Some(*value), false, false, element_width);
         }
 
         // print the last memory value
         if let Some((addr, value)) = mem.last() {
-            print_mem_address(addr.0, Some(*value), true, false, element_width);
+            print_mem_address(*addr, Some(*value), true, false, element_width);
         }
     }
 
@@ -162,12 +162,12 @@ fn print_interval(mem_interval: Vec<(u32, Option<Felt>)>, is_local: bool) {
 
     // print the main part of the memory (wihtout the last value)
     for (addr, mem_value) in mem_interval.iter().take(mem_interval.len() - 1) {
-        print_mem_address(*addr, *mem_value, false, is_local, element_width)
+        print_mem_address((*addr).into(), *mem_value, false, is_local, element_width)
     }
 
     // print the last memory value
     if let Some((addr, value)) = mem_interval.last() {
-        print_mem_address(*addr, *value, true, is_local, element_width);
+        print_mem_address((*addr).into(), *value, true, is_local, element_width);
     }
 }
 
@@ -176,7 +176,7 @@ fn print_interval(mem_interval: Vec<(u32, Option<Felt>)>, is_local: bool) {
 /// If `is_local` is true, the output address is formatted as decimal value, otherwise as hex
 /// string.
 fn print_mem_address(
-    addr: u32,
+    addr: MemoryAddress,
     mem_value: Option<Felt>,
     is_last: bool,
     is_local: bool,

--- a/processor/src/host/debug.rs
+++ b/processor/src/host/debug.rs
@@ -84,12 +84,12 @@ impl Printer {
 
         // print the main part of the memory (wihtout the last value)
         for (addr, value) in mem.iter().take(mem.len() - 1) {
-            print_mem_address(*addr as u32, Some(*value), false, false, element_width);
+            print_mem_address(addr.0, Some(*value), false, false, element_width);
         }
 
         // print the last memory value
         if let Some((addr, value)) = mem.last() {
-            print_mem_address(*addr as u32, Some(*value), true, false, element_width);
+            print_mem_address(addr.0, Some(*value), true, false, element_width);
         }
     }
 

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -7,6 +7,7 @@ extern crate alloc;
 extern crate std;
 
 use alloc::{sync::Arc, vec::Vec};
+use core::fmt::{Display, LowerHex};
 
 use errors::ErrorContext;
 use miden_air::trace::{
@@ -99,18 +100,30 @@ pub mod crypto {
 
 type QuadFelt = QuadExtension<Felt>;
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub struct MemoryAddress(u32);
-
-impl MemoryAddress {
-    pub fn as_u32(&self) -> u32 {
-        self.0
-    }
-}
 
 impl From<u32> for MemoryAddress {
     fn from(addr: u32) -> Self {
         MemoryAddress(addr)
+    }
+}
+
+impl From<MemoryAddress> for u32 {
+    fn from(value: MemoryAddress) -> Self {
+        value.0
+    }
+}
+
+impl Display for MemoryAddress {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        Display::fmt(&self.0, f)
+    }
+}
+
+impl LowerHex for MemoryAddress {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        LowerHex::fmt(&self.0, f)
     }
 }
 

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -99,6 +99,21 @@ pub mod crypto {
 
 type QuadFelt = QuadExtension<Felt>;
 
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct MemoryAddress(u32);
+
+impl MemoryAddress {
+    pub fn as_u32(&self) -> u32 {
+        self.0
+    }
+}
+
+impl From<u32> for MemoryAddress {
+    fn from(addr: u32) -> Self {
+        MemoryAddress(addr)
+    }
+}
+
 type SysTrace = [Vec<Felt>; SYS_TRACE_WIDTH];
 
 pub struct DecoderTrace {
@@ -748,7 +763,7 @@ impl ProcessState<'_> {
     ///
     /// The state is returned as a vector of (address, value) tuples, and includes addresses which
     /// have been accessed at least once.
-    pub fn get_mem_state(&self, ctx: ContextId) -> Vec<(u64, Felt)> {
+    pub fn get_mem_state(&self, ctx: ContextId) -> Vec<(MemoryAddress, Felt)> {
         self.chiplets.memory.get_state_at(ctx, self.system.clk())
     }
 }


### PR DESCRIPTION
Changes the type used to store memory addresses from `u64` to `u32` as they are limited to `2**32`. Follows [this suggestion](https://github.com/0xPolygonMiden/miden-vm/pull/1627#issuecomment-2599646003) to wrap the address in a new type: `MemoryAddress(u32)`.

Closes #1612