### PR TITLE
Fix build

### DIFF
--- a/processor/Cargo.toml
+++ b/processor/Cargo.toml
@@ -32,7 +32,7 @@ miette = { package = "miden-miette", version = "8.0", default-features = false, 
     "derive"
 ] }
 tracing = { version = "0.1", default-features = false, features = ["attributes"] }
-vm-core = { package = "miden-core", path = "../core", version = "0.14", default-features = false }
+vm-core = { package = "miden-core", path = "../core", version = "0.14", default-features = false, features = ["diagnostics"] }
 winter-prover = { package = "winter-prover", version = "0.12", default-features = false }
 thiserror = { workspace = true }
 


### PR DESCRIPTION
Hotfix - `cargo build` no longer works on `next` because `ExecutionError` derives `miette::Diagnostic`, which is only a valid derive when `core::SourceFile` derives `miette::SourceCode` (which is only defined when the `diagnostics` feature is enabled [here](https://github.com/0xPolygonMiden/miden-vm/blob/217ec8c5701fab14634cdc1db973a28e05133c90/core/src/debuginfo/source_file.rs#L18)).

The CI probably didn't catch it because we build everything with `--all-features`, which would have enabled the `diagnostics` feature in `core`.