### PR TITLE
`ExecutionOptions::with_debugging()` now takes a boolean parameter

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,3 @@
+[profile.ci]
+# Do not cancel the test run on the first failure.
+fail-fast = false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,10 @@ jobs:
   test:
     name: test on ubuntu-latest
     runs-on: ubuntu-latest
+    # This is needed to make sure the CI doesn't kill our job
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
     steps:
       - uses: actions/checkout@main
       - uses: taiki-e/install-action@nextest 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,10 +10,6 @@ jobs:
   test:
     name: test on ubuntu-latest
     runs-on: ubuntu-latest
-    # This is needed to make sure the CI doesn't kill our job
-    timeout-minutes: 30
-    strategy:
-      fail-fast: false
     steps:
       - uses: actions/checkout@main
       - uses: taiki-e/install-action@nextest 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 - Add kernel procedures digests as public inputs to the recursive verifier (#1724).
 
+#### Changes
+- [BREAKING] `ExecutionOptions::with_debugging()` now takes a boolean parameter (#1761)
+
 
 ## 0.13.2 (2025-04-02)
 

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ test-build: ## Build the test binary
 
 .PHONY: test
 test: ## Run all tests
-	$(BACKTRACE) cargo nextest run --profile default --cargo-profile test-dev --features concurrent,testing --no-fail-fast
+	$(BACKTRACE) cargo nextest run --profile ci --cargo-profile test-dev --features concurrent,testing
 
 .PHONY: test-docs
 test-docs: ## Run documentation tests

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ test-build: ## Build the test binary
 
 .PHONY: test
 test: ## Run all tests
-	$(BACKTRACE) cargo nextest run --profile default --cargo-profile test-dev --features concurrent,testing
+	$(BACKTRACE) cargo nextest run --profile default --cargo-profile test-dev --features concurrent,testing --no-fail-fast
 
 .PHONY: test-docs
 test-docs: ## Run documentation tests

--- a/air/src/options.rs
+++ b/air/src/options.rs
@@ -259,7 +259,8 @@ impl ExecutionOptions {
         self
     }
 
-    /// Enables execution of programs in debug mode.
+    /// Enables execution of programs in debug mode when the `enable_debugging` flag is set to true;
+    /// otherwise, debug mode is disabled.
     ///
     /// In debug mode the VM does the following:
     /// - Executes `debug` instructions (these are ignored in regular mode).

--- a/air/src/options.rs
+++ b/air/src/options.rs
@@ -265,8 +265,8 @@ impl ExecutionOptions {
     /// - Executes `debug` instructions (these are ignored in regular mode).
     /// - Records additional info about program execution (e.g., keeps track of stack state at every
     ///   cycle of the VM) which enables stepping through the program forward and backward.
-    pub fn with_debugging(mut self) -> Self {
-        self.enable_debugging = true;
+    pub fn with_debugging(mut self, enable_debugging: bool) -> Self {
+        self.enable_debugging = enable_debugging;
         self
     }
 

--- a/miden/tests/integration/operations/decorators/events.rs
+++ b/miden/tests/integration/operations/decorators/events.rs
@@ -92,7 +92,7 @@ fn test_debug_with_debugging() {
         &program,
         StackInputs::default(),
         &mut host,
-        ExecutionOptions::default().with_debugging(),
+        ExecutionOptions::default().with_debugging(true),
         Arc::new(DefaultSourceManager::default()),
     )
     .unwrap();

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -218,7 +218,7 @@ impl Process {
         Self::initialize(
             kernel,
             stack_inputs,
-            ExecutionOptions::default().with_tracing().with_debugging(),
+            ExecutionOptions::default().with_tracing().with_debugging(true),
         )
     }
 

--- a/stdlib/tests/main.rs
+++ b/stdlib/tests/main.rs
@@ -10,6 +10,16 @@ macro_rules! build_test {
     }}
 }
 
+/// Instantiates a test in debug mode with Miden standard library included.
+#[macro_export]
+macro_rules! build_debug_test {
+    ($($params:tt)+) => {{
+        let mut test = test_utils::build_test_by_mode!(true, $($params)+);
+        test.libraries = vec![miden_stdlib::StdLibrary::default().into()];
+        test
+    }}
+}
+
 mod collections;
 mod crypto;
 mod mast_forest_merge;

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -239,12 +239,8 @@ impl Test {
         }
 
         // execute the test
-        let mut process = Process::new(
-            program.kernel().clone(),
-            self.stack_inputs.clone(),
-            ExecutionOptions::default(),
-        )
-        .with_source_manager(self.source_manager.clone());
+        let mut process = Process::new_debug(program.kernel().clone(), self.stack_inputs.clone())
+            .with_source_manager(self.source_manager.clone());
         process.execute(&program, &mut host).unwrap();
 
         // validate the memory state
@@ -339,12 +335,8 @@ impl Test {
             host.load_mast_forest(library.mast_forest().clone()).unwrap();
         }
 
-        let mut process = Process::new(
-            program.kernel().clone(),
-            self.stack_inputs.clone(),
-            ExecutionOptions::default(),
-        )
-        .with_source_manager(self.source_manager.clone());
+        let mut process = Process::new_debug(program.kernel().clone(), self.stack_inputs.clone())
+            .with_source_manager(self.source_manager.clone());
         let stack_outputs = process.execute(&program, &mut host)?;
         let trace = ExecutionTrace::new(process, stack_outputs);
         assert_eq!(&program.hash(), trace.program_hash(), "inconsistent program hash");
@@ -363,11 +355,7 @@ impl Test {
             host.load_mast_forest(library.mast_forest().clone()).unwrap();
         }
 
-        let mut process = Process::new(
-            program.kernel().clone(),
-            self.stack_inputs.clone(),
-            ExecutionOptions::default(),
-        );
+        let mut process = Process::new_debug(program.kernel().clone(), self.stack_inputs.clone());
         process.execute(&program, &mut host)?;
         Ok((process, host))
     }

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -239,8 +239,12 @@ impl Test {
         }
 
         // execute the test
-        let mut process = Process::new_debug(program.kernel().clone(), self.stack_inputs.clone())
-            .with_source_manager(self.source_manager.clone());
+        let mut process = Process::new(
+            program.kernel().clone(),
+            self.stack_inputs.clone(),
+            ExecutionOptions::default().with_debugging(self.in_debug_mode),
+        )
+        .with_source_manager(self.source_manager.clone());
         process.execute(&program, &mut host).unwrap();
 
         // validate the memory state
@@ -335,8 +339,12 @@ impl Test {
             host.load_mast_forest(library.mast_forest().clone()).unwrap();
         }
 
-        let mut process = Process::new_debug(program.kernel().clone(), self.stack_inputs.clone())
-            .with_source_manager(self.source_manager.clone());
+        let mut process = Process::new(
+            program.kernel().clone(),
+            self.stack_inputs.clone(),
+            ExecutionOptions::default().with_debugging(self.in_debug_mode),
+        )
+        .with_source_manager(self.source_manager.clone());
         let stack_outputs = process.execute(&program, &mut host)?;
         let trace = ExecutionTrace::new(process, stack_outputs);
         assert_eq!(&program.hash(), trace.program_hash(), "inconsistent program hash");
@@ -355,7 +363,12 @@ impl Test {
             host.load_mast_forest(library.mast_forest().clone()).unwrap();
         }
 
-        let mut process = Process::new_debug(program.kernel().clone(), self.stack_inputs.clone());
+        let mut process = Process::new(
+            program.kernel().clone(),
+            self.stack_inputs.clone(),
+            ExecutionOptions::default().with_debugging(self.in_debug_mode),
+        )
+        .with_source_manager(self.source_manager.clone());
         process.execute(&program, &mut host)?;
         Ok((process, host))
     }

--- a/test-utils/src/test_builders.rs
+++ b/test-utils/src/test_builders.rs
@@ -85,6 +85,8 @@ macro_rules! build_test {
 ///   `merkle_store` are also expected.
 /// * `merkle_store` (optional): the initial merkle set values. When provided, `stack_inputs` and
 ///   `advice_stack` are also expected.
+///
+/// NOTE: use `miden_stdlib::tests::build_debug_test` to include the standard library in the test.
 #[macro_export]
 macro_rules! build_debug_test {
     ($($params:tt)+) => {{


### PR DESCRIPTION
This PR provides 2 minor improvements to testing:
- Adds a `build_debug_test!` in the standard library such that simply changing from `build_test!()` to `build_debug_test!()` now properly makes all `debug.*` statements work.
    - `test_utils::build_debug_test!()` doesn't add the standard library to `Test.libraries`, so any test that needs stdlib fails to compile
    - Since it's a macro, adding the standard library to `build_test_by_mode!()` was messy (i.e. the stdlib needs to be a dependency everywhere it's used)
    - I employed the same fix as `stdlib::build_test!()` and just added a new definition for `build_debug_test!()` in `stdlib`
- Instantiate `Process` in debug mode for debug tests so that `debug` statements are actually printed

So now, if you want to debug your test, all you need to do is use `build_debug_test!()` instead of `build_test!()`, and debug statements will properly print.